### PR TITLE
Allow for selection=None in make_train_validation_dataloader

### DIFF
--- a/src/graphnet/training/utils.py
+++ b/src/graphnet/training/utils.py
@@ -29,14 +29,15 @@ def make_dataloader(
     *,
     batch_size: int,
     shuffle: bool,
-    selection: List[int] = None,
+    selection: Optional[List[int]] = None,
     num_workers: int = 10,
     persistent_workers: bool = True,
     node_truth: List[str] = None,
-    node_truth_table: str = None,
+    truth_table: str = "truth",
+    node_truth_table: Optional[str] = None,
     string_selection: List[int] = None,
-    loss_weight_table: str = None,
-    loss_weight_column: str = None,
+    loss_weight_table: Optional[str] = None,
+    loss_weight_column: Optional[str] = None,
 ) -> DataLoader:
     """Construct `DataLoader` instance."""
     # Check(s)
@@ -50,6 +51,7 @@ def make_dataloader(
         truth=truth,
         selection=selection,
         node_truth=node_truth,
+        truth_table=truth_table,
         node_truth_table=node_truth_table,
         string_selection=string_selection,
         loss_weight_table=loss_weight_table,
@@ -86,16 +88,17 @@ def make_train_validation_dataloader(
     truth: List[str],
     *,
     batch_size: int,
-    database_indices: List[int] = None,
+    database_indices: Optional[List[int]] = None,
     seed: int = 42,
     test_size: float = 0.33,
     num_workers: int = 10,
     persistent_workers: bool = True,
-    node_truth: str = None,
-    node_truth_table: str = None,
-    string_selection: List[int] = None,
-    loss_weight_column: str = None,
-    loss_weight_table: str = None,
+    node_truth: Optional[str] = None,
+    truth_table: str = "truth",
+    node_truth_table: Optional[str] = None,
+    string_selection: Optional[List[int]] = None,
+    loss_weight_column: Optional[str] = None,
+    loss_weight_table: Optional[str] = None,
 ) -> Tuple[DataLoader, DataLoader]:
     """Construct train and test `DataLoader` instances."""
     # Reproducibility
@@ -109,9 +112,13 @@ def make_train_validation_dataloader(
         # If no selection is provided, use all events in dataset.
         dataset: Dataset
         if db.endswith(".db"):
-            dataset = SQLiteDataset(db, pulsemaps, features, truth)
+            dataset = SQLiteDataset(
+                db, pulsemaps, features, truth, truth_table=truth_table
+            )
         elif db.endswith(".parquet"):
-            dataset = ParquetDataset(db, pulsemaps, features, truth)
+            dataset = ParquetDataset(
+                db, pulsemaps, features, truth, truth_table=truth_table
+            )
         else:
             raise RuntimeError(
                 f"File {db} with format {db.split('.'[-1])} not supported."
@@ -146,6 +153,7 @@ def make_train_validation_dataloader(
         num_workers=num_workers,
         persistent_workers=persistent_workers,
         node_truth=node_truth,
+        truth_table=truth_table,
         node_truth_table=node_truth_table,
         string_selection=string_selection,
         loss_weight_column=loss_weight_column,

--- a/tests/training/test_dataloader_utilities.py
+++ b/tests/training/test_dataloader_utilities.py
@@ -1,0 +1,55 @@
+"""Unit tests for dataloader utilities.
+
+@NOTE: These utility methods should be deprecated in favour of the indicated
+member methods in `DataLoader`.
+"""
+
+import os.path
+
+from graphnet.data.constants import FEATURES, TRUTH
+from graphnet.constants import TEST_DATA_DIR
+from graphnet.training.utils import make_train_validation_dataloader
+
+# Configuration
+NB_EVENTS_TOTAL = 5
+PATH = os.path.join(
+    TEST_DATA_DIR,
+    "sqlite",
+    "oscNext_genie_level7_v02",
+    "oscNext_genie_level7_v02_first_5_frames.db",
+)
+
+
+# Unit test(s)
+def test_none_selection() -> None:
+    """Test agreement of the two ways to calculate this loss."""
+    (train_dataloader, test_dataloader,) = make_train_validation_dataloader(
+        PATH,
+        selection=None,
+        pulsemaps=["SRTInIcePulses"],
+        features=FEATURES.DEEPCORE,
+        truth=TRUTH.DEEPCORE,
+        batch_size=1,
+    )
+
+    assert len(train_dataloader) + len(test_dataloader) == NB_EVENTS_TOTAL
+
+
+def test_array_selection() -> None:
+    """Test agreement of the two ways to calculate this loss."""
+    selection = [0, 1, 3, 4]
+
+    (train_dataloader, test_dataloader,) = make_train_validation_dataloader(
+        PATH,
+        selection=selection,
+        pulsemaps=["SRTInIcePulses"],
+        features=FEATURES.DEEPCORE,
+        truth=TRUTH.DEEPCORE,
+        batch_size=1,
+    )
+
+    assert len(train_dataloader) + len(test_dataloader) == len(selection)
+
+
+if __name__ == "__main__":
+    test_array_selection()

--- a/tests/training/test_dataloader_utilities.py
+++ b/tests/training/test_dataloader_utilities.py
@@ -56,7 +56,7 @@ def test_array_selection(selection: Tuple[int]) -> None:
     """Test agreement of the two ways to calculate this loss."""
     (train_dataloader, test_dataloader) = make_train_validation_dataloader(
         PATH_SQLITE,
-        selection=selection,
+        selection=list(selection),
         pulsemaps=["SRTInIcePulses"],
         features=FEATURES.DEEPCORE,
         truth=TRUTH.DEEPCORE,
@@ -71,7 +71,7 @@ def test_empty_selection() -> None:
     try:
         _ = make_train_validation_dataloader(
             PATH_SQLITE,
-            selection=tuple(),
+            selection=list(),
             pulsemaps=["SRTInIcePulses"],
             features=FEATURES.DEEPCORE,
             truth=TRUTH.DEEPCORE,

--- a/tests/training/test_dataloader_utilities.py
+++ b/tests/training/test_dataloader_utilities.py
@@ -5,6 +5,9 @@ member methods in `DataLoader`.
 """
 
 import os.path
+from typing import Tuple
+
+import pytest
 
 from graphnet.data.constants import FEATURES, TRUTH
 from graphnet.constants import TEST_DATA_DIR
@@ -12,11 +15,17 @@ from graphnet.training.utils import make_train_validation_dataloader
 
 # Configuration
 NB_EVENTS_TOTAL = 5
-PATH = os.path.join(
+PATH_SQLITE = os.path.join(
     TEST_DATA_DIR,
     "sqlite",
     "oscNext_genie_level7_v02",
     "oscNext_genie_level7_v02_first_5_frames.db",
+)
+PATH_PARQUET = os.path.join(
+    TEST_DATA_DIR,
+    "parquet",
+    "oscNext_genie_level7_v02",
+    "oscNext_genie_level7_v02_first_5_frames.parquet",
 )
 
 
@@ -24,7 +33,7 @@ PATH = os.path.join(
 def test_none_selection() -> None:
     """Test agreement of the two ways to calculate this loss."""
     (train_dataloader, test_dataloader,) = make_train_validation_dataloader(
-        PATH,
+        PATH_SQLITE,
         selection=None,
         pulsemaps=["SRTInIcePulses"],
         features=FEATURES.DEEPCORE,
@@ -35,12 +44,18 @@ def test_none_selection() -> None:
     assert len(train_dataloader) + len(test_dataloader) == NB_EVENTS_TOTAL
 
 
-def test_array_selection() -> None:
+@pytest.mark.parametrize(
+    "selection",
+    [
+        (0, 1, 2, 3, 4),
+        (0, 1, 3, 4),
+        (0, 1),
+    ],
+)
+def test_array_selection(selection: Tuple[int]) -> None:
     """Test agreement of the two ways to calculate this loss."""
-    selection = [0, 1, 3, 4]
-
-    (train_dataloader, test_dataloader,) = make_train_validation_dataloader(
-        PATH,
+    (train_dataloader, test_dataloader) = make_train_validation_dataloader(
+        PATH_SQLITE,
         selection=selection,
         pulsemaps=["SRTInIcePulses"],
         features=FEATURES.DEEPCORE,
@@ -51,5 +66,34 @@ def test_array_selection() -> None:
     assert len(train_dataloader) + len(test_dataloader) == len(selection)
 
 
-if __name__ == "__main__":
-    test_array_selection()
+def test_empty_selection() -> None:
+    """Test agreement of the two ways to calculate this loss."""
+    try:
+        _ = make_train_validation_dataloader(
+            PATH_SQLITE,
+            selection=tuple(),
+            pulsemaps=["SRTInIcePulses"],
+            features=FEATURES.DEEPCORE,
+            truth=TRUTH.DEEPCORE,
+            batch_size=1,
+        )
+        assert False  # Is expected to throw `ValueError`.
+    except ValueError:
+        pass
+
+
+def test_parquet() -> None:
+    """Test agreement of the two ways to calculate this loss."""
+    try:
+        _ = make_train_validation_dataloader(
+            PATH_PARQUET,
+            selection=None,
+            pulsemaps=["SRTInIcePulses"],
+            features=FEATURES.DEEPCORE,
+            truth=TRUTH.DEEPCORE,
+            batch_size=1,
+        )
+        assert False  # Is expected to throw `AssertionError`.
+    except AssertionError as e:
+        assert str(e).startswith("Format of input file")
+        assert str(e).endswith("is not supported.")


### PR DESCRIPTION
Mainly fixing this in service of #378. I think these utility functions should be deprecated in favour of the simpler syntax offered by `DatasetConfig`, see e.g. [here](https://github.com/graphnet-team/graphnet/blob/main/configs/datasets/dev_lvl7_robustness_muon_neutrino_0000.yml#L26-L29).

I have also added a few unit tests to demonstrate the the solution seems to work as intended.

Closes #233. 