### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Use [GitHub issues](https://github.com/graphnet-team/graphnet/issues) for tracki
 
 ## Pull requests
 
-Develop code in a forks of the [main repo](https://github.com/graphnet-team/graphnet). Make contributions in dedicated development/feature branches on your forked repositories, e.g. if you are implementing a specific `GraphBuiler` class you could create a branch named `add-euclidean-graph-builder` on your own fork.
+Develop code in a fork of the [main repo](https://github.com/graphnet-team/graphnet). Make contributions in dedicated development/feature branches on your forked repositories, e.g. if you are implementing a specific `GraphDefinition` class you could create a branch named `add-euclidean-graph-definition` on your own fork.
 
 Create pull requests from your development branch into `graphnet-team/graphnet:main` to contribute to the project. **To be accepted,** pull requests must:
   * pass all automated checks,
@@ -20,7 +20,7 @@ Create pull requests from your development branch into `graphnet-team/graphnet:m
 
 ## Conventions
 
-This repository aims to support python 3 version that are actively supported (currently `>=3.6`). Standard python coding conventions should be followed:
+This repository aims to support python 3 version that are actively supported (currently `>=3.8`). Standard python coding conventions should be followed:
 
 * Adhere to [PEP 8](https://www.python.org/dev/peps/pep-0008/)
 * Use [pylint](https://www.pylint.org/)/[flake8](https://flake8.pycqa.org/) and [black](https://black.readthedocs.io/) to ensure as clean and well-formatted code as possible


### PR DESCRIPTION
There was a typo in `CONTRIBUTING.md´ which has been fixed.
`CONTRIBUTING.md´ also contained references to GraphBuilder which were removed in #558. The example has been replaced with GraphDefinition
Finally `CONTRIBUTING.md´ said the library support python>=3.6 however #548 introduced a requirement of python>=3.8. The supported python version has been updated to python>=3.8 (#571 aims to introduce support for python 3.11 so the statement should be true in the near future.)

Currently Asogaard is referenced for the wandb team, maybe we should also update this? Since he is not currently working on the project anymore