### PR TITLE
Fix Build Icetray CI/CD job

### DIFF
--- a/.github/actions/install-cpu/action.yml
+++ b/.github/actions/install-cpu/action.yml
@@ -26,7 +26,7 @@ runs:
       shell: bash
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
+        pip install --upgrade pip>=20
         pip install wheel setuptools==59.5.0
       shell: bash
     - name: Install package

--- a/.github/actions/install-cpu/action.yml
+++ b/.github/actions/install-cpu/action.yml
@@ -26,7 +26,7 @@ runs:
       shell: bash
     - name: Install dependencies
       run: |
-        pip install --upgrade 'pip>=20,<22.1'
+        pip install --upgrade pip
         pip install wheel setuptools==59.5.0
       shell: bash
     - name: Install package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,6 @@ jobs:
           echo "PYTHONPATH=/usr/local/icetray/lib:$PYTHONPATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/icetray/lib:/usr/local/icetray/cernroot/lib:/usr/local/icetray/lib/tools:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: Debug
-        run: |
-          which python
-          python -V
-          echo $PYTHONPATH
-          echo $PATH
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
   build-icetray:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: icecube/icetray:combo-stable
     steps:
       - name: Set environment variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
   build-icetray:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: icecube/icetray:combo-stable
     steps:
       - name: Set environment variables
@@ -44,6 +44,12 @@ jobs:
           echo "PYTHONPATH=/usr/local/icetray/lib:$PYTHONPATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/icetray/lib:/usr/local/icetray/cernroot/lib:/usr/local/icetray/lib/tools:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v3
+      - name: Debug
+        run: |
+          which python
+          python -V
+          echo $PYTHONPATH
+          echo $PATH
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]


### PR DESCRIPTION
We got a weird install error recently on the Build Icetray job. This is currently blocking our other PRs. By upgrading pip it seems to have gone away.