### PR TITLE
EnsembleDataset

### DIFF
--- a/examples/02_data/04_ensemble_dataset.py
+++ b/examples/02_data/04_ensemble_dataset.py
@@ -48,7 +48,7 @@ def main() -> None:
         truth_table=truth_table,
     )
 
-    ensemble_dataset = EnsembleDataset([dataset_1, dataset_2])
+    ensemble_dataset = EnsembleDataset(datasets=[dataset_1, dataset_2])
 
     logger.info(f"dataset_1 have length: {len(dataset_1)}")
     logger.info(f"dataset_2 have length: {len(dataset_2)}")
@@ -67,7 +67,8 @@ def main() -> None:
         for batch in tqdm(dataloader, unit=" batches", colour="green"):
             time.sleep(wait_time)
 
-    logger.info(batch["dataset_idx"])
+    for i in range(batch_size):
+        logger.info(f"Event {i} came from {batch['dataset_path'][i]}")
 
 
 if __name__ == "__main__":

--- a/examples/02_data/04_ensemble_dataset.py
+++ b/examples/02_data/04_ensemble_dataset.py
@@ -1,1 +1,76 @@
 """Example for EnsembleDataset."""
+
+from timer import timer
+
+import sqlite3
+import time
+import torch.multiprocessing
+import torch.utils.data
+from torch_geometric.data.batch import Batch
+from tqdm import tqdm
+
+from graphnet.constants import TEST_SQLITE_DATA
+from graphnet.data.constants import FEATURES, TRUTH
+from graphnet.data.dataset import Dataset
+from graphnet.data.sqlite.sqlite_dataset import SQLiteDataset
+from graphnet.data import EnsembleDataset
+from graphnet.utilities.logging import get_logger
+
+
+logger = get_logger()
+
+# Constants
+features = FEATURES.DEEPCORE
+truth = TRUTH.DEEPCORE
+
+
+def main() -> None:
+    """Read intermediate file using `Dataset` class."""
+    # Check(s)
+    pulsemap = "SRTInIcePulses"
+    truth_table = "truth"
+    batch_size = 5
+    num_workers = 1  # 30
+    wait_time = 0.00  # sec.
+
+    # Common variables
+    dataset_1 = SQLiteDataset(
+        TEST_SQLITE_DATA,
+        pulsemap,
+        features,
+        truth,
+        truth_table=truth_table,
+    )
+
+    dataset_2 = SQLiteDataset(
+        TEST_SQLITE_DATA,
+        pulsemap,
+        features,
+        truth,
+        truth_table=truth_table,
+    )
+
+    ensemble_dataset = EnsembleDataset([dataset_1, dataset_2])
+
+    logger.info(f"dataset_1 have length: {len(dataset_1)}")
+    logger.info(f"dataset_2 have length: {len(dataset_2)}")
+    logger.info(f"EnsembleDataset have length {len(ensemble_dataset)}")
+
+    dataloader = torch.utils.data.DataLoader(
+        ensemble_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        collate_fn=Batch.from_data_list,
+        prefetch_factor=2,
+    )
+
+    with timer("torch dataloader"):
+        for batch in tqdm(dataloader, unit=" batches", colour="green"):
+            time.sleep(wait_time)
+
+    logger.info(batch["dataset_idx"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_data/04_ensemble_dataset.py
+++ b/examples/02_data/04_ensemble_dataset.py
@@ -2,7 +2,6 @@
 
 from timer import timer
 
-import sqlite3
 import time
 import torch.multiprocessing
 import torch.utils.data
@@ -11,7 +10,6 @@ from tqdm import tqdm
 
 from graphnet.constants import TEST_SQLITE_DATA
 from graphnet.data.constants import FEATURES, TRUTH
-from graphnet.data.dataset import Dataset
 from graphnet.data.sqlite.sqlite_dataset import SQLiteDataset
 from graphnet.data import EnsembleDataset
 from graphnet.utilities.logging import get_logger

--- a/examples/02_data/04_ensemble_dataset.py
+++ b/examples/02_data/04_ensemble_dataset.py
@@ -1,0 +1,1 @@
+"""Example for EnsembleDataset."""

--- a/src/graphnet/data/__init__.py
+++ b/src/graphnet/data/__init__.py
@@ -9,7 +9,7 @@ from graphnet.utilities.imports import has_torch_package
 
 if has_torch_package():
     import torch.multiprocessing
-    from dataset import EnsembleDataset
+    from .dataset import EnsembleDataset
 
     torch.multiprocessing.set_sharing_strategy("file_system")
 

--- a/src/graphnet/data/__init__.py
+++ b/src/graphnet/data/__init__.py
@@ -9,6 +9,7 @@ from graphnet.utilities.imports import has_torch_package
 
 if has_torch_package():
     import torch.multiprocessing
+    from dataset import EnsembleDataset
 
     torch.multiprocessing.set_sharing_strategy("file_system")
 

--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -685,9 +685,12 @@ class EnsembleDataset(torch.utils.data.Dataset):
             dataset_index += 1
         self._index = multi_indices
 
-    def __get_item__(self, sequential_idx: int) -> Data:
-        """Grab a graph from one Dataset and returns it."""
+    def __getitem__(self, sequential_idx: int) -> Data:
+        """Grab a graph from one Dataset and returns it.
+
+        Dataset idx is added to graph as ´dataset_idx´ for bookkeeping.
+        """
         multi_index = self._index[sequential_idx]
         graph = self.datasets[multi_index[0]].__getitem__(multi_index[1])
-        graph["ensemble_idx"] = torch.tensor(multi_index, dtype=torch.float)
+        graph["dataset_idx"] = torch.tensor(multi_index[0], dtype=torch.int)
         return graph

--- a/src/graphnet/data/dataset.py
+++ b/src/graphnet/data/dataset.py
@@ -11,7 +11,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    Sequence,
+    Iterable,
 )
 
 from tqdm import tqdm
@@ -605,6 +605,9 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
         # Add custom labels to the graph
         for key, fn in self._label_fns.items():
             graph[key] = fn(graph)
+
+        # Add Dataset Path. Useful if multiple datasets are concatenated.
+        graph["dataset_path"] = self._path
         return graph
 
     def _get_labels(self, truth_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -655,42 +658,13 @@ class Dataset(torch.utils.data.Dataset, Configurable, LoggerMixin, ABC):
             return -1
 
 
-class EnsembleDataset(torch.utils.data.Dataset):
+class EnsembleDataset(torch.utils.data.ConcatDataset):
     """Construct a single dataset from a collection of datasets."""
 
-    def __init__(self, datasets: Sequence[Dataset]) -> None:
+    def __init__(self, datasets: Iterable[Dataset]) -> None:
         """Construct a single dataset from a collection of datasets.
 
         Args:
             datasets: A collection of Datasets
         """
-        assert len(datasets) > 0, "Must provide at least one dataset."
-        self.datasets = datasets
-        self._setup_indices()
-
-    def __len__(self) -> int:
-        """Return length of dataset."""
-        length = 0
-        for dataset in self.datasets:
-            length += len(dataset)
-        return length
-
-    def _setup_indices(self) -> None:
-        """Create a global multi index on the form (dataset_idx, event_no)."""
-        multi_indices = []
-        dataset_index = 0
-        for dataset in tqdm(self.datasets, desc="Building Global Index"):
-            for local_event_no in range(len(dataset)):
-                multi_indices.append((dataset_index, local_event_no))
-            dataset_index += 1
-        self._index = multi_indices
-
-    def __getitem__(self, sequential_idx: int) -> Data:
-        """Grab a graph from one Dataset and returns it.
-
-        Dataset idx is added to graph as ´dataset_idx´ for bookkeeping.
-        """
-        multi_index = self._index[sequential_idx]
-        graph = self.datasets[multi_index[0]].__getitem__(multi_index[1])
-        graph["dataset_idx"] = torch.tensor(multi_index[0], dtype=torch.int)
-        return graph
+        super().__init__(datasets=datasets)


### PR DESCRIPTION
This PR introduces a new `Dataset` called `EnsembleDataset`. It combines a list of smaller `Dataset`s into one large `Dataset`. 

You could use this to combine datasets from different sqlite databases, but is not back-end specific, so it works with parquet too.

@asogaard this means that the multiple-database-training functionality that still lives in `SQLiteDataset` can be removed!

It also comes with a little example.