### PR TITLE
Add inactive sensors to graph

### DIFF
--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -326,7 +326,7 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         """Return a the event index corresponding to a `sequential_index`."""
 
     @abstractmethod
-    def _setup_geometry_table(self) -> None:
+    def _setup_geometry_table(self, geometry_table: str) -> None:
         """Must assign self._geometry_table."""
 
     @abstractmethod

--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -140,6 +140,8 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         loss_weight_column: Optional[str] = None,
         loss_weight_default_value: Optional[float] = None,
         seed: Optional[int] = None,
+        add_inactive_sensors: bool = False,
+        geometry_table: str = "geometry_table",
     ):
         """Construct Dataset.
 
@@ -185,6 +187,8 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
                 subset of events when resolving a string-based selection (e.g.,
                 `"10000 random events ~ event_no % 5 > 0"` or `"20% random
                 events ~ event_no % 5 > 0"`).
+            add_inactive_sensors: If True, sensors that measured nothing during the event will be appended to the graph.
+            geometry_table: The sqlite table in which the detector geometry is stored.
         """
         # Check(s)
         if isinstance(pulsemaps, str):
@@ -205,6 +209,9 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         self._index_column = index_column
         self._truth_table = truth_table
         self._loss_weight_default_value = loss_weight_default_value
+        self._add_inactive_sensors = add_inactive_sensors
+        if self._add_inactive_sensors:
+            self._set_geometry_table(geometry_table)
 
         if node_truth is not None:
             assert isinstance(node_truth_table, str)

--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -142,6 +142,9 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         seed: Optional[int] = None,
         add_inactive_sensors: bool = False,
         geometry_table: str = "geometry_table",
+        sensor_x_position: str = "dom_x",
+        sensor_y_position: str = "dom_y",
+        sensor_z_position: str = "dom_z",
     ):
         """Construct Dataset.
 
@@ -189,6 +192,9 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
                 events ~ event_no % 5 > 0"`).
             add_inactive_sensors: If True, sensors that measured nothing during the event will be appended to the graph.
             geometry_table: The sqlite table in which the detector geometry is stored.
+            sensor_x_position: column name of x-coordinate of sensors. e.g. "dom_x",
+            sensor_y_position: column name of y-coordinate of sensors. e.g. "dom_y",
+            sensor_z_position: column name of z-coordinate of sensors. e.g. "dom_z",
         """
         # Check(s)
         if isinstance(pulsemaps, str):
@@ -210,6 +216,11 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         self._truth_table = truth_table
         self._loss_weight_default_value = loss_weight_default_value
         self._add_inactive_sensors = add_inactive_sensors
+        self._sensor_position = {
+            "sensor_x_position_column": sensor_x_position,
+            "sensor_y_position_column": sensor_y_position,
+            "sensor_z_position_column": sensor_z_position,
+        }
         if self._add_inactive_sensors:
             self._set_geometry_table(geometry_table)
 
@@ -313,6 +324,10 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         self, sequential_index: Optional[int]
     ) -> Optional[int]:
         """Return a the event index corresponding to a `sequential_index`."""
+
+    @abstractmethod
+    def _setup_geometry_table(self) -> None:
+        """Must assign self._geometry_table."""
 
     @abstractmethod
     def query_table(

--- a/src/graphnet/data/sqlite/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite/sqlite_dataset.py
@@ -7,6 +7,8 @@ import numpy as np
 
 from graphnet.data.dataset import Dataset, ColumnMissingException
 
+from graphnet.data.sqlite.sqlite_utilities import database_table_exists
+
 
 class SQLiteDataset(Dataset):
     """Pytorch dataset for reading data from SQLite databases."""
@@ -179,19 +181,13 @@ class SQLiteDataset(Dataset):
         return self
 
     def _setup_geometry_table(self, geometry_table: str) -> None:
-        if self._table_exists(geometry_table):
+        """Assign the geometry table to self if it exists in the database."""
+        assert isinstance(self._path, str)
+        if database_table_exists(
+            database_path=self._path, table_name=geometry_table
+        ):
             self._geoemtry_table = geometry_table
         else:
             assert (
                 1 == 2
             ), f"Geometry table named {geometry_table} is not in the database {self._path}"
-
-    def _table_exists(self, geometry_table: str) -> bool:
-        assert isinstance(self._path, str)
-        with sqlite3.connect(self._path) as conn:
-            query = 'SELECT name FROM sqlite_master WHERE type == "name" '
-            all_tables = conn.execute(query).fetchall()
-        if geometry_table in all_tables:
-            return True
-        else:
-            return False

--- a/src/graphnet/data/sqlite/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite/sqlite_dataset.py
@@ -147,3 +147,21 @@ class SQLiteDataset(Dataset):
                 self._all_connections_established = False
                 self._conn = None
         return self
+
+    def _setup_geometry_table(self, geometry_table: str) -> None:
+        if self._table_exists(geometry_table):
+            self._geoemtry_table = geometry_table
+        else:
+            assert (
+                1 == 2
+            ), f"Geometry table named {geometry_table} is not in the database {self._path}"
+
+    def _table_exists(self, geometry_table: str) -> bool:
+        assert isinstance(self._path, str)
+        with sqlite3.connect(self._path) as conn:
+            query = 'SELECT name FROM sqlite_master WHERE type == "name" '
+            all_tables = conn.execute(query).fetchall()
+        if geometry_table in all_tables:
+            return True
+        else:
+            return False

--- a/src/graphnet/data/sqlite/sqlite_dataset.py
+++ b/src/graphnet/data/sqlite/sqlite_dataset.py
@@ -3,6 +3,7 @@
 from typing import Any, List, Optional, Tuple, Union
 import pandas as pd
 import sqlite3
+import numpy as np
 
 from graphnet.data.dataset import Dataset, ColumnMissingException
 
@@ -49,6 +50,7 @@ class SQLiteDataset(Dataset):
         """Query table at a specific index, optionally with some selection."""
         # Check(s)
         if isinstance(columns, list):
+            n_features = len(columns)
             columns = ", ".join(columns)
 
         if not selection:  # I.e., `None` or `""`
@@ -67,11 +69,39 @@ class SQLiteDataset(Dataset):
                 combined_selections = (
                     f"{self._index_column} = {index} and {selection}"
                 )
+            if (
+                self._add_inactive_sensors
+                and self._sensor_position["x"] in columns
+                and n_features > 1
+            ):  # if this is a pulsemap query
+                active_query = f"select (CAST({self._sensor_position['x']} AS str) || '_' || CAST({self._sensor_position['y']} AS str) || '_' || CAST({self._sensor_position['z']} AS str)) as UID, {columns} from {table} where {self._index_column} = {index} and {selection}"
+                active_result = self._conn.execute(active_query).fetchall()
+                if len(columns.split(", ")) > 1:
+                    columns = ", ".join(
+                        columns.split(", ")[1:]
+                    )  # remove event_no because not in geometry table
+                query = f"select {columns} from {self._geometry_table} where UID not in {str(tuple(np.array(active_result)[:,0]))}"
+                inactive_result = self._conn.execute(query).fetchall()
+                active_result = np.asarray(active_result)[
+                    :, 2:
+                ].tolist()  # drops UID column & event_no
 
-            result = self._conn.execute(
-                f"SELECT {columns} FROM {table} WHERE "
-                f"{combined_selections}"
-            ).fetchall()
+                result = []
+                result.extend(active_result)
+                result.extend(inactive_result)
+                result = (
+                    np.concatenate(
+                        [np.repeat(index, len(result)).reshape(-1, 1), result],
+                        axis=1,
+                    )
+                    .astype("float64")
+                    .tolist()  # adds event_no again.
+                )
+            else:
+                result = self._conn.execute(
+                    f"SELECT {columns} FROM {table} WHERE "
+                    f"{combined_selections}"
+                ).fetchall()
         except sqlite3.OperationalError as e:
             if "no such column" in str(e):
                 raise ColumnMissingException(str(e))


### PR DESCRIPTION
This PR is a draft. It's a bit rough around the edges but outlines a method of adding inactive sensor modules to the graphs. 

The general idea is to add abstract (backend specific implementations needed) methods to the Dataset class that queries geometry_tables for sensor_id's. In SQLite I've created a method that constructs `geometry_table` (look-up table for geometry) from pulsemap tables. 

Right now, the `_get_inactive_sensors` will actually extract the active pulsemap on its own (and create the UID in the process). This means that every pulsemap will be extracted twice; a bit inefficient.

Let me know what you think of the general approach! I'll try to polish this up during the week.
