### PR TITLE
Enable multi-GPU training

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3
       args: [--config=black.toml]
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1

--- a/configs/models/dynedge_energy_example.yml
+++ b/configs/models/dynedge_energy_example.yml
@@ -5,7 +5,7 @@ arguments:
       arguments:
         graph_builder:
           ModelConfig:
-            arguments: {columns: null, device: null, nb_nearest_neighbours: 8}
+            arguments: {columns: null, nb_nearest_neighbours: 8}
             class_name: KNNGraphBuilder
         scalers: null
       class_name: IceCubeDeepCore

--- a/configs/models/dynedge_position_custom_scaling_example.yml
+++ b/configs/models/dynedge_position_custom_scaling_example.yml
@@ -5,7 +5,7 @@ arguments:
       arguments:
         graph_builder:
           ModelConfig:
-            arguments: {columns: null, device: null, nb_nearest_neighbours: 8}
+            arguments: {columns: null, nb_nearest_neighbours: 8}
             class_name: KNNGraphBuilder
         scalers: null
       class_name: IceCubeDeepCore

--- a/configs/models/dynedge_position_example.yml
+++ b/configs/models/dynedge_position_example.yml
@@ -5,7 +5,7 @@ arguments:
       arguments:
         graph_builder:
           ModelConfig:
-            arguments: {columns: null, device: null, nb_nearest_neighbours: 8}
+            arguments: {columns: null, nb_nearest_neighbours: 8}
             class_name: KNNGraphBuilder
         scalers: null
       class_name: IceCubeDeepCore

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -4,6 +4,7 @@ import os
 
 from pytorch_lightning.callbacks import EarlyStopping
 from pytorch_lightning.loggers import WandbLogger
+from pytorch_lightning.utilities import rank_zero_only
 
 from graphnet.data.dataloader import DataLoader
 from graphnet.models import Model
@@ -33,15 +34,12 @@ def main() -> None:
     config = TrainingConfig(
         target="energy",
         early_stopping_patience=5,
-        fit={"gpus": [0], "max_epochs": 5},
-        dataloader={"batch_size": 512, "num_workers": 10},
+        fit={"gpus": [0, 1], "max_epochs": 5},
+        dataloader={"batch_size": 4, "num_workers": 10},
     )
 
     archive = "/groups/icecube/asogaard/gnn/results/"
     run_name = "dynedge_{}_example".format(config.target)
-
-    # Log configuration to W&B
-    wandb_logger.experiment.config.update(config)
 
     # Construct dataloaders
     dataset_config = DatasetConfig.load(
@@ -51,12 +49,18 @@ def main() -> None:
         dataset_config,
         **config.dataloader,
     )
-    wandb_logger.experiment.config.update(dataset_config.as_dict())
 
     # Build model
     model_config = ModelConfig.load(f"configs/models/{run_name}.yml")
     model = Model.from_config(model_config, trust=True)
-    wandb_logger.experiment.config.update(model_config.as_dict())
+
+    # Log configurations to W&B
+    # NB: Only log to W&B on the rank-zero process in case of multi-GPU
+    #     training.
+    if rank_zero_only == 0:
+        wandb_logger.experiment.config.update(config)
+        wandb_logger.experiment.config.update(model_config.as_dict())
+        wandb_logger.experiment.config.update(dataset_config.as_dict())
 
     # Train model
     callbacks = [

--- a/examples/train_model.py
+++ b/examples/train_model.py
@@ -35,7 +35,7 @@ def main() -> None:
         target="energy",
         early_stopping_patience=5,
         fit={"gpus": [0, 1], "max_epochs": 5},
-        dataloader={"batch_size": 4, "num_workers": 10},
+        dataloader={"batch_size": 128, "num_workers": 10},
     )
 
     archive = "/groups/icecube/asogaard/gnn/results/"

--- a/src/graphnet/models/components/layers.py
+++ b/src/graphnet/models/components/layers.py
@@ -3,13 +3,13 @@
 from typing import Any, Callable, Optional, Sequence, Union
 
 from torch.functional import Tensor
-
 from torch_geometric.nn import EdgeConv
 from torch_geometric.nn.pool import knn_graph
 from torch_geometric.typing import Adj
+from pytorch_lightning import LightningModule
 
 
-class DynEdgeConv(EdgeConv):
+class DynEdgeConv(EdgeConv, LightningModule):
     """Dynamical edge convolution layer."""
 
     def __init__(
@@ -56,6 +56,6 @@ class DynEdgeConv(EdgeConv):
             x=x[:, self.features_subset],
             k=self.nb_neighbors,
             batch=batch,
-        ).to(x.device)
+        ).to(self.device)
 
         return x, edge_index

--- a/src/graphnet/models/graph_builders.py
+++ b/src/graphnet/models/graph_builders.py
@@ -25,7 +25,6 @@ class KNNGraphBuilder(GraphBuilder):  # pylint: disable=too-few-public-methods
         self,
         nb_nearest_neighbours: int,
         columns: List[int] = None,
-        device: str = None,
     ):
         """Construct `KNNGraphBuilder`."""
         # Base class constructor
@@ -38,7 +37,6 @@ class KNNGraphBuilder(GraphBuilder):  # pylint: disable=too-few-public-methods
         # Member variable(s)
         self._nb_nearest_neighbours = nb_nearest_neighbours
         self._columns = columns
-        self._device = device
 
     def forward(self, data: Data) -> Data:
         """Forward pass."""
@@ -54,7 +52,7 @@ class KNNGraphBuilder(GraphBuilder):  # pylint: disable=too-few-public-methods
             data.x[:, self._columns],
             self._nb_nearest_neighbours,
             data.batch,
-        ).to(self._device)
+        ).to(self.device)
 
         return data
 
@@ -67,7 +65,6 @@ class RadialGraphBuilder(GraphBuilder):
         self,
         radius: float,
         columns: List[int] = None,
-        device: str = None,
     ):
         """Construct `RadialGraphBuilder`."""
         # Base class constructor
@@ -80,7 +77,6 @@ class RadialGraphBuilder(GraphBuilder):
         # Member variable(s)
         self._radius = radius
         self._columns = columns
-        self._device = device
 
     def forward(self, data: Data) -> Data:
         """Forward pass."""
@@ -96,7 +92,7 @@ class RadialGraphBuilder(GraphBuilder):
             data.x[:, self._columns],
             self._radius,
             data.batch,
-        ).to(self._device)
+        ).to(self.device)
 
         return data
 

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -59,6 +59,7 @@ class Model(Configurable, LightningModule, LoggerMixin, ABC):
             log_every_n_steps=log_every_n_steps,
             logger=logger,
             gradient_clip_val=gradient_clip_val,
+            strategy="ddp",
             **trainer_kwargs,
         )
         try:

--- a/src/graphnet/models/standard_model.py
+++ b/src/graphnet/models/standard_model.py
@@ -113,6 +113,7 @@ class StandardModel(Model):
             prog_bar=True,
             on_epoch=True,
             on_step=False,
+            sync_dist=True,
         )
         return loss
 
@@ -126,6 +127,7 @@ class StandardModel(Model):
             prog_bar=True,
             on_epoch=True,
             on_step=False,
+            sync_dist=True,
         )
         return loss
 


### PR DESCRIPTION
* Enables multi-GPU training using the "DDP" strategy.
* Updates training example to run on multiple GPUs.
* Updates `GraphBuilder` classes as well as model config files to remove `device` argument, which is deprecated in favour of letting pytorch-lightning handling devices as much as possible (recommended for multi-GPU training).

Closes #301

cc @sathanas31