### PR TITLE
automatic attribute length adjustment

### DIFF
--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -181,9 +181,7 @@ class Model(Logger, Configurable, LightningModule, ABC):
         dataloader: DataLoader,
         prediction_columns: List[str],
         *,
-        node_level: bool = False,
         additional_attributes: Optional[List[str]] = None,
-        index_column: str = "event_no",
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
     ) -> pd.DataFrame:
@@ -231,12 +229,29 @@ class Model(Logger, Configurable, LightningModule, ABC):
         )
         for batch in dataloader:
             for attr in attributes:
-                attribute = batch[attr].detach().cpu().numpy()
-                if node_level:
-                    if attr == index_column:
-                        attribute = np.repeat(
-                            attribute, batch.n_pulses.detach().cpu().numpy()
+                attribute = batch[attr]
+                if isinstance(attribute, torch.Tensor):
+                    attribute = attribute.detach().cpu().numpy()
+
+                # Check if node level predictions
+                # If true, additional attributes are repeated
+                # to make dimensions fit
+                if len(attribute) < np.sum(
+                    batch.n_pulses.detach().cpu().numpy()
+                ):
+                    attribute = np.repeat(
+                        attribute, batch.n_pulses.detach().cpu().numpy()
+                    )
+                    try:
+                        assert len(attribute) == len(batch.x)
+                    except AssertionError:
+                        self.warning_once(
+                            "Could not automatically adjust length"
+                            f"of additional attribute {attr} to match length of"
+                            f"predictions. Make sure {attr} is a graph-level or"
+                            "node-level attribute. Attribute skipped."
                         )
+                        pass
                 attributes[attr].extend(attribute)
 
         data = np.concatenate(

--- a/src/graphnet/models/standard_model.py
+++ b/src/graphnet/models/standard_model.py
@@ -191,9 +191,7 @@ class StandardModel(Model):
         dataloader: DataLoader,
         prediction_columns: Optional[List[str]] = None,
         *,
-        node_level: bool = False,
         additional_attributes: Optional[List[str]] = None,
-        index_column: str = "event_no",
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
     ) -> pd.DataFrame:
@@ -207,9 +205,7 @@ class StandardModel(Model):
         return super().predict_as_dataframe(
             dataloader=dataloader,
             prediction_columns=prediction_columns,
-            node_level=node_level,
             additional_attributes=additional_attributes,
-            index_column=index_column,
             gpus=gpus,
             distribution_strategy=distribution_strategy,
         )


### PR DESCRIPTION
This small PR removes the need for arguments `index_column` and `node_level` to `model.predict_as_dataframe` by replacing the if-else statements with an automated check that is able to adjust attribute sequence length to match the prediction lengths. 

With this change, `model.predict_as_dataframe` is able to automatically adjust the length of all additional attributes for both node-level and graph-level predictions. 