### PR TITLE
Restrict pytorch-lightning and pandas to < 2.0 until breaking changes are resolved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ EXTRAS_REQUIRE = {
         "torch-scatter>=2.0",
         "torch-sparse>=0.6",
         "torch-geometric>=2.0",
-        "pytorch-lightning>=1.6",
+        "pytorch-lightning>=1.6, <2.0",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ INSTALL_REQUIRES = [
     "dill>=0.3",
     "matplotlib>=3.5",
     "numpy>=1.21",
-    "pandas>=1.3",
+    "pandas>=1.3, <2.0",
     "pyarrow",
     "pydantic",
     "ruamel.yaml",


### PR DESCRIPTION
Have opened separate issues about making code compatible with new versions:
* #477
* #478 

Closes #470 