### PR TITLE
Fix Logger typing

### DIFF
--- a/src/graphnet/training/callbacks.py
+++ b/src/graphnet/training/callbacks.py
@@ -142,7 +142,7 @@ class ProgressBar(TQDMProgressBar):
         """
         super().on_train_epoch_end(trainer, model)
 
-        h = logger.handlers[0]
+        h = logger.logger.handlers[0]
         assert isinstance(h, logging.StreamHandler)
         level = h.level
         h.setLevel(logging.ERROR)

--- a/src/graphnet/utilities/logging.py
+++ b/src/graphnet/utilities/logging.py
@@ -83,7 +83,7 @@ class RepeatFilter(object):
 
 def get_logger(
     level: Optional[int] = None, log_folder: str = LOG_FOLDER
-) -> logging.Logger:
+) -> logging.LoggerAdapter:
     """Get `logger` instance, to be used in place of `print()`.
 
     The logger will print the specified level of output to the terminal, and
@@ -130,9 +130,9 @@ def get_logger(
     logger.addHandler(file_handler)
 
     # Make className empty by default
-    logger = logging.LoggerAdapter(logger, extra={"className": ""})
+    logger_adapter = logging.LoggerAdapter(logger, extra={"className": ""})
 
-    logger.info(f"Writing log to \033[1m{log_path}\033[0m")
+    logger_adapter.info(f"Writing log to \033[1m{log_path}\033[0m")
 
     # Have pytorch lightning write to same log file
     pl_logger = logging.getLogger("pytorch_lightning")
@@ -140,7 +140,7 @@ def get_logger(
     pl_logger.addHandler(pl_file_handler)
 
     # Store as global variable
-    LOGGER = logger
+    LOGGER = logger_adapter
 
     return LOGGER
 


### PR DESCRIPTION
The use and typing of the `logger` from `get_logger` was slightly mishandled in #310 leading to an error in the `ProgressBar` callback. This PR fixes this.