### PR TITLE
SQLite utility methods

### DIFF
--- a/src/graphnet/data/sqlite/__init__.py
+++ b/src/graphnet/data/sqlite/__init__.py
@@ -3,7 +3,12 @@
 from graphnet.utilities.imports import has_torch_package
 
 from .sqlite_dataconverter import SQLiteDataConverter
-from .sqlite_utilities import run_sql_code, save_to_sql, create_table
+from .sqlite_utilities import (
+    run_sql_code,
+    save_to_sql,
+    create_table,
+    create_table_and_save_to_sql,
+)
 
 if has_torch_package():
     from .sqlite_dataset import SQLiteDataset

--- a/src/graphnet/data/sqlite/__init__.py
+++ b/src/graphnet/data/sqlite/__init__.py
@@ -3,12 +3,7 @@
 from graphnet.utilities.imports import has_torch_package
 
 from .sqlite_dataconverter import SQLiteDataConverter
-from .sqlite_utilities import (
-    run_sql_code,
-    save_to_sql,
-    create_table,
-    create_table_and_save_to_sql,
-)
+from .sqlite_utilities import create_table_and_save_to_sql
 
 if has_torch_package():
     from .sqlite_dataset import SQLiteDataset

--- a/src/graphnet/data/sqlite/sqlite_dataconverter.py
+++ b/src/graphnet/data/sqlite/sqlite_dataconverter.py
@@ -10,7 +10,10 @@ import sqlite3
 from tqdm import tqdm
 
 from graphnet.data.dataconverter import DataConverter  # type: ignore[attr-defined]
-from graphnet.data.sqlite.sqlite_utilities import save_to_sql, create_table
+from graphnet.data.sqlite.sqlite_utilities import (
+    create_table,
+    create_table_and_save_to_sql,
+)
 
 
 class SQLiteDataConverter(DataConverter):
@@ -51,7 +54,15 @@ class SQLiteDataConverter(DataConverter):
         saved_any = False
         for table, df in dataframe.items():
             if len(df) > 0:
-                save_to_sql(df, table, output_file)
+                create_table_and_save_to_sql(
+                    df,
+                    table,
+                    output_file,
+                    default_type="FLOAT",
+                    integer_primary_key=not (
+                        is_pulse_map(table) or is_mc_tree(table)
+                    ),
+                )
                 saved_any = True
 
         if saved_any:

--- a/src/graphnet/data/sqlite/sqlite_dataconverter.py
+++ b/src/graphnet/data/sqlite/sqlite_dataconverter.py
@@ -10,7 +10,7 @@ import sqlite3
 from tqdm import tqdm
 
 from graphnet.data.dataconverter import DataConverter  # type: ignore[attr-defined]
-from graphnet.data.sqlite.sqlite_utilities import run_sql_code, save_to_sql
+from graphnet.data.sqlite.sqlite_utilities import save_to_sql, create_table
 
 
 class SQLiteDataConverter(DataConverter):
@@ -92,12 +92,13 @@ class SQLiteDataConverter(DataConverter):
                     input_files, table_name
                 )
                 if len(column_names) > 1:
-                    is_pulse_map = is_pulsemap_check(table_name)
-                    self._create_table(
-                        output_file,
-                        table_name,
+                    create_table(
                         column_names,
-                        is_pulse_map=is_pulse_map,
+                        table_name,
+                        output_file,
+                        integer_primary_key=not (
+                            is_pulse_map(table_name) or is_mc_tree(table_name)
+                        ),
                     )
 
             # Merge temporary databases into newly created one
@@ -156,60 +157,6 @@ class SQLiteDataConverter(DataConverter):
 
         pulsemap_dicts = [data_dict[pulsemap] for pulsemap in self._pulsemaps]
         return any(d["dom_x"] for d in pulsemap_dicts)
-
-    def _attach_index(self, database: str, table_name: str) -> None:
-        """Attach the table index.
-
-        Important for query times!
-        """
-        code = (
-            "PRAGMA foreign_keys=off;\n"
-            "BEGIN TRANSACTION;\n"
-            f"CREATE INDEX event_no_{table_name} ON {table_name} (event_no);\n"
-            "COMMIT TRANSACTION;\n"
-            "PRAGMA foreign_keys=on;"
-        )
-        run_sql_code(database, code)
-
-    def _create_table(
-        self,
-        database: str,
-        table_name: str,
-        columns: List[str],
-        is_pulse_map: bool = False,
-    ) -> None:
-        """Create a table.
-
-        Args:
-            database: Path to the database.
-            table_name: Name of the table.
-            columns: The names of the columns of the table.
-            is_pulse_map: Whether or not this is a pulse map table.
-        """
-        query_columns = list()
-        for column in columns:
-            if column == "event_no":
-                if not is_pulse_map:
-                    type_ = "INTEGER PRIMARY KEY NOT NULL"
-                else:
-                    type_ = "NOT NULL"
-            else:
-                type_ = "FLOAT"
-            query_columns.append(f"{column} {type_}")
-        query_columns_string = ", ".join(query_columns)
-
-        code = (
-            "PRAGMA foreign_keys=off;\n"
-            f"CREATE TABLE {table_name} ({query_columns_string});\n"
-            "PRAGMA foreign_keys=on;"
-        )
-        run_sql_code(database, code)
-
-        if is_pulse_map:
-            self.debug(table_name)
-            self.debug("Attaching indices")
-            self._attach_index(database, table_name)
-        return
 
     def _submit_to_database(
         self, database: str, key: str, data: pd.DataFrame
@@ -280,9 +227,11 @@ def construct_dataframe(extraction: Dict[str, Any]) -> pd.DataFrame:
     return out
 
 
-def is_pulsemap_check(table_name: str) -> bool:
-    """Check whether `table_name` corresponds to a pulsemap."""
-    if "pulse" in table_name.lower():
-        return True
-    else:
-        return False
+def is_pulse_map(table_name: str) -> bool:
+    """Check whether `table_name` corresponds to a pulse map."""
+    return "pulse" in table_name.lower() or "series" in table_name.lower()
+
+
+def is_mc_tree(table_name: str) -> bool:
+    """Check whether `table_name` corresponds to an MC tree."""
+    return "I3MCTree" in table_name

--- a/src/graphnet/data/sqlite/sqlite_dataconverter.py
+++ b/src/graphnet/data/sqlite/sqlite_dataconverter.py
@@ -96,6 +96,7 @@ class SQLiteDataConverter(DataConverter):
                         column_names,
                         table_name,
                         output_file,
+                        default_type="FLOAT",
                         integer_primary_key=not (
                             is_pulse_map(table_name) or is_mc_tree(table_name)
                         ),

--- a/src/graphnet/data/sqlite/sqlite_utilities.py
+++ b/src/graphnet/data/sqlite/sqlite_utilities.py
@@ -97,9 +97,6 @@ def create_table(
             other such data that is expected to have more that one row per
             event (i.e., with the same index).
     """
-    print(
-        f"!! {table_name} in {database_path} has integer_primary_key = {integer_primary_key}"
-    )
     # Prepare column names and types
     query_columns = []
     for column in columns:
@@ -127,7 +124,6 @@ def create_table(
 
     # Attaching index to all non-truth-like tables (e.g., pulse maps).
     if not integer_primary_key:
-        print(f"!! Attaching index for {table_name} in {database_path}")
         attach_index(database_path, table_name)
 
 

--- a/src/graphnet/data/sqlite/sqlite_utilities.py
+++ b/src/graphnet/data/sqlite/sqlite_utilities.py
@@ -57,7 +57,9 @@ def create_table(
     columns: List[str],
     table_name: str,
     database_path: str,
+    *,
     index_column: str = "event_no",
+    default_type: str = "NOT NULL",
     integer_primary_key: bool = True,
 ) -> None:
     """Create a table.
@@ -67,6 +69,7 @@ def create_table(
         table_name: Name of the table.
         database_path: Path to the database.
         index_column: Name of the index column.
+        default_type: The type used for all non-index columns.
         integer_primary_key: Whether or not to create the `index_column` with
             the `INTEGER PRIMARY KEY` type. Such a column is required to have
             unique, integer values for each row. This is appropriate when the
@@ -78,10 +81,12 @@ def create_table(
     # Prepare column names and types
     query_columns = []
     for column in columns:
-        if column == index_column and integer_primary_key:
-            type_ = "INTEGER PRIMARY KEY NOT NULL"
-        else:
-            type_ = "NOT NULL"
+        type_ = default_type
+        if column == index_column:
+            if integer_primary_key:
+                type_ = "INTEGER PRIMARY KEY NOT NULL"
+            else:
+                type_ = "NOT NULL"
 
         query_columns.append(f"{column} {type_}")
 

--- a/src/graphnet/data/utilities/parquet_to_sqlite.py
+++ b/src/graphnet/data/utilities/parquet_to_sqlite.py
@@ -75,8 +75,12 @@ class ParquetToSQLiteConverter(LoggerMixin):
         database_path = os.path.join(
             outdir, database_name, "data", database_name + ".db"
         )
+        self.info(f"Processing {len(self._parquet_files)} Parquet file(s)")
         for i in trange(
-            len(self._parquet_files), desc="Main", colour="#0000ff", position=0
+            len(self._parquet_files),
+            unit="file(s)",
+            colour="green",
+            position=0,
         ):
             parquet_file = ak.from_parquet(self._parquet_files[i])
             n_events_in_file = self._count_events(parquet_file)

--- a/src/graphnet/data/utilities/parquet_to_sqlite.py
+++ b/src/graphnet/data/utilities/parquet_to_sqlite.py
@@ -100,8 +100,9 @@ class ParquetToSQLiteConverter(LoggerMixin):
                     )
             self._event_counter += n_events_in_file
         self._save_config(outdir, database_name)
-        print(
-            f"Database saved at: \n{outdir}/{database_name}/data/{database_name}.db"
+        self.info(
+            "Database saved at: \n"
+            f"{outdir}/{database_name}/data/{database_name}.db"
         )
 
     def _count_events(self, open_parquet_file: ak.Array) -> int:
@@ -138,9 +139,10 @@ class ParquetToSQLiteConverter(LoggerMixin):
         if len(df.columns) == 1:
             if df.columns == ["values"]:
                 df.columns = [field_name]
-        if (
-            len(df) != n_events_in_file
-        ):  # if true, the dataframe contains more than 1 row pr. event (e.g. Pulsemap).
+
+        # If true, the dataframe contains more than 1 row pr. event (i.e.,
+        # pulsemap).
+        if len(df) != n_events_in_file:
             event_nos = []
             c = 0
             for event_no in range(
@@ -150,7 +152,10 @@ class ParquetToSQLiteConverter(LoggerMixin):
                     event_nos.extend(
                         np.repeat(event_no, len(df[df.columns[0]][c])).tolist()
                     )
-                except KeyError:  # KeyError indicates that this df has no entry for event_no (e.g. an event with no detector response)
+
+                # KeyError indicates that this df has no entry for event_no
+                # (e.g., an event with no detector response).
+                except KeyError:
                     pass
                 c += 1
         else:

--- a/src/graphnet/data/utilities/parquet_to_sqlite.py
+++ b/src/graphnet/data/utilities/parquet_to_sqlite.py
@@ -118,23 +118,26 @@ class ParquetToSQLiteConverter(LoggerMixin):
         df = self._convert_to_dataframe(ak_array, field_name, n_events_in_file)
         if field_name in self._created_tables:
             save_to_sql(
-                database_path,
-                field_name,
                 df,
+                field_name,
+                database_path,
             )
         else:
             if len(df) > n_events_in_file:
                 is_pulse_map = True
             else:
                 is_pulse_map = False
-            create_table(df, field_name, database_path, is_pulse_map)
-            if is_pulse_map:
-                attach_index(database_path, table_name=field_name)
+            create_table(
+                df.columns,
+                field_name,
+                database_path,
+                integer_primary_key=not is_pulse_map,
+            )
             self._created_tables.append(field_name)
             save_to_sql(
-                database_path,
-                field_name,
                 df,
+                field_name,
+                database_path,
             )
 
     def _convert_to_dataframe(

--- a/src/graphnet/pisa/fitting.py
+++ b/src/graphnet/pisa/fitting.py
@@ -20,7 +20,7 @@ from pisa.core.pipeline import Pipeline
 from pisa.analysis.analysis import Analysis
 from pisa import ureg
 
-from graphnet.data.sqlite import run_sql_code, save_to_sql
+from graphnet.data.sqlite import save_to_sql, create_table
 
 mpl.use("pdf")
 plt.rc("font", family="serif")
@@ -157,37 +157,9 @@ class WeightFitter:
             results = results.append(data)
 
         if add_to_database:
-            self._create_table(self._database_path, weight_name, results)
+            create_table(results.columns, weight_name, self._database_path)
             save_to_sql(results, weight_name, self._database_path)
         return results.sort_values("event_no").reset_index(drop=True)
-
-    # @TODO: Remove duplication wrt. method with same name in
-    #        `src/graphnet/data/sqlite/sqlite_dataconverter.py`
-    def _create_table(
-        self, database: str, table_name: str, df: pd.DataFrame
-    ) -> None:
-        """Create a table.
-
-        Args:
-            database: Path to the pipeline database.
-            table_name: Name of the table to be created.
-            df: DataFrame of combined predictions.
-        """
-        query_columns_list = list()
-        for column in df.columns:
-            if column == "event_no":
-                type_ = "INTEGER PRIMARY KEY NOT NULL"
-            else:
-                type_ = "FLOAT"
-            query_columns_list.append(f"{column} {type_}")
-        query_columns = ", ".join(query_columns_list)
-
-        code = (
-            "PRAGMA foreign_keys=off;\n"
-            f"CREATE TABLE {table_name} ({query_columns});\n"
-            "PRAGMA foreign_keys=on;"
-        )
-        run_sql_code(database, code)
 
     def _make_config(
         self,

--- a/src/graphnet/pisa/fitting.py
+++ b/src/graphnet/pisa/fitting.py
@@ -20,7 +20,7 @@ from pisa.core.pipeline import Pipeline
 from pisa.analysis.analysis import Analysis
 from pisa import ureg
 
-from graphnet.data.sqlite import save_to_sql, create_table
+from graphnet.data.sqlite import create_table_and_save_to_sql
 
 mpl.use("pdf")
 plt.rc("font", family="serif")
@@ -157,8 +157,9 @@ class WeightFitter:
             results = results.append(data)
 
         if add_to_database:
-            create_table(results.columns, weight_name, self._database_path)
-            save_to_sql(results, weight_name, self._database_path)
+            create_table_and_save_to_sql(
+                results.columns, weight_name, self._database_path
+            )
         return results.sort_values("event_no").reset_index(drop=True)
 
     def _make_config(

--- a/src/graphnet/training/weight_fitting.py
+++ b/src/graphnet/training/weight_fitting.py
@@ -1,14 +1,13 @@
 """Classes for fitting per-event weights for training."""
 
+from abc import ABC, abstractmethod
+from typing import Any, Optional, List, Callable
+
 import numpy as np
 import pandas as pd
 import sqlite3
-from typing import Any, Optional, List, Callable
-from graphnet.data.sqlite.sqlite_utilities import (
-    save_to_sql,
-    create_table,
-)
-from abc import ABC, abstractmethod
+
+from graphnet.data.sqlite.sqlite_utilities import create_table_and_save_to_sql
 from graphnet.utilities.logging import LoggerMixin
 
 
@@ -92,10 +91,9 @@ class WeightFitter(ABC, LoggerMixin):
         weights = self._fit_weights(truth, **kwargs)
 
         if add_to_database:
-            create_table(
-                weights.columns, self._weight_name, self._database_path
+            create_table_and_save_to_sql(
+                weights, self._weight_name, self._database_path
             )
-            save_to_sql(weights, self._weight_name, self._database_path)
         return weights.sort_values(self._index_column).reset_index(drop=True)
 
     @abstractmethod

--- a/src/graphnet/training/weight_fitting.py
+++ b/src/graphnet/training/weight_fitting.py
@@ -92,7 +92,9 @@ class WeightFitter(ABC, LoggerMixin):
         weights = self._fit_weights(truth, **kwargs)
 
         if add_to_database:
-            create_table(weights, self._weight_name, self._database_path)
+            create_table(
+                weights.columns, self._weight_name, self._database_path
+            )
             save_to_sql(weights, self._weight_name, self._database_path)
         return weights.sort_values(self._index_column).reset_index(drop=True)
 

--- a/src/graphnet/utilities/config/base_config.py
+++ b/src/graphnet/utilities/config/base_config.py
@@ -56,12 +56,14 @@ def get_all_argument_values(
     """Return dict of all argument values to `fn`, including defaults."""
     # Get all default argument values
     cfg = OrderedDict()
-    for key, parameter in inspect.signature(fn).parameters.items():
-        if key == "self" or (
-            key in ["kwargs", "kwds"] and parameter.default == inspect._empty
-        ):
+    for key, param in inspect.signature(fn).parameters.items():
+        # Don't save `self`, `*args`, or `**kwargs`
+        if key == "self" or param.kind in [
+            param.VAR_POSITIONAL,
+            param.VAR_KEYWORD,
+        ]:
             continue
-        cfg[key] = parameter.default
+        cfg[key] = param.default
 
     # Add positional arguments
     for key, val in zip(cfg.keys(), args):

--- a/src/graphnet/utilities/config/base_config.py
+++ b/src/graphnet/utilities/config/base_config.py
@@ -57,7 +57,9 @@ def get_all_argument_values(
     # Get all default argument values
     cfg = OrderedDict()
     for key, parameter in inspect.signature(fn).parameters.items():
-        if key == "self":
+        if key == "self" or (
+            key in ["kwargs", "kwds"] and parameter.default == inspect._empty
+        ):
             continue
         cfg[key] = parameter.default
 

--- a/src/graphnet/utilities/config/base_config.py
+++ b/src/graphnet/utilities/config/base_config.py
@@ -57,7 +57,7 @@ def get_all_argument_values(
     # Get all default argument values
     cfg = OrderedDict()
     for key, parameter in inspect.signature(fn).parameters.items():
-        if key == "self" or parameter.default == inspect._empty:
+        if key == "self":
             continue
         cfg[key] = parameter.default
 

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -2,7 +2,9 @@
 
 import os
 
+import pandas as pd
 import pytest
+import sqlite3
 import torch
 
 import graphnet.constants
@@ -214,5 +216,35 @@ def test_parquet_to_sqlite_converter() -> None:
         assert torch.allclose(dataset_from_parquet[ix].x, dataset[ix].x)
 
 
+@pytest.mark.order(5)
+@pytest.mark.parametrize("pulsemap", ["SRTInIcePulses"])
+@pytest.mark.parametrize("event_no", [1])
+def test_database_query_plan(pulsemap: str, event_no: int) -> None:
+    """Test query plan agreement in original and parquet-converted database."""
+    # Configure paths to databases to compare
+    database_name = FILE_NAME + "_from_parquet"
+    parquet_converted_database = (
+        f"{OUTPUT_DATA_DIR}/{database_name}/data/{database_name}.db"
+    )
+    sqlite_database = get_file_path("sqlite")
+
+    # Get query plans
+    query = f"EXPLAIN QUERY PLAN SELECT * FROM {pulsemap} WHERE event_no={event_no}"
+    with sqlite3.connect(sqlite_database) as conn:
+        sqlite_plan = pd.read_sql(query, conn)
+
+    with sqlite3.connect(parquet_converted_database) as conn:
+        parquet_plan = pd.read_sql(query, conn)
+
+    # Compare
+    assert "USING INDEX event_no" in sqlite_plan["detail"].iloc[0]
+    assert "USING INDEX event_no" in parquet_plan["detail"].iloc[0]
+
+    assert (sqlite_plan["detail"] == parquet_plan["detail"]).all()
+
+
 if __name__ == "__main__":
+    test_dataconverter("sqlite")
+    test_dataconverter("parquet")
     test_parquet_to_sqlite_converter()
+    test_database_query_plan("SRTInIcePulses", 1)

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -23,7 +23,7 @@ from graphnet.data.sqlite import (
     SQLiteDataConverter,
 )
 from graphnet.data.sqlite.sqlite_dataconverter import (
-    is_pulsemap_check,
+    is_pulse_map,
 )
 from graphnet.utilities.imports import has_icecube_package
 
@@ -57,12 +57,12 @@ def get_file_path(backend: str) -> str:
 # Unit test(s)
 def test_is_pulsemap_check() -> None:
     """Test behaviour of `is_pulsemap_check`."""
-    assert is_pulsemap_check("SplitInIcePulses") is True
-    assert is_pulsemap_check("SRTInIcePulses") is True
-    assert is_pulsemap_check("InIceDSTPulses") is True
-    assert is_pulsemap_check("RTTWOfflinePulses") is True
-    assert is_pulsemap_check("truth") is False
-    assert is_pulsemap_check("retro") is False
+    assert is_pulse_map("SplitInIcePulses") is True
+    assert is_pulse_map("SRTInIcePulses") is True
+    assert is_pulse_map("InIceDSTPulses") is True
+    assert is_pulse_map("RTTWOfflinePulses") is True
+    assert is_pulse_map("truth") is False
+    assert is_pulse_map("retro") is False
 
 
 @pytest.mark.order(1)

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -229,7 +229,11 @@ def test_database_query_plan(pulsemap: str, event_no: int) -> None:
     sqlite_database = get_file_path("sqlite")
 
     # Get query plans
-    query = f"EXPLAIN QUERY PLAN SELECT * FROM {pulsemap} WHERE event_no={event_no}"
+    query = f"""
+    EXPLAIN QUERY PLAN
+    SELECT * FROM {pulsemap}
+    WHERE event_no={event_no}
+    """
     with sqlite3.connect(sqlite_database) as conn:
         sqlite_plan = pd.read_sql(query, conn)
 


### PR DESCRIPTION
* Removes duplication of `create_table` and `attach_index`-like functions
* Updates a call to `save_to_sql` in  [src/graphnet/data/utilities/parquet_to_sqlite.py](https://github.com/graphnet-team/graphnet/blob/main/src/graphnet/data/utilities/parquet_to_sqlite.py#L119-L138) that looked backwards to me. Please check whether I'm mistaken here, @RasmusOrsoe!

Closes #358 

cc @Peterandresen12 