### PR TITLE
Fix unbounded wandb in training example

### DIFF
--- a/examples/04_training/03_train_classification_model.py
+++ b/examples/04_training/03_train_classification_model.py
@@ -129,7 +129,7 @@ def main(
         train_dataloaders,
         valid_dataloaders,
         callbacks=callbacks,
-        logger=wandb_logger,
+        logger=wandb_logger if wandb else None,
         **config.fit,
     )
 


### PR DESCRIPTION
Currently, wandb logging is unbounded in the multi-class classification training example when called for `.fit`. Ensures that a check is made whether wandb is used.