### PR TITLE
Update torch_gpu.txt

### DIFF
--- a/requirements/torch_gpu.txt
+++ b/requirements/torch_gpu.txt
@@ -1,3 +1,4 @@
 # Contains packages recommended for functional performance
 --find-links https://download.pytorch.org/whl/torch_stable.html
+torch==2.0.1+cu117
 --find-links https://data.pyg.org/whl/torch-2.0.0+cu117.html


### PR DESCRIPTION
In #548 the requirements file was changed to automatically install newer versions of torch. By an oversight it defaulted to a roc-driver version for the gpu install. This pr changes the default gpu install to 2.0.1cu117. Which better reflects the behavior prior to #548.