### PR TITLE
Fix type hint

### DIFF
--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -71,7 +71,7 @@ class GraphDefinition(Model):
 
     def forward(  # type: ignore
         self,
-        node_features: np.array,
+        node_features: np.ndarray,
         node_feature_names: List[str],
         truth_dicts: Optional[List[Dict[str, Any]]] = None,
         custom_label_functions: Optional[Dict[str, Callable[..., Any]]] = None,

--- a/src/graphnet/models/graphs/nodes/nodes.py
+++ b/src/graphnet/models/graphs/nodes/nodes.py
@@ -68,5 +68,5 @@ class NodeDefinition(Model):  # pylint: disable=too-few-public-methods
 class NodesAsPulses(NodeDefinition):
     """Represent each measured pulse of Cherenkov Radiation as a node."""
 
-    def _construct_nodes(self, x: torch.tensor) -> Data:
+    def _construct_nodes(self, x: torch.Tensor) -> Data:
         return Data(x=x)


### PR DESCRIPTION
np.array and torch.tensor are factory functions and not the actual classes. This PR changes the type hint to correctly refer to the classes.