### PR TITLE
docs: Updated `_get_all_indices` docstring

### DIFF
--- a/src/graphnet/data/dataset/dataset.py
+++ b/src/graphnet/data/dataset/dataset.py
@@ -369,7 +369,7 @@ class Dataset(Logger, Configurable, torch.utils.data.Dataset, ABC):
 
     @abstractmethod
     def _get_all_indices(self) -> List[int]:
-        """Return a list of all available values in `self._index_column`."""
+        """Return a list of all unique values in `self._index_column`."""
 
     @abstractmethod
     def _get_event_index(


### PR DESCRIPTION
Closes #497
Updated the docstring for the `_get_all_indices` method in `dataset.py` to clarify that it returns unique values from `self._index_column`.
