### PR TITLE
Changed i3featureextractor.py to also extract the event datetime from frame I3EventHeader.

### DIFF
--- a/src/graphnet/data/extractors/i3featureextractor.py
+++ b/src/graphnet/data/extractors/i3featureextractor.py
@@ -57,14 +57,13 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
         if "CalibrationErrata" in frame:
             calibration_errata = frame.Get("CalibrationErrata")
 
+        event_time = frame["I3EventHeader"].start_time.mod_julian_day_double
+
         for om_key in om_keys:
             # Common values for each OM
             x = self._gcd_dict[om_key].position.x
             y = self._gcd_dict[om_key].position.y
             z = self._gcd_dict[om_key].position.z
-            event_time = frame[
-                "I3EventHeader"
-            ].start_time.mod_julian_day_double
             area = self._gcd_dict[om_key].area
             rde = self._get_relative_dom_efficiency(frame, om_key)
 

--- a/src/graphnet/data/extractors/i3featureextractor.py
+++ b/src/graphnet/data/extractors/i3featureextractor.py
@@ -30,6 +30,7 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
             "is_bad_dom": [],
             "is_saturated_dom": [],
             "is_errata_dom": [],
+            "event_time": [],
         }
 
         # Get OM data
@@ -61,6 +62,7 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
             x = self._gcd_dict[om_key].position.x
             y = self._gcd_dict[om_key].position.y
             z = self._gcd_dict[om_key].position.z
+            event_time = frame["I3EventHeader"].start_time.mod_julian_day_double
             area = self._gcd_dict[om_key].area
             rde = self._get_relative_dom_efficiency(frame, om_key)
 
@@ -101,6 +103,8 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
                 output["is_bad_dom"].append(is_bad_dom)
                 output["is_saturated_dom"].append(is_saturated_dom)
                 output["is_errata_dom"].append(is_errata_dom)
+                output["event_time"].append(event_time)
+                
         return output
 
     def _get_relative_dom_efficiency(self, frame, om_key):

--- a/src/graphnet/data/extractors/i3featureextractor.py
+++ b/src/graphnet/data/extractors/i3featureextractor.py
@@ -62,7 +62,9 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
             x = self._gcd_dict[om_key].position.x
             y = self._gcd_dict[om_key].position.y
             z = self._gcd_dict[om_key].position.z
-            event_time = frame["I3EventHeader"].start_time.mod_julian_day_double
+            event_time = frame[
+                "I3EventHeader"
+            ].start_time.mod_julian_day_double
             area = self._gcd_dict[om_key].area
             rde = self._get_relative_dom_efficiency(frame, om_key)
 
@@ -104,7 +106,7 @@ class I3FeatureExtractorIceCube86(I3FeatureExtractor):
                 output["is_saturated_dom"].append(is_saturated_dom)
                 output["is_errata_dom"].append(is_errata_dom)
                 output["event_time"].append(event_time)
-                
+
         return output
 
     def _get_relative_dom_efficiency(self, frame, om_key):


### PR DESCRIPTION
I have changed the i3featureextractor.py to also extract the datetime of the events, which can for instance be used to identify the moon position at the time of each event. The datetime is required for the `icecube.astro.I3GetMoonDirection()`

https://docs.icecube.aq/icetray/main/projects/astro/index.html