### PR TITLE
add more labels for extraction

### DIFF
--- a/src/graphnet/data/extractors/i3ntmuonlabelsextractor.py
+++ b/src/graphnet/data/extractors/i3ntmuonlabelsextractor.py
@@ -25,13 +25,23 @@ class I3NTMuonLabelExtractor(I3Extractor):
         """Extract muon labels from the Northeren Track Dataset."""
         keys = [
             "classification",
+            "classification_ic79",
             "classification_emuon_deposited",
             "classification_emuon_entry",
             "classification_emuon_cascade_energy",
             "classification_emuon_track_energy",
             "classification_emuon_track_length",
+            "energy_on_muon_appearance",
+            "ic79_energy_on_muon_appearance",
+            "ic79_classification_emuon_deposited",
+            "ic79_classification_emuon_entry",
+            "ic79_classification_emuon_cascade_energy",
+            "ic79_classification_emuon_track_energy",
+            "ic79_classification_emuon_track_length",
             "classification_label",
+            "classification_label_ic79",
             "coincident_muons",
+            "coincident_muons_ic79",
         ]
         output = {}
         for key in keys:


### PR DESCRIPTION
Adds additional labels to `I3NTMuonLabelExtractor`. These are required for the northeren track energy reconstruction. 