### PR TITLE
Add meta class to handle config saving

### DIFF
--- a/src/graphnet/data/dataset/dataset.py
+++ b/src/graphnet/data/dataset/dataset.py
@@ -27,7 +27,7 @@ from graphnet.training.labels import Label
 from graphnet.utilities.config import (
     Configurable,
     DatasetConfig,
-    save_dataset_config,
+    DatasetConfigSaverABCMeta,
 )
 from graphnet.utilities.config.parsing import traverse_and_apply
 from graphnet.utilities.logging import Logger
@@ -85,7 +85,13 @@ def parse_graph_definition(cfg: dict) -> GraphDefinition:
     return graph_definition
 
 
-class Dataset(Logger, Configurable, torch.utils.data.Dataset, ABC):
+class Dataset(
+    Logger,
+    Configurable,
+    torch.utils.data.Dataset,
+    ABC,
+    metaclass=DatasetConfigSaverABCMeta,
+):
     """Base Dataset class for reading from any intermediate file format."""
 
     # Class method(s)
@@ -188,7 +194,6 @@ class Dataset(Logger, Configurable, torch.utils.data.Dataset, ABC):
             .replace("${GRAPHNET}", GRAPHNET_ROOT_DIR)
         )
 
-    @save_dataset_config
     def __init__(
         self,
         path: Union[str, List[str]],

--- a/src/graphnet/models/coarsening.py
+++ b/src/graphnet/models/coarsening.py
@@ -22,7 +22,6 @@ from graphnet.models.components.pool import (
     std_pool_x,
 )
 from graphnet.models import Model
-from graphnet.utilities.config import save_model_config
 
 # Utility method(s)
 from torch_geometric.utils import degree
@@ -63,7 +62,6 @@ class Coarsening(Model):
         "sum": (sum_pool, sum_pool_x),
     }
 
-    @save_model_config
     def __init__(
         self,
         reduce: str = "avg",
@@ -198,7 +196,6 @@ class Coarsening(Model):
 class AttributeCoarsening(Coarsening):
     """Coarsen pulses based on specified attributes."""
 
-    @save_model_config
     def __init__(
         self,
         attributes: List[str],

--- a/src/graphnet/models/detector/detector.py
+++ b/src/graphnet/models/detector/detector.py
@@ -8,13 +8,11 @@ import torch
 
 from graphnet.models import Model
 from graphnet.utilities.decorators import final
-from graphnet.utilities.config import save_model_config
 
 
 class Detector(Model):
     """Base class for all detector-specific read-ins in graphnet."""
 
-    @save_model_config
     def __init__(self) -> None:
         """Construct `Detector`."""
         # Base class constructor

--- a/src/graphnet/models/gnn/convnet.py
+++ b/src/graphnet/models/gnn/convnet.py
@@ -10,14 +10,12 @@ import torch.nn.functional as F
 from torch_geometric.nn import TAGConv, global_add_pool, global_max_pool
 from torch_geometric.data import Data
 
-from graphnet.utilities.config import save_model_config
 from graphnet.models.gnn.gnn import GNN
 
 
 class ConvNet(GNN):
     """ConvNet (convolutional network) model."""
 
-    @save_model_config
     def __init__(
         self,
         nb_inputs: int,

--- a/src/graphnet/models/gnn/dynedge.py
+++ b/src/graphnet/models/gnn/dynedge.py
@@ -7,7 +7,6 @@ from torch_geometric.data import Data
 from torch_scatter import scatter_max, scatter_mean, scatter_min, scatter_sum
 
 from graphnet.models.components.layers import DynEdgeConv
-from graphnet.utilities.config import save_model_config
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.utils import calculate_xyzt_homophily
 
@@ -22,7 +21,6 @@ GLOBAL_POOLINGS = {
 class DynEdge(GNN):
     """DynEdge (dynamical edge convolutional) model."""
 
-    @save_model_config
     def __init__(
         self,
         nb_inputs: int,

--- a/src/graphnet/models/gnn/dynedge_jinst.py
+++ b/src/graphnet/models/gnn/dynedge_jinst.py
@@ -10,7 +10,6 @@ from torch_geometric.data import Data
 from torch_scatter import scatter_max, scatter_mean, scatter_min, scatter_sum
 
 from graphnet.models.components.layers import DynEdgeConv
-from graphnet.utilities.config import save_model_config
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.utils import calculate_xyzt_homophily
 
@@ -18,7 +17,6 @@ from graphnet.models.utils import calculate_xyzt_homophily
 class DynEdgeJINST(GNN):
     """DynEdge (dynamical edge convolutional) model used in [2209.03042]."""
 
-    @save_model_config
     def __init__(
         self,
         nb_inputs: int,

--- a/src/graphnet/models/gnn/dynedge_kaggle_tito.py
+++ b/src/graphnet/models/gnn/dynedge_kaggle_tito.py
@@ -18,7 +18,6 @@ from torch_geometric.utils import to_dense_batch
 from torch_scatter import scatter_max, scatter_mean, scatter_min, scatter_sum
 
 from graphnet.models.components.layers import DynTrans
-from graphnet.utilities.config import save_model_config
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.utils import calculate_xyzt_homophily
 
@@ -33,7 +32,6 @@ GLOBAL_POOLINGS = {
 class DynEdgeTITO(GNN):
     """DynEdge (dynamical edge convolutional) model."""
 
-    @save_model_config
     def __init__(
         self,
         nb_inputs: int,

--- a/src/graphnet/models/gnn/gnn.py
+++ b/src/graphnet/models/gnn/gnn.py
@@ -6,13 +6,11 @@ from torch import Tensor
 from torch_geometric.data import Data
 
 from graphnet.models import Model
-from graphnet.utilities.config import save_model_config
 
 
 class GNN(Model):
     """Base class for all core GNN models in graphnet."""
 
-    @save_model_config
     def __init__(self, nb_inputs: int, nb_outputs: int) -> None:
         """Construct `GNN`."""
         # Base class constructor

--- a/src/graphnet/models/graphs/edges/edges.py
+++ b/src/graphnet/models/graphs/edges/edges.py
@@ -7,7 +7,6 @@ import torch
 from torch_geometric.nn import knn_graph, radius_graph
 from torch_geometric.data import Data
 
-from graphnet.utilities.config import save_model_config
 from graphnet.models.utils import calculate_distance_matrix
 from graphnet.models import Model
 
@@ -48,7 +47,6 @@ class EdgeDefinition(Model):  # pylint: disable=too-few-public-methods
 class KNNEdges(EdgeDefinition):  # pylint: disable=too-few-public-methods
     """Builds edges from the k-nearest neighbours."""
 
-    @save_model_config
     def __init__(
         self,
         nb_nearest_neighbours: int,
@@ -85,7 +83,6 @@ class KNNEdges(EdgeDefinition):  # pylint: disable=too-few-public-methods
 class RadialEdges(EdgeDefinition):
     """Builds graph from a sphere of chosen radius centred at each node."""
 
-    @save_model_config
     def __init__(
         self,
         radius: float,
@@ -126,7 +123,6 @@ class EuclideanEdges(EdgeDefinition):  # pylint: disable=too-few-public-methods
     See https://arxiv.org/pdf/1809.06166.pdf.
     """
 
-    @save_model_config
     def __init__(
         self,
         sigma: float,

--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -11,8 +11,6 @@ import torch
 from torch_geometric.data import Data
 import numpy as np
 
-from graphnet.utilities.config import save_model_config
-
 from graphnet.models.detector import Detector
 from .edges import EdgeDefinition
 from .nodes import NodeDefinition
@@ -22,7 +20,6 @@ from graphnet.models import Model
 class GraphDefinition(Model):
     """An Abstract class to create graph definitions from."""
 
-    @save_model_config
     def __init__(
         self,
         detector: Detector,

--- a/src/graphnet/models/graphs/graphs.py
+++ b/src/graphnet/models/graphs/graphs.py
@@ -3,7 +3,6 @@
 from typing import List, Optional
 import torch
 
-from graphnet.utilities.config import save_model_config
 from .graph_definition import GraphDefinition
 from graphnet.models.detector import Detector
 from graphnet.models.graphs.edges import EdgeDefinition, KNNEdges
@@ -13,7 +12,6 @@ from graphnet.models.graphs.nodes import NodeDefinition
 class KNNGraph(GraphDefinition):
     """A Graph representation where Edges are drawn to nearest neighbours."""
 
-    @save_model_config
     def __init__(
         self,
         detector: Detector,

--- a/src/graphnet/models/graphs/nodes/nodes.py
+++ b/src/graphnet/models/graphs/nodes/nodes.py
@@ -7,14 +7,12 @@ import torch
 from torch_geometric.data import Data
 
 from graphnet.utilities.decorators import final
-from graphnet.utilities.config import save_model_config
 from graphnet.models import Model
 
 
 class NodeDefinition(Model):  # pylint: disable=too-few-public-methods
     """Base class for graph building."""
 
-    @save_model_config
     def __init__(self) -> None:
         """Construct `Detector`."""
         # Base class constructor

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -18,11 +18,17 @@ from torch.utils.data import DataLoader, SequentialSampler
 from torch_geometric.data import Data
 
 from graphnet.utilities.logging import Logger
-from graphnet.utilities.config import Configurable, ModelConfig
+from graphnet.utilities.config import (
+    Configurable,
+    ModelConfig,
+    ModelConfigSaverABC,
+)
 from graphnet.training.callbacks import ProgressBar
 
 
-class Model(Logger, Configurable, LightningModule, ABC):
+class Model(
+    Logger, Configurable, LightningModule, ABC, metaclass=ModelConfigSaverABC
+):
     """Base class for all models in graphnet."""
 
     @abstractmethod

--- a/src/graphnet/models/standard_model.py
+++ b/src/graphnet/models/standard_model.py
@@ -10,7 +10,6 @@ from torch.utils.data import DataLoader
 from torch_geometric.data import Data
 import pandas as pd
 
-from graphnet.utilities.config import save_model_config
 from graphnet.models.graphs import GraphDefinition
 from graphnet.models.gnn.gnn import GNN
 from graphnet.models.model import Model
@@ -24,7 +23,6 @@ class StandardModel(Model):
     model (detector read-in, GNN architecture, and task-specific read-outs).
     """
 
-    @save_model_config
     def __init__(
         self,
         *,

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from graphnet.training.loss_functions import LossFunction  # type: ignore[attr-defined]
 
 from graphnet.models import Model
-from graphnet.utilities.config import save_model_config
 from graphnet.utilities.decorators import final
 
 
@@ -39,7 +38,6 @@ class Task(Model):
         """Return default prediction labels."""
         return self._default_prediction_labels
 
-    @save_model_config
     def __init__(
         self,
         *,
@@ -264,7 +262,6 @@ class Task(Model):
 class IdentityTask(Task):
     """Identity, or trivial, task."""
 
-    @save_model_config
     def __init__(
         self,
         nb_outputs: int,

--- a/src/graphnet/training/loss_functions.py
+++ b/src/graphnet/training/loss_functions.py
@@ -19,7 +19,6 @@ from torch.nn.functional import (
     softplus,
 )
 
-from graphnet.utilities.config import save_model_config
 from graphnet.models.model import Model
 from graphnet.utilities.decorators import final
 
@@ -27,7 +26,6 @@ from graphnet.utilities.decorators import final
 class LossFunction(Model):
     """Base class for loss functions in `graphnet`."""
 
-    @save_model_config
     def __init__(self, **kwargs: Any) -> None:
         """Construct `LossFunction`, saving model config."""
         super().__init__(**kwargs)
@@ -120,7 +118,6 @@ class CrossEntropyLoss(LossFunction):
     (0, num_classes - 1).
     """
 
-    @save_model_config
     def __init__(
         self,
         options: Union[int, List[Any], Dict[Any, int]],

--- a/src/graphnet/training/utils.py
+++ b/src/graphnet/training/utils.py
@@ -22,7 +22,7 @@ from graphnet.models.graphs import GraphDefinition
 def collate_fn(graphs: List[Data]) -> Batch:
     """Remove graphs with less than two DOM hits.
 
-    Should not occur in "productio"n.
+    Should not occur in "production".
     """
     graphs = [g for g in graphs if g.n_pulses > 1]
     return Batch.from_data_list(graphs)

--- a/src/graphnet/training/utils.py
+++ b/src/graphnet/training/utils.py
@@ -32,7 +32,7 @@ def collate_fn(graphs: List[Data]) -> Batch:
 def make_dataloader(
     db: str,
     pulsemaps: Union[str, List[str]],
-    graph_definition: Optional[GraphDefinition],
+    graph_definition: GraphDefinition,
     features: List[str],
     truth: List[str],
     *,
@@ -92,7 +92,7 @@ def make_dataloader(
 # @TODO: Remove in favour of DataLoader{,.from_dataset_config}
 def make_train_validation_dataloader(
     db: str,
-    graph_definition: Optional[GraphDefinition],
+    graph_definition: GraphDefinition,
     selection: Optional[List[int]],
     pulsemaps: Union[str, List[str]],
     features: List[str],

--- a/src/graphnet/training/utils.py
+++ b/src/graphnet/training/utils.py
@@ -22,7 +22,7 @@ from graphnet.models.graphs import GraphDefinition
 def collate_fn(graphs: List[Data]) -> Batch:
     """Remove graphs with less than two DOM hits.
 
-    Should not occur in "production.
+    Should not occur in "productio"n.
     """
     graphs = [g for g in graphs if g.n_pulses > 1]
     return Batch.from_data_list(graphs)

--- a/src/graphnet/utilities/config/__init__.py
+++ b/src/graphnet/utilities/config/__init__.py
@@ -5,10 +5,12 @@ from .dataset_config import (
     DatasetConfig,
     DatasetConfigSaverMeta,
     DatasetConfigSaverABCMeta,
+    save_dataset_config,
 )
 from .model_config import (
     ModelConfig,
     ModelConfigSaverMeta,
     ModelConfigSaverABC,
+    save_model_config,
 )
 from .training_config import TrainingConfig

--- a/src/graphnet/utilities/config/__init__.py
+++ b/src/graphnet/utilities/config/__init__.py
@@ -1,6 +1,16 @@
 """Modules for configuration files for use across `graphnet`."""
 
 from .configurable import Configurable
-from .dataset_config import DatasetConfig, DatasetConfigSaverMeta
-from .model_config import ModelConfig, ModelConfigSaverMeta
+from .dataset_config import (
+    DatasetConfig,
+    DatasetConfigSaverMeta,
+    DatasetConfigSaverABCMeta,
+    DatasetConfigSaver,
+)
+from .model_config import (
+    ModelConfig,
+    ModelConfigSaverMeta,
+    ModelConfigSaver,
+    ModelConfigSaverABC,
+)
 from .training_config import TrainingConfig

--- a/src/graphnet/utilities/config/__init__.py
+++ b/src/graphnet/utilities/config/__init__.py
@@ -5,12 +5,10 @@ from .dataset_config import (
     DatasetConfig,
     DatasetConfigSaverMeta,
     DatasetConfigSaverABCMeta,
-    DatasetConfigSaver,
 )
 from .model_config import (
     ModelConfig,
     ModelConfigSaverMeta,
-    ModelConfigSaver,
     ModelConfigSaverABC,
 )
 from .training_config import TrainingConfig

--- a/src/graphnet/utilities/config/__init__.py
+++ b/src/graphnet/utilities/config/__init__.py
@@ -1,6 +1,6 @@
 """Modules for configuration files for use across `graphnet`."""
 
 from .configurable import Configurable
-from .dataset_config import DatasetConfig, save_dataset_config
-from .model_config import ModelConfig, save_model_config
+from .dataset_config import DatasetConfig, DatasetConfigSaverMeta
+from .model_config import ModelConfig, ModelConfigSaverMeta
 from .training_config import TrainingConfig

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -1,5 +1,5 @@
 """Config classes for the `graphnet.data.dataset` module."""
-
+from abc import ABCMeta
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -208,3 +208,15 @@ class DatasetConfigSaverMeta(type):
             arguments=dict(**cfg),
         )
         return created_obj
+
+
+class DatasetConfigSaverABCMeta(DatasetConfigSaverMeta, ABCMeta):
+    """Common interface between DatasetConfigSaver and ABC Metaclasses."""
+
+    pass
+
+
+class DatasetConfigSaver(metaclass=DatasetConfigSaverMeta):
+    """Baseclass for DatasetConfig saving."""
+
+    pass

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -178,39 +178,33 @@ class DatasetConfig(BaseConfig):
             return obj
 
 
-def save_dataset_config(init_fn: Callable) -> Callable:
-    """Save the arguments to `__init__` functions as member `DatasetConfig`."""
+class DatasetConfigSaverMeta(type):
+    """Metaclass for `DatasetConfig` that saves the config after `__init__`."""
 
-    def _replace_model_instance_with_config(
-        obj: Union["Model", Any]
-    ) -> Union[ModelConfig, Any]:
-        """Replace `Model` instances in `obj` with their `ModelConfig`."""
-        from graphnet.models import Model
-        import torch
+    def __call__(cls: Any, *args: Any, **kwargs: Any) -> object:
+        """Catch object construction and save config after `__init__`."""
 
-        if isinstance(obj, Model):
-            return obj.config
+        def _replace_model_instance_with_config(
+            obj: Union["Model", Any]
+        ) -> Union[ModelConfig, Any]:
+            """Replace `Model` instances in `obj` with their `ModelConfig`."""
+            from graphnet.models import Model
 
-        if isinstance(obj, torch.dtype):
-            return obj.__str__()
+            if isinstance(obj, Model):
+                return obj.config
+            else:
+                return obj
 
-        else:
-            return obj
-
-    @wraps(init_fn)
-    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
-        """Set `DatasetConfig` after calling `init_fn`."""
-        # Call wrapped method
-        ret = init_fn(self, *args, **kwargs)
+        # Create object
+        created_obj = super().__call__(*args, **kwargs)
 
         # Get all argument values, including defaults
-        cfg = get_all_argument_values(init_fn, *args, **kwargs)
-
-        # Handle nested `Model`s, etc.
+        cfg = get_all_argument_values(created_obj.__init__, *args, **kwargs)
         cfg = traverse_and_apply(cfg, _replace_model_instance_with_config)
-        # Add `DatasetConfig` as member variables
-        self._config = DatasetConfig(**cfg)
 
-        return ret
-
-    return wrapper
+        # Store config in
+        created_obj._config = DatasetConfig(
+            class_name=str(created_obj.__class__.__name__),
+            arguments=dict(**cfg),
+        )
+        return created_obj

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -189,9 +189,13 @@ class DatasetConfigSaverMeta(type):
         ) -> Union[ModelConfig, Any]:
             """Replace `Model` instances in `obj` with their `ModelConfig`."""
             from graphnet.models import Model
+            import torch
 
             if isinstance(obj, Model):
                 return obj.config
+
+            if isinstance(obj, torch.dtype):
+                return obj.__str__()
             else:
                 return obj
 
@@ -203,20 +207,11 @@ class DatasetConfigSaverMeta(type):
         cfg = traverse_and_apply(cfg, _replace_model_instance_with_config)
 
         # Store config in
-        created_obj._config = DatasetConfig(
-            class_name=str(created_obj.__class__.__name__),
-            arguments=dict(**cfg),
-        )
+        created_obj._config = DatasetConfig(**cfg)
         return created_obj
 
 
 class DatasetConfigSaverABCMeta(DatasetConfigSaverMeta, ABCMeta):
     """Common interface between DatasetConfigSaver and ABC Metaclasses."""
-
-    pass
-
-
-class DatasetConfigSaver(metaclass=DatasetConfigSaverMeta):
-    """Baseclass for DatasetConfig saving."""
 
     pass

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -1,4 +1,5 @@
 """Config classes for the `graphnet.models` module."""
+from abc import ABCMeta
 from functools import wraps
 import inspect
 import re
@@ -278,3 +279,15 @@ class ModelConfigSaverMeta(type):
             arguments=dict(**cfg),
         )
         return created_obj
+
+
+class ModelConfigSaverABC(ModelConfigSaverMeta, ABCMeta):
+    """Common interface between ModelConfigSaver and ABC Metaclasses."""
+
+    pass
+
+
+class ModelConfigSaver(metaclass=ModelConfigSaverMeta):
+    """Base class for ModelConfig saving."""
+
+    pass

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -285,9 +285,3 @@ class ModelConfigSaverABC(ModelConfigSaverMeta, ABCMeta):
     """Common interface between ModelConfigSaver and ABC Metaclasses."""
 
     pass
-
-
-class ModelConfigSaver(metaclass=ModelConfigSaverMeta):
-    """Base class for ModelConfig saving."""
-
-    pass


### PR DESCRIPTION
Currently we're using a decorator around every `__init__` of classes that inherits from `Model/Dataset`. This creates redundant boilerplate code. This PR aims to introduce a new way of handling the backend config saving. This is done by creating metaclasses responsible for intercepting the objects created and store a corresponding config dict to the created objects.

The following is done:
1. Create relevant metaclasses (`ModelConfigSaverMeta`, `DatasetConfigSaverMeta`) along with common interfaces between these metaclasses and `ABCMeta`.
2. Remove usage of `save_model_config` and `save_dataset_config` and add deprecation warnings when they're used in code.

This means the config saving is purely done in the backend, away from any frontend users, making the code easier to read and avoids potential slip-ups where one might forget to use `@save_model_config`.

This PR currently introduces a bug. I suspect the bug is a conflict with #584.

Could you maybe try to take a look at this @RasmusOrsoe 