### PR TITLE
Graph Normalisation

### DIFF
--- a/configs/models/dynedge_energy_example.yml
+++ b/configs/models/dynedge_energy_example.yml
@@ -20,7 +20,7 @@ arguments:
         nb_neighbours: 8
         post_processing_layer_sizes: null
         readout_layer_sizes: null
-        use_graph_normalization: True
+        use_graph_normalization: null
       class_name: DynEdge
   optimizer_class: '!class torch.optim.adam Adam'
   optimizer_kwargs: {eps: 0.001, lr: 1e-05}

--- a/configs/models/dynedge_energy_example.yml
+++ b/configs/models/dynedge_energy_example.yml
@@ -20,6 +20,7 @@ arguments:
         nb_neighbours: 8
         post_processing_layer_sizes: null
         readout_layer_sizes: null
+        use_graph_normalization: True
       class_name: DynEdge
   optimizer_class: '!class torch.optim.adam Adam'
   optimizer_kwargs: {eps: 0.001, lr: 1e-05}

--- a/src/graphnet/models/gnn/dynedge.py
+++ b/src/graphnet/models/gnn/dynedge.py
@@ -159,6 +159,11 @@ class DynEdge(GNN):
         # Base class constructor
         super().__init__(nb_inputs, self._readout_layer_sizes[-1])
 
+        # GraphNorm
+        self._graphnorm = torch_geometric.nn.norm.GraphNorm(
+            nb_inputs, eps=1e-5
+        )
+
         # Remaining member variables()
         self._activation = torch.nn.LeakyReLU()
         self._nb_inputs = nb_inputs
@@ -282,9 +287,7 @@ class DynEdge(GNN):
         x, edge_index, batch = data.x, data.edge_index, data.batch
 
         if self._use_graph_normalization:
-            x = torch_geometric.nn.norm.GraphNorm(x.size(-1), eps=1e-5)(
-                x, batch
-            )
+            x = self._graphnorm(x, batch)
 
         global_variables = self._calculate_global_variables(
             x,


### PR DESCRIPTION
In an attempt to improve our overall reconstruction predictions, I found the following [article](https://arxiv.org/pdf/2009.03294.pdf). As it turns out, it was already implemented in PyTorch geometric, and this PR is a draft implementation of graph normalisation using GraphNorm from PyTorch geometric.

We can alleviate overfitting and stabilise training by normalising the representations of nodes in our graphs and ensure that the predictions of the network are not overly influenced by individual nodes that have extreme values and instead emphasise overall graph structure.