### PR TITLE
Bug-fix for dynedge Refactor

### DIFF
--- a/src/graphnet/models/gnn/dynedge.py
+++ b/src/graphnet/models/gnn/dynedge.py
@@ -325,7 +325,7 @@ class DynEdge(GNN):
                 x = torch.cat(
                     [
                         x,
-                        global_variables.unsqueeze(1),
+                        global_variables,
                     ],
                     dim=1,
                 )


### PR DESCRIPTION
#302 introduced a nice refactor of dynedge. 

However, a small bug was introduced where the concatenation of global variables failed because of dimensions. This is fixed here.