### PR TITLE
Bugfix of create_table method

### DIFF
--- a/src/graphnet/data/sqlite/sqlite_utilities.py
+++ b/src/graphnet/data/sqlite/sqlite_utilities.py
@@ -67,6 +67,8 @@ def create_table(
                 type_ = "INTEGER PRIMARY KEY NOT NULL"
             else:
                 type_ = "NOT NULL"
+        else:
+            type_ = "NOT NULL"
         query_columns.append(f"{column} {type_}")
     query_columns = ", ".join(query_columns)
 


### PR DESCRIPTION
Recent PR made the `create_table` a utility method. However, a small bug in the method assigned all columns in a truth-array as primary keys. This is fixed here. 