### PR TITLE
Better selection in DatasetConfig

### DIFF
--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -118,7 +118,7 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         truth_table: str = "truth",
         node_truth_table: Optional[str] = None,
         string_selection: Optional[List[int]] = None,
-        selection: Optional[Union[str, List[int], List[List[int]]]],
+        selection: Optional[Union[str, List[int], List[List[int]]]] = None,
         dtype: torch.dtype = torch.float32,
         loss_weight_table: Optional[str] = None,
         loss_weight_column: Optional[str] = None,

--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -283,6 +283,12 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         """Return a list of all available values in `self._index_column`."""
 
     @abstractmethod
+    def _get_event_index(
+        self, sequential_index: Optional[int]
+    ) -> Optional[int]:
+        """Return a the event index corresponding to a `sequential_index`."""
+
+    @abstractmethod
     def query_table(
         self,
         table: str,

--- a/src/graphnet/data/parquet/parquet_dataset.py
+++ b/src/graphnet/data/parquet/parquet_dataset.py
@@ -44,6 +44,17 @@ class ParquetDataset(Dataset):
             )
         ).tolist()
 
+    def _get_event_index(
+        self, sequential_index: Optional[int]
+    ) -> Optional[int]:
+        index: Optional[int]
+        if sequential_index is None:
+            index = None
+        else:
+            index = cast(List[int], self._indices)[sequential_index]
+
+        return index
+
     def _format_dictionary_result(
         self, dictionary: Dict
     ) -> List[Tuple[Any, ...]]:
@@ -87,11 +98,7 @@ class ParquetDataset(Dataset):
             selection is None
         ), "Argument `selection` is currently not supported"
 
-        index: Optional[int]
-        if sequential_index is None:
-            index = None
-        else:
-            index = cast(List[int], self._indices)[sequential_index]
+        index = self._get_event_index(sequential_index)
 
         try:
             if index is None:

--- a/src/graphnet/data/parquet/parquet_dataset.py
+++ b/src/graphnet/data/parquet/parquet_dataset.py
@@ -74,13 +74,14 @@ class ParquetDataset(Dataset):
 
         return list(map(tuple, list(zip(*dictionary.values()))))
 
-    def _query_table(
+    def query_table(
         self,
         table: str,
         columns: Union[List[str], str],
         sequential_index: Optional[int] = None,
         selection: Optional[str] = None,
     ) -> List[Tuple[Any, ...]]:
+        """Query table at a specific index, optionally with some selection."""
         # Check(s)
         assert (
             selection is None

--- a/src/graphnet/data/parquet/parquet_dataset.py
+++ b/src/graphnet/data/parquet/parquet_dataset.py
@@ -35,14 +35,14 @@ class ParquetDataset(Dataset):
         # Set custom member variable(s)
         self._parquet_hook = ak.from_parquet(self._path, lazy=False)
 
-    def _get_all_indices(self) -> np.ndarray:
+    def _get_all_indices(self) -> List[int]:
         return np.arange(
             len(
                 ak.to_numpy(
                     self._parquet_hook[self._truth_table][self._index_column]
                 ).tolist()
             )
-        )
+        ).tolist()
 
     def _format_dictionary_result(
         self, dictionary: Dict

--- a/src/graphnet/data/sqlite/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite/sqlite_dataset.py
@@ -39,7 +39,7 @@ class SQLiteDataset(Dataset):
     def _post_init(self) -> None:
         self._close_connection()
 
-    def _query_table(
+    def query_table(
         self,
         table: str,
         columns: Union[List[str], str],

--- a/src/graphnet/data/sqlite/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite/sqlite_dataset.py
@@ -54,17 +54,10 @@ class SQLiteDataset(Dataset):
         if not selection:  # I.e., `None` or `""`
             selection = "1=1"  # Identically true, to select all
 
-        index: int = 0
-        if sequential_index is not None:
-            index_ = self._indices[sequential_index]
-            if self._database_list is None:
-                assert isinstance(index_, int)
-                index = index_
-            else:
-                assert isinstance(index_, list)
-                index = index_[0]
+        index = self._get_event_index(sequential_index)
 
         # Query table
+        assert index is not None
         self._establish_connection(index)
         try:
             assert self._conn
@@ -93,6 +86,20 @@ class SQLiteDataset(Dataset):
         )
         self._close_connection()
         return indices.values.ravel().tolist()
+
+    def _get_event_index(
+        self, sequential_index: Optional[int]
+    ) -> Optional[int]:
+        index: int = 0
+        if sequential_index is not None:
+            index_ = self._indices[sequential_index]
+            if self._database_list is None:
+                assert isinstance(index_, int)
+                index = index_
+            else:
+                assert isinstance(index_, list)
+                index = index_[0]
+        return index
 
     # Custom, internal method(s)
     # @TODO: Is it necessary to return anything here?

--- a/src/graphnet/data/utilities/string_selection_resolver.py
+++ b/src/graphnet/data/utilities/string_selection_resolver.py
@@ -162,6 +162,8 @@ class StringSelectionResolver(LoggerMixin):
         self.debug(f"Reading cached indices from {cache_path}")
         with open(cache_path, "r") as f:
             indices = json.load(f)
+        if isinstance(indices, dict):
+            return indices[self._index_column]
         return indices
 
     def _save_index_cache(self, indices: List[str], cache_path: str) -> None:

--- a/src/graphnet/data/utilities/string_selection_resolver.py
+++ b/src/graphnet/data/utilities/string_selection_resolver.py
@@ -277,34 +277,43 @@ class StringSelectionResolver(LoggerMixin):
 
         Returns the part of `selection` that did not relate to the above.
         """
+        # Default outputs.
+        nb_events: Optional[int] = None
+        frac_events: Optional[float] = None
+
         random_events_pattern = (
             r" *([0-9]+[eE0-9\.-]*[%]?) +random events ~ *(.*)$"
         )
-        nb_events: Optional[int] = None
-        frac_events: Optional[float] = None
         m = re.search(random_events_pattern, selection)
-        if m:
-            nb_events_str, selection = m.group(1), m.group(2)
-            if "%" in nb_events_str:
-                frac_events = float(nb_events_str.split("%")[0]) / 100.0
-                assert (
-                    frac_events > 0
-                ), "Got a non-positive fraction of random events."
-                assert (
-                    frac_events <= 1
-                ), "Got a fraction of random events greater than 100%."
-            else:
-                nb_events_float = float(nb_events_str)
-                assert (
-                    nb_events_float > 0
-                ), "Got a non-positive number of random events."
-                if nb_events_float < 1:
-                    self.warning(
-                        "Got a number of random events between 0 and 1. "
-                        "Interpreting this as a fraction of random events."
-                    )
-                    frac_events = nb_events_float
-                else:
-                    nb_events = int(nb_events_float)
+        if m is None:
+            return nb_events, frac_events, selection
+
+        nb_events_str, selection = m.group(1), m.group(2)
+
+        # Percentage of events.
+        if "%" in nb_events_str:
+            frac_events = float(nb_events_str.split("%")[0]) / 100.0
+            assert (
+                frac_events > 0
+            ), "Got a non-positive fraction of random events."
+            assert (
+                frac_events <= 1
+            ), "Got a fraction of random events greater than 100%."
+            return nb_events, frac_events, selection
+
+        # Number of events
+        nb_events_float = float(nb_events_str)
+        assert (
+            nb_events_float > 0
+        ), "Got a non-positive number of random events."
+
+        if nb_events_float < 1:
+            self.warning(
+                "Got a number of random events between 0 and 1. "
+                "Interpreting this as a fraction of random events."
+            )
+            frac_events = nb_events_float
+        else:
+            nb_events = int(nb_events_float)
 
         return nb_events, frac_events, selection

--- a/src/graphnet/data/utilities/string_selection_resolver.py
+++ b/src/graphnet/data/utilities/string_selection_resolver.py
@@ -1,0 +1,290 @@
+"""Utilities for resolving string-based selections to event indices."""
+
+import ast
+import hashlib
+import json
+import os
+import re
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+import pandas as pd
+
+from graphnet.utilities.logging import LoggerMixin
+
+if TYPE_CHECKING:
+    from graphnet.data.dataset import Dataset
+
+
+class StringSelectionResolver(LoggerMixin):
+    """Resolve string-based selection to event indices.
+
+    String-based selection, using in `DatasetConfig`, is a very flexible way of
+    defining event selections. Below we show a few examples of how to reproduce
+    some standard event selections using this syntax.
+
+    * get_desired_event_numbers(
+        desired_size: int,
+        fraction_noise: float,
+        fraction_muon: float,
+        fraction_nu_e: float,
+        fraction_nu_mu: float,
+        fraction_nu_tau: float,
+    )
+    ```yml
+    # dataset/config.yml
+    (...)
+    selection:
+        test:
+            - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 12
+            - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 14
+            - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 16
+            - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 13
+            - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 1
+        validation:
+            - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 12
+            - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 14
+            - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 16
+            - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 13
+            - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 1
+        train:
+            - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 12
+            - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 14
+            - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 16
+            - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 13
+            - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 1
+    ```
+
+    * get_equal_proportion_neutrino_indices:
+    Desired outcome:
+
+    * get_even_signal_background_indicies:
+    Desired outcome:
+
+    * get_even_track_cascade_indicies:
+    Desired outcome:
+
+    * get_even_dbang_selection:
+    Desired outcome:
+    """
+
+    # Class method(s)
+    @classmethod
+    def _parse_variable_names(cls, selection: str) -> List[str]:
+        """Parse `selection`, return named entities that are not funtions."""
+        tree = ast.parse(selection)
+        functions = []
+        names = []
+        for node in ast.walk(tree):
+            # Save named entities
+            if isinstance(node, ast.Name):
+                names.append(node.id)
+
+            # Save names of functions
+            elif isinstance(node, ast.Call):
+                functions.append(node.func.id)  # type: ignore[attr-defined]
+
+        variables = list(set(names) - set(functions))
+        return variables
+
+    def __init__(
+        self,
+        dataset: "Dataset",
+        index_column: str,
+        seed: Optional[int] = None,
+        use_cache: bool = True,
+    ):
+        """Construct `StringSelectionResolver`."""
+        self._dataset = dataset
+        self._index_column = index_column
+        self._seed = seed
+        self._use_cache = use_cache
+
+    # Public method(s)
+    def resolve(self, selection: str) -> List[int]:
+        """Resolve selection as string to list of indicies.
+
+        Selections are expected to have pandas.DataFrame.query-compatible
+        syntax, e.g., ``` "event_no % 5 > 0" ``` Selections may also specify a
+        fixed number of events to randomly sample, e.g., ``` "10000 random
+        events ~ event_no % 5 > 0" "20% random events ~ event_no % 5 > 0" ```
+        """
+        self.info(f"Resolving selection: {selection}")
+
+        # (Opt.) Load cached indices, if available.
+        cache_path = self._get_cache_path(selection)
+        if self._use_cache and os.path.exists(cache_path):
+            return self._load_cache(cache_path)
+
+        # Check whether to do random sampling
+        (
+            nb_events,
+            frac_events,
+            selection,
+        ) = self._get_random_events_from_selection(selection)
+
+        # Check whether to read indices from file
+        filename_pattern = r"[\w\-\/]+\.(csv|json)$"
+        results = re.search(filename_pattern, selection)
+        if results:
+            selection_path = results.group(0)
+            df_selection = self._read_selection_from_file(selection_path)
+
+        # Use selection string to perform query on dataset.
+        else:
+            df_selection = self._query_selection_from_dataset(selection)
+
+        # Get random subset, if necessary.
+        df_selection = self._sample_indices(
+            df_selection,
+            selection,
+            nb_events,
+            frac_events,
+        )
+
+        # Convert from pandas.DataFrame to list.
+        indices = df_selection[self._index_column].values.tolist()
+
+        # (Opt.) Cache indices.
+        if self._use_cache:
+            self._save_cache(indices, cache_path)
+
+        return indices
+
+    # Internal method(s)
+    def _get_cache_path(self, selection: str) -> str:
+        """Return a cache path unique to the input files and selection."""
+        path = self._dataset.path
+        truth_table = self._dataset.truth_table
+
+        path_string = path if isinstance(path, str) else "-".join(path)
+        unique_string = f"{path_string}-{truth_table}-{selection}"
+        hex = hashlib.sha256(unique_string.encode("utf-8")).hexdigest()
+        cache_path = f"/tmp/selection-{hex}.json"
+        return cache_path
+
+    def _load_cache(self, cache_path: str) -> List[int]:
+        assert cache_path.endswith(".json")
+        self.debug(f"> Reading cached indices from {cache_path}")
+        with open(cache_path, "r") as f:
+            indices = json.load(f)
+        return indices
+
+    def _save_cache(self, indices: List[str], cache_path: str) -> None:
+        self.debug(f"> Saving indices to {cache_path}")
+        with open(cache_path, "w") as f:
+            json.dump(indices, f)
+
+    def _read_selection_from_file(self, path: str) -> pd.DataFrame:
+        self.info(f"Reading indices from: {path}")
+        if path.endswith(".csv"):
+            df_selection = pd.read_csv(path)
+
+        elif path.endswith(".json"):
+            indices = self._load_cache(path)
+            df_selection = pd.DataFrame(
+                data=indices,
+                columns=[self._index_column],
+            )
+
+        else:
+            assert False, "Shouldn't reach here."
+
+        return df_selection
+
+    def _query_selection_from_dataset(self, selection: str) -> pd.DataFrame:
+        variables = self._parse_variable_names(selection)
+        self.debug(f"Parsed variable names {variables} from '{selection}'.")
+        df_values = pd.DataFrame(
+            data=self._dataset.query_table(
+                self._dataset.truth_table,
+                list(variables),
+            ),
+            columns=list(variables),
+        )
+        df_selection = df_values.query(selection)
+        return df_selection
+
+    def _get_random_state(self, selection: str) -> Optional[int]:
+        random_state: Optional[int] = None
+        if self._seed is not None:
+            # Make sure that a dataset config with a single `seed` yields
+            # different random samples for potentially different selection
+            # (i.e., train, test, val).
+            selection_hex = hashlib.sha256(
+                selection.encode("utf-8")
+            ).hexdigest()
+            random_state = (self._seed + int(selection_hex, 16)) % 2**32
+
+        return random_state
+
+    def _sample_indices(
+        self,
+        df_selection: pd.DataFrame,
+        selection: str,
+        nb_events: Optional[int],
+        frac_events: Optional[float],
+    ) -> pd.DataFrame:
+        if (nb_events is None) and (frac_events is None):
+            return df_selection
+
+        nb_events_available = len(df_selection)
+        if nb_events_available == 0:
+            self.warning(f"No events passed selection `{selection}`")
+            return df_selection
+
+        random_state = self._get_random_state(selection)
+        if nb_events and nb_events_available < nb_events:
+            self.warning(
+                f"Requested {nb_events} events but selection only "
+                f"contains {nb_events_available}. Returning all of "
+                "these."
+            )
+            nb_events = nb_events_available
+
+        df_selection = df_selection.sample(
+            n=nb_events,
+            frac=frac_events,
+            replace=False,
+            random_state=random_state,
+        )
+
+        return df_selection
+
+    def _get_random_events_from_selection(
+        self, selection: str
+    ) -> Tuple[Optional[int], Optional[float], str]:
+        """Parse the `selection` to extract num/frac of random events.
+
+        Returns the part of `selection` that did not relate to the above.
+        """
+        random_events_pattern = (
+            r" *([0-9]+[eE0-9\.-]*[%]?) +random events ~ *(.*)$"
+        )
+        nb_events: Optional[int] = None
+        frac_events: Optional[float] = None
+        m = re.search(random_events_pattern, selection)
+        if m:
+            nb_events_str, selection = m.group(1), m.group(2)
+            if "%" in nb_events_str:
+                frac_events = float(nb_events_str.split("%")[0]) / 100.0
+                assert (
+                    frac_events > 0
+                ), "Got a non-positive fraction of random events."
+                assert (
+                    frac_events <= 1
+                ), "Got a fraction of random events greater than 100%."
+            else:
+                nb_events_float = float(nb_events_str)
+                assert (
+                    nb_events_float > 0
+                ), "Got a non-positive number of random events."
+                if nb_events_float < 1:
+                    self.warning(
+                        "Got a number of random events between 0 and 1. "
+                        "Interpreting this as a fraction of random events."
+                    )
+                    frac_events = nb_events_float
+                else:
+                    nb_events = int(nb_events_float)
+
+        return nb_events, frac_events, selection

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -39,7 +39,12 @@ class DatasetConfig(BaseConfig):
     node_truth_table: Optional[str] = None
     string_selection: Optional[List[int]] = None
     selection: Optional[
-        Union[str, Sequence[int], Dict[str, Union[str, Sequence[int]]]]
+        Union[
+            str,
+            List[int],
+            List[List[int]],
+            Dict[str, Union[str, List[str], List[int], List[List[int]]]],
+        ]
     ]
     loss_weight_table: Optional[str] = None
     loss_weight_column: Optional[str] = None
@@ -82,10 +87,29 @@ class DatasetConfig(BaseConfig):
                 "train": Dataset(...),
                 "test": Dataset(...),
             }
+
+            # You can also combine multiple selections into a single, named
+            # dataset
+            >>> dataset.config.selection = {
+                "train": [
+                    "event_no % 2 == 0 & abs(pid) == 12",
+                    "event_no % 2 == 0 & abs(pid) == 14",
+                    "event_no % 2 == 0 & abs(pid) == 16",
+                ],
+                (...)
+            }
+            >>> dataset.config.dump("dataset.yml")
+            >>> datasets: Dict[str, ConcatDataset] = Dataset.from_config(
+                "dataset.yml"
+            )
+            >>> datasets
+            {
+                "train": ConcatDataset(...),
+                (...)
+            }
         """
         # Single-key dictioaries are unpacked
         if isinstance(data["selection"], dict) and len(data["selection"]) == 1:
-            print("SINGLE-KEY DICT!")
             data["selection"] = next(iter(data["selection"].values()))
 
         # Base class constructor

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -107,6 +107,13 @@ class DatasetConfig(BaseConfig):
                 "train": ConcatDataset(...),
                 (...)
             }
+
+            # Finally, you can still reference existing selection files in CSV
+            # or JSON formats:
+            >>> dataset.config.selection = {
+                "train": "50000 random events ~ train_selection.csv",
+                "test": "test_selection.csv",
+            }
         """
         # Single-key dictioaries are unpacked
         if isinstance(data["selection"], dict) and len(data["selection"]) == 1:

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -41,11 +41,11 @@ class DatasetConfig(BaseConfig):
     selection: Optional[
         Union[
             str,
-            List[int],
-            List[List[int]],
-            Dict[str, Union[str, List[str], List[int], List[List[int]]]],
+            List[str],
+            List[Union[int, List[int]]],
+            Dict[str, Union[str, List[str]]],
         ]
-    ]
+    ] = None
     loss_weight_table: Optional[str] = None
     loss_weight_column: Optional[str] = None
     loss_weight_default_value: Optional[float] = None

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -148,8 +148,8 @@ def test_dataset(backend: str) -> None:
 
 @pytest.mark.order(3)
 @pytest.mark.parametrize("backend", ["sqlite", "parquet"])
-def test_dataset_query_table(backend: str) -> None:
-    """Test the implementation of `Dataset._query_table` for `backend`."""
+def test_datasetquery_table(backend: str) -> None:
+    """Test the implementation of `Dataset.query_table` for `backend`."""
     path = get_file_path(backend)
     assert os.path.exists(path)
 
@@ -171,13 +171,13 @@ def test_dataset_query_table(backend: str) -> None:
 
     # Compare to expectations
     nb_events_to_test = 5
-    results_all = dataset._query_table(
+    results_all = dataset.query_table(
         pulsemap,
         columns=["event_no", opt["features"][0]],
     )
     for ix_test in range(nb_events_to_test):
 
-        results_single = dataset._query_table(
+        results_single = dataset.query_table(
             pulsemap,
             columns=["event_no", opt["features"][0]],
             sequential_index=ix_test,


### PR DESCRIPTION
Adds:

* Ability to do a more comprehensive string-based selection in the `DatasetConfig` files, e.g. `event_no % 5 == 0 & abs(pid) == 12` which wasn't possible before. (The parser mistook `abs` for a variable, e.g.) 
* The option of combining multiple selections into a single, named dataset, see e.g.:

```yml
# dataset/config.yml
  selection:
      test:
          - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 12
          - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 14
          - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 16
          - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 13
          - 50000 random events ~ event_no % 5 == 0 & abs(pid) == 1
      validation:
          - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 12
          - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 14
          - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 16
          - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 13
          - 10000 random events ~ event_no % 5 == 1 & abs(pid) == 1
      train:
          - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 12
          - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 14
          - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 16
          - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 13
          - 10000 random events ~ event_no % 5 > 1 & abs(pid) == 1
```

* The option to load selection files (CSV, JSON) using the same syntax.

```yml
# dataset/config.yml
  selection:
      test: test_selection.csv
      train: 50000 random events ~ train_selection.csv
```

cc @moustholmes, @MortenHolmRep 

Closes #386 