### PR TITLE
added I3NTMuonLabelExtractor

### DIFF
--- a/src/graphnet/data/extractors/__init__.py
+++ b/src/graphnet/data/extractors/__init__.py
@@ -16,4 +16,4 @@ from .i3tumextractor import I3TUMExtractor
 from .i3hybridrecoextractor import I3GalacticPlaneHybridRecoExtractor
 from .i3genericextractor import I3GenericExtractor
 from .i3pisaextractor import I3PISAExtractor
-from i3ntmuonlabelsextractor import I3NTMuonLabelExtractor
+from .i3ntmuonlabelsextractor import I3NTMuonLabelExtractor

--- a/src/graphnet/data/extractors/__init__.py
+++ b/src/graphnet/data/extractors/__init__.py
@@ -16,3 +16,4 @@ from .i3tumextractor import I3TUMExtractor
 from .i3hybridrecoextractor import I3GalacticPlaneHybridRecoExtractor
 from .i3genericextractor import I3GenericExtractor
 from .i3pisaextractor import I3PISAExtractor
+from i3ntmuonlabelsextractor import I3NTMuonLabelExtractor

--- a/src/graphnet/data/extractors/i3ntmuonlabelsextractor.py
+++ b/src/graphnet/data/extractors/i3ntmuonlabelsextractor.py
@@ -1,0 +1,48 @@
+"""I3Extractor class(es) for extracting TUM DNN reconstruction."""
+
+from typing import TYPE_CHECKING, Dict
+
+from graphnet.data.extractors.i3extractor import I3Extractor
+
+if TYPE_CHECKING:
+    from icecube import icetray  # pyright: reportMissingImports=false
+
+
+class I3NTMuonLabelExtractor(I3Extractor):
+    """Class for extracting muon labels from the Northeren Track Dataset."""
+
+    def __init__(
+        self,
+        name: str = "northeren_tracks_muon_labels",
+        padding_value: int = -1,
+    ):
+        """Construct I3NTMuonLabelExtractor."""
+        # Base class constructor
+        super().__init__(name)
+        self._padding_value = padding_value
+
+    def __call__(self, frame: "icetray.I3Frame") -> Dict[str, float]:
+        """Extract muon labels from the Northeren Track Dataset."""
+        keys = [
+            "classification",
+            "classification_emuon_deposited",
+            "classification_emuon_entry",
+            "classification_emuon_cascade_energy",
+            "classification_emuon_track_energy",
+            "classification_emuon_track_length",
+            "classification_label",
+            "coincident_muons",
+        ]
+        output = {}
+        for key in keys:
+            try:
+                value = frame[key].value
+            except KeyError:
+                value = self._padding_value
+            output.update(
+                {
+                    key: value,
+                }
+            )
+
+        return output


### PR DESCRIPTION
`I3NTMuonLabelExtractor` extracts labels for muons exclusively on the northeren track dataset. These labels are needed to reconstruct energy and classify topology.

The labels are: 

-             "classification" - topology type in int
-             "classification_emuon_deposited" - deposited muon energy
-             "classification_emuon_entry" - muon of energy on entry of the detector
-             "classification_emuon_cascade_energy" - cascade energy
-             "classification_emuon_track_energy" - track energy
-             "classification_emuon_track_length" - length of track
-             "classification_label" - topology type in string format
-             "coincident_muons" - :-)