### PR TITLE
Add a more thorough check for whether icetray is installed

### DIFF
--- a/src/graphnet/utilities/imports.py
+++ b/src/graphnet/utilities/imports.py
@@ -10,6 +10,7 @@ def has_icecube_package() -> bool:
     """Check whether the `icecube` package is available."""
     try:
         import icecube  # pyright: reportMissingImports=false
+        from icecube import icetray, dataio
 
         return True
     except ImportError:


### PR DESCRIPTION
Closes #480 

The error in the above issue was due to the existence of a directory named `icecube` where the script/command was called. While this is a user error, I think it is not unlikely that it might happen again. Therefore this PR adds a somewhat more thorough check for whether `icecube`/`icetray` is installed to avoid similar issues in the future.