### PR TITLE
Allow for accessing source code for lambda functions loaded from config

### DIFF
--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -145,7 +145,15 @@ class ModelConfig(BaseConfig):
 
         elif isinstance(obj, str) and obj.startswith("!lambda"):
             if trust:
-                return eval(obj[1:])
+                source = obj[1:]
+                f = eval(source)
+
+                # Save a copy of the source code attached to the callable,
+                # since the `inspect` module is not able to get the source code
+                # for functions that are not defined on file.
+                # See `self._serialise`.
+                f._source = source
+                return f
             else:
                 raise ValueError(
                     "Constructing model containing a lambda function "
@@ -195,7 +203,14 @@ class ModelConfig(BaseConfig):
             return f"!class {obj.__module__} {obj.__name__}"
         elif isinstance(obj, Callable):  # type: ignore[arg-type]
             if hasattr(obj, "__name__") and obj.__name__ == "<lambda>":
-                return "!" + inspect.getsource(obj).split("=")[1].strip("\n ,")
+                if hasattr(obj, "_source"):
+                    # If source code is set manually during deserialisation.
+                    # See `self._deserialise`.
+                    source = obj._source
+                else:
+                    source = inspect.getsource(obj).split("=")[1].strip("\n ,")
+
+                return "!" + source
             else:
                 try:
                     source = inspect.getsource(obj)

--- a/tests/utilities/test_model_config.py
+++ b/tests/utilities/test_model_config.py
@@ -2,6 +2,7 @@
 
 import os.path
 
+import pytest
 import torch
 from torch.optim.adam import Adam
 
@@ -143,4 +144,19 @@ def test_complete_model_config(path: str = "/tmp/complete_model.yml") -> None:
     assert repr(constructed_model) == repr(model)
 
 
-test_complete_model_config()
+@pytest.mark.run(after="test_complete_model_config")
+def test_loading_and_saving_model_config(
+    load_path: str = "/tmp/complete_model.yml",
+    save_path: str = "/tmp/complete_model_duplicate.yml",
+) -> None:
+    """Test loading and then saving model config."""
+    # Load and construct model
+    loaded_config = ModelConfig.load(load_path)
+    model = Model.from_config(loaded_config, trust=True)
+
+    # Save config to file
+    model.save_config(save_path)
+
+    # Check that the configs agree
+    saved_config = ModelConfig.load(save_path)
+    assert saved_config == loaded_config


### PR DESCRIPTION
This PR addresses a problem that occurs when a lambda function is loaded from a `ModelConfig` file and then saved again. When saving a `ModelConfig` to file, the source code for `lambda`s are written directly to the file. However, for `lambda`s that are defined dynamically (through `eval`) rather than in a source file, the `inspect` module cannot access the source code. Instead, the PR ensures that the original source code for any `lambda` that is read from a `ModelConfig` file is kept verbatim as an attribute, such that it can be accessed should we want to write the config to file again.

This PR also adds a unit tests to check this behaviour.

Closes #452 