### PR TITLE
Refactor configs and add Configurable class

### DIFF
--- a/src/graphnet/models/coarsening.py
+++ b/src/graphnet/models/coarsening.py
@@ -22,7 +22,7 @@ from graphnet.models.components.pool import (
     std_pool_x,
 )
 from graphnet.models import Model
-from graphnet.models.config import save_config
+from graphnet.utilities.config import save_config
 
 # Utility method(s)
 from torch_geometric.utils import degree

--- a/src/graphnet/models/detector/detector.py
+++ b/src/graphnet/models/detector/detector.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from typing import List
 
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 
 try:
     from typing import final

--- a/src/graphnet/models/gnn/convnet.py
+++ b/src/graphnet/models/gnn/convnet.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 from torch_geometric.nn import TAGConv, global_add_pool, global_max_pool
 from torch_geometric.data import Data
 
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 from graphnet.models.gnn.gnn import GNN
 
 

--- a/src/graphnet/models/gnn/dynedge.py
+++ b/src/graphnet/models/gnn/dynedge.py
@@ -7,7 +7,7 @@ from torch_geometric.data import Data
 from torch_scatter import scatter_max, scatter_mean, scatter_min, scatter_sum
 
 from graphnet.models.components.layers import DynEdgeConv
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.utils import calculate_xyzt_homophily
 

--- a/src/graphnet/models/gnn/dynedge_jinst.py
+++ b/src/graphnet/models/gnn/dynedge_jinst.py
@@ -10,7 +10,7 @@ from torch_geometric.data import Data
 from torch_scatter import scatter_max, scatter_mean, scatter_min, scatter_sum
 
 from graphnet.models.components.layers import DynEdgeConv
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.utils import calculate_xyzt_homophily
 

--- a/src/graphnet/models/gnn/gnn.py
+++ b/src/graphnet/models/gnn/gnn.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from torch_geometric.data import Data
 
 from graphnet.models import Model
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 
 
 class GNN(Model):

--- a/src/graphnet/models/graph_builders.py
+++ b/src/graphnet/models/graph_builders.py
@@ -6,7 +6,7 @@ import torch
 from torch_geometric.nn import knn_graph, radius_graph
 from torch_geometric.data import Data
 
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 from graphnet.models.utils import calculate_distance_matrix
 from graphnet.models import Model
 

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 import dill
 import os.path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 try:
     from typing import final
@@ -19,33 +19,16 @@ import torch
 from torch import Tensor
 from torch_geometric.data import Data
 
-
 from graphnet.utilities.logging import LoggerMixin
-
-if TYPE_CHECKING:
-    # Avoid cyclic dependency
-    from graphnet.models.config import ModelConfig
+from graphnet.utilities.config import Configurable, ModelConfig
 
 
-class Model(LightningModule, LoggerMixin, ABC):
+class Model(Configurable, LightningModule, LoggerMixin, ABC):
     """Base class for all models in graphnet."""
 
     @abstractmethod
     def forward(self, x: Union[Tensor, Data]) -> Union[Tensor, Data]:
         """Forward pass."""
-
-    @final
-    @property
-    def config(self) -> "ModelConfig":
-        """Return configuration to re-create the model."""
-        try:
-            return self._config
-        except AttributeError:
-            self.error(
-                "ModelConfig was not set. "
-                "Did you wrap the class constructor with `save_config`?"
-            )
-            raise
 
     def save(self, path: str) -> None:
         """Save entire model to `path`."""
@@ -83,15 +66,10 @@ class Model(LightningModule, LoggerMixin, ABC):
             state_dict = path
         return super().load_state_dict(state_dict)
 
-    @final
-    def save_config(self, path: str) -> None:
-        """Save ModelConfig to `path` as YAML file."""
-        self.config.dump(path)
-
     @classmethod
-    def from_config(
+    def from_config(  # type: ignore[override]
         cls,
-        source: Union["ModelConfig", str],
+        source: Union[ModelConfig, str],
         trust: bool = False,
         load_modules: Optional[List[str]] = None,
     ) -> "Model":
@@ -100,15 +78,18 @@ class Model(LightningModule, LoggerMixin, ABC):
         Arguments:
             trust: Whether to trust the ModelConfig file enough to `eval(...)`
                 any lambda function expressions contained.
+            load_modules: List of modules used in the definition of the model
+                which, as a consequence, need to be loaded into the global
+                namespace. Defaults to loading `torch`.
 
         Raises:
             ValueError: If the ModelConfig contains lambda functions but
                 `trust = False`.
         """
-        from graphnet.models.config import ModelConfig
-
         if isinstance(source, str):
             source = ModelConfig.load(source)
 
-        assert isinstance(source, ModelConfig)
+        assert isinstance(
+            source, ModelConfig
+        ), f"Argument `source` of type ({type(source)}) is not a `ModelConfig"
         return source.construct_model(trust=trust, load_modules=load_modules)

--- a/src/graphnet/models/standard_model.py
+++ b/src/graphnet/models/standard_model.py
@@ -9,7 +9,7 @@ from torch.optim import Adam
 from torch_geometric.data import Data
 
 from graphnet.models.coarsening import Coarsening
-from graphnet.models.config import save_config
+from graphnet.utilities.config import save_config
 from graphnet.models.detector.detector import Detector
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.model import Model
@@ -157,4 +157,6 @@ class StandardModel(Model):
         if mode:
             for task in self._tasks:
                 task.train_eval()
+        else:
+            self.inference()
         return self

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from graphnet.training.loss_functions import LossFunction  # type: ignore[attr-defined]
 
 from graphnet.models import Model
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 
 
 class Task(Model):

--- a/src/graphnet/training/loss_functions.py
+++ b/src/graphnet/training/loss_functions.py
@@ -22,7 +22,7 @@ import scipy.special
 import torch
 from torch import Tensor
 
-from graphnet.models.config import save_config
+from graphnet.utilities.config.model_config import save_config
 from graphnet.models.model import Model
 
 

--- a/src/graphnet/utilities/config/__init__.py
+++ b/src/graphnet/utilities/config/__init__.py
@@ -1,5 +1,4 @@
 """Modules for configuration files for use across `graphnet`."""
 
 from .configurable import Configurable
-from .dataset_config import DatasetConfig
 from .model_config import ModelConfig, save_config

--- a/src/graphnet/utilities/config/__init__.py
+++ b/src/graphnet/utilities/config/__init__.py
@@ -1,0 +1,5 @@
+"""Modules for configuration files for use across `graphnet`."""
+
+from .configurable import Configurable
+from .dataset_config import DatasetConfig
+from .model_config import ModelConfig, save_config

--- a/src/graphnet/utilities/config/base_config.py
+++ b/src/graphnet/utilities/config/base_config.py
@@ -1,0 +1,39 @@
+"""Base config class(es)."""
+
+from typing import Optional
+
+from pydantic import BaseModel
+import ruamel.yaml as yaml
+
+from graphnet.utilities.logging import LoggerMixin
+
+
+CONFIG_FILES_SUFFIXES = (".yml", ".yaml")
+
+
+class BaseConfig(BaseModel, LoggerMixin):
+    """Base class for Configs."""
+
+    @classmethod
+    def load(cls, path: str) -> "BaseConfig":
+        """Load BaseConfig from `path`."""
+        assert path.endswith(
+            CONFIG_FILES_SUFFIXES
+        ), "Please specify YAML config file."
+        with open(path, "r") as f:
+            config_dict = yaml.safe_load(f)
+
+        return cls(**config_dict)
+
+    def dump(self, path: Optional[str] = None) -> Optional[str]:
+        """Save BaseConfig to `path` as YAML file, or return as string."""
+        config_dict = self._as_dict()[self.__class__.__name__]
+
+        if path:
+            if not path.endswith(CONFIG_FILES_SUFFIXES):
+                path += CONFIG_FILES_SUFFIXES[0]
+            with open(path, "w") as f:
+                yaml.dump(config_dict, f)
+            return None
+        else:
+            return yaml.dump(config_dict)

--- a/src/graphnet/utilities/config/configurable.py
+++ b/src/graphnet/utilities/config/configurable.py
@@ -1,0 +1,46 @@
+"""Bases for all configurable classes in  `graphnet`."""
+
+from abc import ABC, abstractclassmethod
+from typing import Any, Union
+
+try:
+    from typing import final
+except ImportError:  # Python version < 3.8
+
+    # Identity decorator
+    def final(f):  # type: ignore  # noqa: D103
+        return f
+
+
+from graphnet.utilities.config.base_config import BaseConfig
+from graphnet.utilities.logging import LoggerMixin
+
+
+class Configurable(LoggerMixin, ABC):
+    """Base class for all configurable classes in graphnet."""
+
+    def __init__(self) -> None:
+        """Construct `Configurable`."""
+        self._config: "BaseConfig"
+
+    @final
+    @property
+    def config(self) -> "BaseConfig":
+        """Return configuration to re-create the instance."""
+        try:
+            return self._config
+        except AttributeError:
+            self.error(
+                "Config was not set. "
+                "Did you wrap the class constructor with `save_config`?"
+            )
+            raise
+
+    @final
+    def save_config(self, path: str) -> None:
+        """Save Config to `path` as YAML file."""
+        self.config.dump(path)
+
+    @abstractclassmethod
+    def from_config(cls, source: Union["BaseConfig", str]) -> Any:
+        """Construct instance from `source` configuration."""

--- a/src/graphnet/utilities/config/configurable.py
+++ b/src/graphnet/utilities/config/configurable.py
@@ -23,6 +23,9 @@ class Configurable(LoggerMixin, ABC):
         """Construct `Configurable`."""
         self._config: "BaseConfig"
 
+        # Base class constructor
+        super().__init__()
+
     @final
     @property
     def config(self) -> "BaseConfig":

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -273,7 +273,7 @@ def save_config(init_fn: Callable) -> Callable:
 
 
 def list_all_submodules(*packages: types.ModuleType) -> List[types.ModuleType]:
-    """List all submodules in `packages`."""
+    """List all submodules in `packages` recursively."""
     # Resolve one or more packages
     if len(packages) > 1:
         return list(
@@ -315,27 +315,24 @@ def get_all_grapnet_classes(*packages: types.ModuleType) -> Dict[str, type]:
 
 def is_graphnet_module(obj: types.ModuleType) -> bool:
     """Return whether `obj` is a module in graphnet."""
-    if not isinstance(obj, types.ModuleType):
-        return False
-    return obj.__name__.startswith("graphnet.")
+    return isinstance(obj, types.ModuleType) and obj.__name__.startswith(
+        "graphnet."
+    )
 
 
 def is_graphnet_class(obj: type) -> bool:
     """Return whether `obj` is a class in graphnet."""
-    if not isinstance(obj, type):
-        return False
-    return obj.__module__.startswith("graphnet.")
+    return isinstance(obj, type) and obj.__module__.startswith("graphnet.")
 
 
 def get_graphnet_classes(module: types.ModuleType) -> Dict[str, type]:
     """Return a lookup of all graphnet class names in `module`."""
-    namespace = module.__dict__
     if not is_graphnet_module(module):
         logger.info(f"{module} is not a graphnet module")
         return {}
-
     classes = {
-        key: val for key, val in namespace.items() if is_graphnet_class(val)
+        key: val
+        for key, val in module.__dict__.items()
+        if is_graphnet_class(val)
     }
-
     return classes

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -85,7 +85,9 @@ class ModelConfig(BaseConfig):
                         ix
                     ] = self._parse_if_model_config_entry(elem)
             else:
-                data["arguments"][arg] = self._parse_model_config_entry(value)
+                data["arguments"][arg] = self._parse_if_model_config_entry(
+                    value
+                )
 
         # Base class constructor
         super().__init__(**data)

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -190,9 +190,9 @@ class ModelConfig(BaseConfig):
             else:
                 raise ValueError(
                     f"Constructing model containing a class ({obj}) with "
-                    "`trust=False`. If you trust the class definitions in this "
-                    "ModelConfig, set `trust=True` and reconstruct the model "
-                    "again."
+                    "`trust=False`. If you trust the class definitions in "
+                    "this ModelConfig, set `trust=True` and reconstruct the "
+                    "model again."
                 )
 
         else:

--- a/tests/models/test_coarsening.py
+++ b/tests/models/test_coarsening.py
@@ -4,7 +4,7 @@ import torch
 from torch_geometric.data import Data, Batch
 
 from graphnet.models.components.pool import group_by
-from graphnet.models.coarsening import Coarsening
+from graphnet.models.coarsening import AttributeCoarsening
 
 
 # Utility method(s)
@@ -105,14 +105,6 @@ def _get_test_data() -> Batch:
     return batch
 
 
-class SimpleCoarsening(Coarsening):
-    """Simple coarsening operation for the purposes of testing."""
-
-    def _perform_clustering(self, data: Data) -> torch.LongTensor:
-        """Cluster nodes in `data` by assigning a cluster index to each."""
-        return group_by(data, ["x0", "x1", "x2"])
-
-
 # Unit test(s)
 def test_attribute_transfer() -> None:
     """Testing the transfering of auxillary attributes during coarsening."""
@@ -120,7 +112,11 @@ def test_attribute_transfer() -> None:
     data = _get_test_data()
 
     # Perform coarsening
-    coarsening = SimpleCoarsening(reduce="avg", transfer_attributes=False)
+    coarsening = AttributeCoarsening(
+        attributes=["x0", "x1", "x2"],
+        reduce="avg",
+        transfer_attributes=False,
+    )
     pooled_data = coarsening(data)
 
     # Test(s)
@@ -131,7 +127,11 @@ def test_attribute_transfer() -> None:
     assert not hasattr(pooled_data, "attr2")
 
     # Perform coarsening
-    coarsening = SimpleCoarsening(reduce="avg", transfer_attributes=True)
+    coarsening = AttributeCoarsening(
+        attributes=["x0", "x1", "x2"],
+        reduce="avg",
+        transfer_attributes=True,
+    )
     pooled_data = coarsening(data)
 
     # Test(s)
@@ -151,7 +151,11 @@ def test_batch_reconstruction() -> None:
     data = _get_test_data()
     original_batch_idx = data.batch
     # Perform coarsening
-    coarsening = SimpleCoarsening(reduce="avg", transfer_attributes=False)
+    coarsening = coarsening = AttributeCoarsening(
+        attributes=["x0", "x1", "x2"],
+        reduce="avg",
+        transfer_attributes=False,
+    )
     pooled_data = coarsening(data)
 
     # Check that the number of batches is as expected.

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -6,7 +6,7 @@ import torch
 from torch.optim.adam import Adam
 
 from graphnet.models import StandardModel, Model
-from graphnet.models.config import ModelConfig
+from graphnet.utilities.config.model_config import ModelConfig
 from graphnet.models.detector.icecube import IceCubeDeepCore
 from graphnet.models.gnn import DynEdge
 from graphnet.models.graph_builders import KNNGraphBuilder


### PR DESCRIPTION
* Moves `ModelConfig` from `graphnet.models.config` to `graphnet.utilities.config` in anticipation of #226 and to better share code between `Config` classes
* Adds `Configurable` base class for class that will support config files.
* Fixes module search in `ModelConfig.construct_model` that previously only listed already-loaded modules, but now lists all.