### PR TITLE
Allow for querying entire column, rather than just one index at a time

### DIFF
--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -2,9 +2,11 @@
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
 import numpy as np
 import torch
 from torch_geometric.data import Data
+
 from graphnet.utilities.logging import LoggerMixin
 
 
@@ -12,7 +14,7 @@ class ColumnMissingException(Exception):
     """Exception to indicate a missing column in a dataset."""
 
 
-class Dataset(ABC, torch.utils.data.Dataset, LoggerMixin):
+class Dataset(torch.utils.data.Dataset, LoggerMixin, ABC):
     """Base Dataset class for reading from any intermediate file format."""
 
     def __init__(
@@ -165,7 +167,7 @@ class Dataset(ABC, torch.utils.data.Dataset, LoggerMixin):
         self,
         table: str,
         columns: Union[List[str], str],
-        sequential_index: int,
+        sequential_index: Optional[int] = None,
         selection: Optional[str] = None,
     ) -> List[Tuple[Any, ...]]:
         """Query a table at a specific index, optionally with some selection.
@@ -175,7 +177,8 @@ class Dataset(ABC, torch.utils.data.Dataset, LoggerMixin):
             columns: Columns to read out.
             sequential_index: Sequentially numbered index
                 (i.e. in [0,len(self))) of the event to query. This _may_
-                differ from the indexation used in `self._indices`.
+                differ from the indexation used in `self._indices`. If no value
+                is provided, the entire column is returned.
             selection: Selection to be imposed before reading out data.
                 Defaults to None.
 

--- a/src/graphnet/data/parquet/parquet_dataset.py
+++ b/src/graphnet/data/parquet/parquet_dataset.py
@@ -48,7 +48,7 @@ class ParquetDataset(Dataset):
         self,
         table: str,
         columns: Union[List[str], str],
-        sequential_index: int,
+        sequential_index: Optional[int] = None,
         selection: Optional[str] = None,
     ) -> List[Tuple[Any, ...]]:
         # Check(s)
@@ -56,10 +56,17 @@ class ParquetDataset(Dataset):
             selection is None
         ), "Argument `selection` is currently not supported"
 
-        index = cast(List[int], self._indices)[sequential_index]
+        index: Optional[int]
+        if sequential_index is None:
+            index = None
+        else:
+            index = cast(List[int], self._indices)[sequential_index]
 
         try:
-            ak_array = self._parquet_hook[table][columns][index]
+            if index is None:
+                ak_array = self._parquet_hook[table][columns][index]
+            else:
+                ak_array = self._parquet_hook[table][columns][:]
         except ValueError as e:
             if "does not exist (not in record)" in str(e):
                 raise ColumnMissingException(str(e))

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -155,9 +155,10 @@ def test_dataset_query_table(backend: str) -> None:
     assert os.path.exists(path)
 
     # Constructor DataConverter instance
+    pulsemap = "SRTInIcePulses"
     opt = dict(
         path=path,
-        pulsemaps="SRTInIcePulses",
+        pulsemaps=pulsemap,
         features=FEATURES.DEEPCORE,
         truth=TRUTH.DEEPCORE,
     )
@@ -172,13 +173,13 @@ def test_dataset_query_table(backend: str) -> None:
     # Compare to expectations
     nb_events_to_test = 5
     results_all = dataset._query_table(
-        opt["pulsemaps"],
+        pulsemap,
         columns=["event_no", opt["features"][0]],
     )
     for ix_test in range(nb_events_to_test):
 
         results_single = dataset._query_table(
-            opt["pulsemaps"],
+            pulsemap,
             columns=["event_no", opt["features"][0]],
             sequential_index=ix_test,
         )

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -147,5 +147,47 @@ def test_dataset(backend: str) -> None:
         assert len(event.features) == len(opt["features"])
 
 
+@pytest.mark.order(4)
+@pytest.mark.parametrize("backend", ["sqlite", "parquet"])
+def test_dataset_query_table(backend: str) -> None:
+    """Test the implementation of `Dataset._query_table` for `backend`."""
+    path = get_file_path(backend)
+    assert os.path.exists(path)
+
+    # Constructor DataConverter instance
+    opt = dict(
+        path=path,
+        pulsemaps="SRTInIcePulses",
+        features=FEATURES.DEEPCORE,
+        truth=TRUTH.DEEPCORE,
+    )
+
+    if backend == "sqlite":
+        dataset = SQLiteDataset(**opt)  # type: ignore[arg-type]
+    elif backend == "parquet":
+        dataset = ParquetDataset(**opt)  # type: ignore[arg-type]
+    else:
+        assert False, "Shouldn't reach here"
+
+    # Compare to expectations
+    nb_events_to_test = 5
+    results_all = dataset._query_table(
+        opt["pulsemaps"],
+        columns=["event_no", opt["features"][0]],
+    )
+    for ix_test in range(nb_events_to_test):
+
+        results_single = dataset._query_table(
+            opt["pulsemaps"],
+            columns=["event_no", opt["features"][0]],
+            sequential_index=ix_test,
+        )
+        event_nos = list(set([res[0] for res in results_single]))
+        assert len(event_nos) == 1
+        event_no: int = event_nos[0]
+        results_all_subset = [res for res in results_all if res[0] == event_no]
+        assert results_all_subset == results_single
+
+
 if __name__ == "__main__":
-    test_dataconverter("sqlite")
+    test_dataset_query_table("parquet")


### PR DESCRIPTION
Pretty much does what it says on the tin: Expands `Dataset._query_table` to make the index argument optional, such that you can query an entire "column" at once, rather than having to do it row-by-row. I will use this for some simplified train/test selection in support of #262, i.e. stuff like `train_selection = "event_no % 5 > 0"` which will use the same syntax as `pandas.DataFrame.query`.