### PR TITLE
Add dedicated Detector class for IceCube-86/main array

### DIFF
--- a/src/graphnet/models/detector/icecube.py
+++ b/src/graphnet/models/detector/icecube.py
@@ -31,6 +31,37 @@ class IceCube86(Detector):
         self._validate_features(data)
 
         # Preprocessing
+        data.x[:, 0] /= 500.0  # dom_x
+        data.x[:, 1] /= 500.0  # dom_y
+        data.x[:, 2] /= 500.0  # dom_z
+        data.x[:, 3] = (data.x[:, 3] - 1.0e04) / 3.0e4  # dom_time
+        data.x[:, 4] = torch.log10(data.x[:, 4]) / 3.0  # charge
+        data.x[:, 5] -= 1.25  # rde
+        data.x[:, 5] /= 0.25
+        data.x[:, 6] /= 0.05  # pmt_area
+
+        return data
+
+
+class IceCubeDeepCore(IceCube86):
+    """`Detector` class for IceCube-DeepCore."""
+
+    # Implementing abstract class attribute
+    features = FEATURES.DEEPCORE
+
+    def _forward(self, data: Data) -> Data:
+        """Ingest data, build graph, and preprocess features.
+
+        Args:
+            data: Input graph data.
+
+        Returns:
+            Connected and preprocessed graph data.
+        """
+        # Check(s)
+        self._validate_features(data)
+
+        # Preprocessing
         data.x[:, 0] /= 100.0  # dom_x
         data.x[:, 1] /= 100.0  # dom_y
         data.x[:, 2] += 350.0  # dom_z
@@ -44,10 +75,6 @@ class IceCube86(Detector):
         data.x[:, 6] /= 0.05  # pmt_area
 
         return data
-
-
-class IceCubeDeepCore(IceCube86):
-    """`Detector` class for IceCube-DeepCore."""
 
 
 class IceCubeUpgrade(IceCubeDeepCore):


### PR DESCRIPTION
So far, the `IceCube86Detector` and `IceCubeDeepCoreDetector` classes have been identical, but the preprocessing used has been tuned to DeepCore events, meaning that the normalisation of DOM positions and pulse timing is not well-suited for events that span the entire main array. This PR specialises to the two classes to their respective domains. 