### PR TITLE
Changed dtype in config files

### DIFF
--- a/configs/datasets/dev_lvl7_robustness_muon_neutrino_0000.yml
+++ b/configs/datasets/dev_lvl7_robustness_muon_neutrino_0000.yml
@@ -5,7 +5,7 @@ graph_definition:
     detector:
       arguments: {}
       class_name: IceCube86
-    dtype: null
+    dtype: torch.float32
     nb_nearest_neighbours: 8
     node_definition:
       arguments: {}

--- a/configs/datasets/test_data_sqlite.yml
+++ b/configs/datasets/test_data_sqlite.yml
@@ -5,7 +5,7 @@ graph_definition:
     detector:
       arguments: {}
       class_name: Prometheus
-    dtype: null
+    dtype: torch.float32
     nb_nearest_neighbours: 8
     node_definition:
       arguments: {}

--- a/configs/datasets/training_classification_example_data_sqlite.yml
+++ b/configs/datasets/training_classification_example_data_sqlite.yml
@@ -5,7 +5,7 @@ graph_definition:
     detector:
       arguments: {}
       class_name: Prometheus
-    dtype: null
+    dtype: torch.float32
     nb_nearest_neighbours: 8
     node_definition:
       arguments: {}

--- a/configs/datasets/training_example_data_parquet.yml
+++ b/configs/datasets/training_example_data_parquet.yml
@@ -5,7 +5,7 @@ graph_definition:
     detector:
       arguments: {}
       class_name: Prometheus
-    dtype: null
+    dtype: torch.float32
     nb_nearest_neighbours: 8
     node_definition:
       arguments: {}

--- a/configs/datasets/training_example_data_sqlite.yml
+++ b/configs/datasets/training_example_data_sqlite.yml
@@ -5,7 +5,7 @@ graph_definition:
     detector:
       arguments: {}
       class_name: Prometheus
-    dtype: null
+    dtype: torch.float32
     nb_nearest_neighbours: 8
     node_definition:
       arguments: {}


### PR DESCRIPTION
In #558 the structure of the config files was changed, resulting in #568. This PR updates the example config files, to take in torch.float32, which is the default behavior. 

Closes #568