### PR TITLE
Type hint fixes

### DIFF
--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -71,7 +71,7 @@ class GraphDefinition(Model):
 
     def forward(  # type: ignore
         self,
-        node_features: np.array,
+        node_features: np.ndarray,
         node_feature_names: List[str],
         truth_dicts: Optional[List[Dict[str, Any]]] = None,
         custom_label_functions: Optional[Dict[str, Callable[..., Any]]] = None,

--- a/src/graphnet/models/graphs/nodes/nodes.py
+++ b/src/graphnet/models/graphs/nodes/nodes.py
@@ -4,9 +4,7 @@ from typing import List
 from abc import abstractmethod
 
 import torch
-from torch_geometric.nn import knn_graph, radius_graph
 from torch_geometric.data import Data
-import numpy as np
 
 from graphnet.utilities.decorators import final
 from graphnet.utilities.config import save_model_config


### PR DESCRIPTION
I noticed some placed where we were type hinting with factory functions instead of the classes themselves.