### PR TITLE
Position reconstruction

### DIFF
--- a/configs/models/dynedge_position_custom_scaling_example.yml
+++ b/configs/models/dynedge_position_custom_scaling_example.yml
@@ -1,0 +1,46 @@
+arguments:
+  coarsening: null
+  detector:
+    ModelConfig:
+      arguments:
+        graph_builder:
+          ModelConfig:
+            arguments: {columns: null, device: null, nb_nearest_neighbours: 8}
+            class_name: KNNGraphBuilder
+        scalers: null
+      class_name: IceCubeDeepCore
+  gnn:
+    ModelConfig:
+      arguments:
+        add_global_variables_after_pooling: false
+        dynedge_layer_sizes: null
+        features_subset: null
+        global_pooling_schemes: [min, max, mean, sum]
+        nb_inputs: 7
+        nb_neighbours: 8
+        post_processing_layer_sizes: null
+        readout_layer_sizes: null
+      class_name: DynEdge
+  optimizer_class: '!class torch.optim.adam Adam'
+  optimizer_kwargs: {eps: 0.001, lr: 0.001}
+  scheduler_class: '!class graphnet.training.callbacks PiecewiseLinearLR'
+  scheduler_config: {interval: step}
+  scheduler_kwargs:
+    factors: [0.01, 1, 0.01]
+    milestones: [0, 33.0, 330]
+  tasks:
+  - ModelConfig:
+      arguments:
+        hidden_size: 128
+        loss_function:
+          ModelConfig:
+            arguments: {}
+            class_name: MSELoss
+        nb_outputs: 3
+        target_labels: [position_x, position_y, position_z]
+        transform_inference: "!function def unscale_XYZ(x):\n    x[:,0] = 764.431509*x[:,0]\n    x[:,1] =\
+          \ 785.041607*x[:,1]\n    x[:,2] = 1083.249944*x[:,2]\n    return x\n"
+        transform_target: "!function def scale_XYZ(x):\n    x[:,0] = x[:,0]/764.431509\n    x[:,1] =\
+          \ x[:,1]/785.041607\n    x[:,2] = x[:,2]/1083.249944\n    return x\n"
+      class_name: IdentityTask
+class_name: StandardModel

--- a/configs/models/dynedge_position_example.yml
+++ b/configs/models/dynedge_position_example.yml
@@ -1,0 +1,44 @@
+arguments:
+  coarsening: null
+  detector:
+    ModelConfig:
+      arguments:
+        graph_builder:
+          ModelConfig:
+            arguments: {columns: null, device: null, nb_nearest_neighbours: 8}
+            class_name: KNNGraphBuilder
+        scalers: null
+      class_name: IceCubeDeepCore
+  gnn:
+    ModelConfig:
+      arguments:
+        add_global_variables_after_pooling: false
+        dynedge_layer_sizes: null
+        features_subset: null
+        global_pooling_schemes: [min, max, mean, sum]
+        nb_inputs: 7
+        nb_neighbours: 8
+        post_processing_layer_sizes: null
+        readout_layer_sizes: null
+      class_name: DynEdge
+  optimizer_class: '!class torch.optim.adam Adam'
+  optimizer_kwargs: {eps: 0.001, lr: 1e-05}
+  scheduler_class: '!class torch.optim.lr_scheduler ReduceLROnPlateau'
+  scheduler_config: {frequency: 1, monitor: val_loss}
+  scheduler_kwargs: {patience: 5}
+  tasks:
+  - ModelConfig:
+      arguments:
+        hidden_size: 128
+        loss_function:
+          ModelConfig:
+            arguments: {}
+            class_name: MSELoss
+        loss_weight: null
+        target_labels: ["position_x", "position_y", "position_y"]
+        transform_inference: null
+        transform_prediction_and_target: null
+        transform_support: null
+        transform_target: null
+      class_name: PositionReconstruction
+class_name: StandardModel

--- a/examples/train_position_reconstruction_model.py
+++ b/examples/train_position_reconstruction_model.py
@@ -1,0 +1,102 @@
+"""Simplified example of training Model."""
+
+import os
+
+from pytorch_lightning.callbacks import EarlyStopping
+from pytorch_lightning.loggers import WandbLogger
+
+from graphnet.data.dataloader import DataLoader
+from graphnet.models import Model
+from graphnet.training.callbacks import ProgressBar
+from graphnet.utilities.config import (
+    DatasetConfig,
+    ModelConfig,
+    TrainingConfig,
+)
+
+# Make sure W&B output directory exists
+WANDB_DIR = "./wandb/"
+os.makedirs(WANDB_DIR, exist_ok=True)
+
+# Initialise Weights & Biases (W&B) run
+wandb_logger = WandbLogger(
+    project="example-script",
+    entity="graphnet-team",
+    save_dir=WANDB_DIR,
+    log_model=True,
+)
+
+
+def main() -> None:
+    """Run example."""
+    # Configuration
+    config = TrainingConfig(
+        target=["position_x", "position_y", "position_z"],
+        early_stopping_patience=5,
+        fit={"gpus": [1], "max_epochs": 5},
+        dataloader={"batch_size": 512, "num_workers": 10},
+    )
+
+    archive = "/groups/icecube/asogaard/gnn/results/"
+    run_name = "dynedge_position_custom_scaling_example.yml"
+
+    # Log configuration to W&B
+    wandb_logger.experiment.config.update(config)
+
+    # Construct dataloaders
+    dataset_config = DatasetConfig.load(
+        "configs/datasets/dev_lvl7_robustness_muon_neutrino_0000.yml"
+    )
+    dataloaders = DataLoader.from_dataset_config(
+        dataset_config,
+        **config.dataloader,
+    )
+    wandb_logger.experiment.config.update(dataset_config.as_dict())
+
+    # Build model
+    model_config = ModelConfig.load(f"configs/models/{run_name}.yml")
+    model = Model.from_config(model_config, trust=True)
+    wandb_logger.experiment.config.update(model_config.as_dict())
+
+    # Train model
+    callbacks = [
+        EarlyStopping(
+            monitor="val_loss",
+            patience=config.early_stopping_patience,
+        ),
+        ProgressBar(),
+    ]
+
+    model.fit(
+        dataloaders["train"],
+        dataloaders["validation"],
+        callbacks=callbacks,
+        logger=wandb_logger,
+        **config.fit,
+    )
+
+    # Get predictions
+    if isinstance(config.target, str):
+        prediction_columns = [config.target + "_pred"]
+        additional_attributes = [config.target]
+    else:
+        prediction_columns = [target + "_pred" for target in config.target]
+        additional_attributes = config.target
+
+    results = model.predict_as_dataframe(
+        dataloaders["test"],
+        prediction_columns=prediction_columns,
+        additional_attributes=additional_attributes + ["event_no"],
+    )
+
+    # Save predictions and model to file
+    db_name = dataset_config.path.split("/")[-1].split(".")[0]
+    path = os.path.join(archive, db_name, run_name)
+
+    results.to_csv(f"{path}/results.csv")
+    model.save_state_dict(f"{path}/state_dict.pth")
+    model.save(f"{path}/model.pth")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -1,7 +1,7 @@
 """Base physics task-specific `Model` class(es)."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import Any, TYPE_CHECKING, List, Tuple, Union
 from typing import Callable, Optional
 import numpy as np
 
@@ -196,15 +196,29 @@ class Task(Model):
                     np.concatenate([-x_test[::-1], [0], x_test])
                 )
 
-            # Add feature dimension before inference transformation to make it match the dimensions of a standard prediction. Remove it again before comparison. Temporary
-            t_test = torch.unsqueeze(transform_target(x_test), -1)
-            t_test = torch.squeeze(transform_inference(t_test), -1)
-            valid = torch.isfinite(t_test)
+            # Add feature dimension before inference transformation to make it
+            # match the dimensions of a standard prediction. Remove it again
+            # before comparison. Temporary
+            try:
+                t_test = torch.unsqueeze(transform_target(x_test), -1)
+                t_test = torch.squeeze(transform_inference(t_test), -1)
+                valid = torch.isfinite(t_test)
 
-            assert torch.allclose(
-                t_test[valid], x_test[valid]
-            ), "The provided transforms for targets during training and predictions during inference are not inverse. Please adjust transformation functions or support."
-            del x_test, t_test, valid
+                assert torch.allclose(t_test[valid], x_test[valid]), (
+                    "The provided transforms for targets during training and "
+                    "predictions during inference are not inverse. Please "
+                    "adjust transformation functions or support."
+                )
+                del x_test, t_test, valid
+
+            except IndexError:
+                self.warning(
+                    "transform_target and/or transform_inference rely on "
+                    "indexing, which we won't validate. Please make sure that "
+                    "they are mutually inverse, i.e. that\n"
+                    "  x = transform_inference(transform_target(x))\n"
+                    "for all x that are within your target range."
+                )
 
         # Set transforms
         if transform_prediction_and_target is not None:
@@ -216,3 +230,28 @@ class Task(Model):
             assert transform_inference is not None
             self._transform_prediction_inference = transform_inference
             self._transform_target = transform_target
+
+
+class IdentityTask(Task):
+    """Identity, or trivial, task."""
+
+    @save_model_config
+    def __init__(self, nb_outputs: int, *args: Any, **kwargs: Any):
+        """Construct IdentityTask.
+
+        Return the `nb_outputs` as a direct, affine transformation of the last
+        hidden layer.
+        """
+        self._nb_inputs = nb_outputs
+
+        # Base class constructor
+        super().__init__(*args, **kwargs)
+
+    @property
+    def nb_inputs(self) -> int:
+        """Return number of inputs assumed by task."""
+        return self._nb_inputs
+
+    def _forward(self, x: Tensor) -> Tensor:
+        # Leave it as is.
+        return x

--- a/src/graphnet/utilities/config/base_config.py
+++ b/src/graphnet/utilities/config/base_config.py
@@ -3,12 +3,11 @@
 from abc import abstractmethod
 from collections import OrderedDict
 import inspect
+import sys
 from typing import Any, Callable, Dict, Optional
 
 from pydantic import BaseModel
 import ruamel.yaml as yaml
-
-from graphnet.utilities.logging import LoggerMixin
 
 
 CONFIG_FILES_SUFFIXES = (".yml", ".yaml")
@@ -41,7 +40,7 @@ class BaseConfig(BaseModel):
                 yaml_.dump(config_dict, f)
             return None
         else:
-            return yaml_.dump(config_dict)
+            return yaml_.dump(config_dict, sys.stdout)
 
     def as_dict(self) -> Dict[str, Dict[str, Any]]:
         """Represent BaseConfig as a dict.

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
     from graphnet.models import Model
 
 
+FUNCTION_DEFINITION_PATTERN = (
+    r"^def (?P<function_name>[a-zA-Z]{1}[a-zA-Z0-9_]+) *\(.*\) *:"
+)
+
+
 class ModelConfig(BaseConfig):
     """Configuration for all `Model`s."""
 
@@ -146,6 +151,22 @@ class ModelConfig(BaseConfig):
                     "reconstruct the model again."
                 )
 
+        elif isinstance(obj, str) and obj.startswith("!function"):
+            if trust:
+                source = obj[10:]
+                match = re.match(FUNCTION_DEFINITION_PATTERN, source)
+                assert match
+                exec(source)
+                fn = eval(match.group("function_name"))
+                return fn
+            else:
+                raise ValueError(
+                    f"Constructing model containing a function ({obj}) with "
+                    "`trust=False`. If you trust the functions in this "
+                    "ModelConfig, set `trust=True` and reconstruct the model "
+                    "again."
+                )
+
         elif isinstance(obj, str) and obj.startswith("!class"):
             if trust:
                 module, class_name = obj.split()[1:]
@@ -173,11 +194,20 @@ class ModelConfig(BaseConfig):
             if hasattr(obj, "__name__") and obj.__name__ == "<lambda>":
                 return "!" + inspect.getsource(obj).split("=")[1].strip("\n ,")
             else:
-                raise ValueError(
-                    f"Object `{obj}` is callable but not a lambda function. "
-                    "Please wrap in a lambda function to allow for saving "
-                    "this function verbatim in a model config file."
-                )
+                try:
+                    source = inspect.getsource(obj)
+                    match = re.match(FUNCTION_DEFINITION_PATTERN, source)
+                    if match and match.group("function_name"):
+                        return f"!function {source}"
+                    else:
+                        raise ValueError
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"Object `{obj}` is callable but not a lambda or regular "
+                        "function. Please wrap in a, e.g., lambda function to "
+                        "allow for saving this function verbatim in a model "
+                        "config file."
+                    )
 
         return obj
 

--- a/src/graphnet/utilities/config/training_config.py
+++ b/src/graphnet/utilities/config/training_config.py
@@ -1,6 +1,6 @@
 """Config classes for the `graphnet.training` module."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 from graphnet.utilities.config.base_config import BaseConfig
 
@@ -9,7 +9,7 @@ class TrainingConfig(BaseConfig):
     """Configuration for all trainings."""
 
     # Fields
-    target: str
+    target: Union[str, List[str]]
     early_stopping_patience: int
     fit: Dict[str, Any]
     dataloader: Dict[str, Any]


### PR DESCRIPTION
* Adds `IdentityTask` with configurable number of output nodes, that doesn't do anything and thus allows for "pass-through" of an affine transformation of the last hidden layer, i.e., without the application of any activation function or anything like that.
* Adds the option to use custom functions for the `transform_*` arguments to `Task`.
* Ignores validation of `transform_target` and `transform_inference` in favour of a warning in cases where these rely on indexing and strictly assume input tensors of dimensionality > 1.
* Adds config files for vertex position reconstruction, with and without custom transform functions
* Adds training example for vertex position reconstruction model, leveraging the above.

Closes #359 