### PR TITLE
Fix `OSError: [Errno 28] No space left on device` in IceTray workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:stable-slim
+    container: icecube/icetray:combo-stable-slim
     steps:
       - name: Set environment variables
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
           echo "PYTHONPATH=/usr/local/icetray/lib:$PYTHONPATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/icetray/lib:/usr/local/icetray/cernroot/lib:/usr/local/icetray/lib/tools:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v3
+      - name: Print available disk space before graphnet install
+        run: df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
@@ -82,16 +84,22 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Print available disk space before graphnet install
+        run: df -h
       - name: Install package
         uses: ./.github/actions/install
         with:
           editable: true
+      - name: Print available disk space after graphnet install
+        run: df -h
       - name: Run unit tests and generate coverage report
         run: |
           set -o pipefail  # To propagate exit code from pytest
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/utilities --ignore=tests/data/ --ignore=tests/deployment/ --ignore=tests/examples/01_icetray/
           coverage run --source=graphnet -m pytest tests/utilities
           coverage report -m
+      - name: Print available disk space after unit tests
+        run: df -h  
 
   build-macos:
     name: Unit tests - macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:icetray-prod-v1.8.1-ubuntu22.04-x64
+    container: icecube/icetray:icetray-prod-v1.8.1-ubuntu20.04-X64
     steps:
       - name: Set environment variables
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,13 +60,10 @@ jobs:
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples
           coverage run --source=graphnet -m pytest tests/examples/01_icetray
           coverage xml -o coverage.xml
-      - name: install git
-        shell: bash
-        run: | 
-          sudo apt-get install git-all
-      - name: Work around permission issue
-        run: |
-          git config --global --add safe.directory /__w/graphnet/graphnet
+    
+      #- name: Work around permission issue
+      #  run: |
+      #    git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:combo-stable
+    container: icecube/icetray:stable-slim
     steps:
       - name: Set environment variables
         run: |
@@ -46,10 +46,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Print available disk space before graphnet install
         run: df -h
-      - name: free disk space
-        run: |
-          docker rmi $(docker image ls -aq)
-          df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,6 @@ jobs:
           haskell: true
           large-packages: false
           swap-storage: true
-      - name: manually remove gcloud
-        shell: bash
-        run: sudo apt-get remove google-cloud-cli
       - name: same as 'large-packages' but without 'google-cloud-sdk'
         shell: bash
         run: | 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,6 @@ jobs:
         run: df -h
       - name: free disk space
         run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
       - name: Upgrade packages already installed on icecube/icetray

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:stable-prod
+    container: icecube/icetray:icetray-prod-v1.8.1-ubuntu20.04-X64
     steps:
       - name: Set environment variables
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,9 @@ jobs:
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples
           coverage run --source=graphnet -m pytest tests/examples/01_icetray
           coverage xml -o coverage.xml
-      - name: Work around permission issue
-        run: |
-          git config --global --add safe.directory /__w/graphnet/graphnet
+      #- name: Work around permission issue
+      #  run: |
+      #    git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:icetray-prod-v1.8.1-ubuntu20.04-X64
+    container: icecube/icetray:combo-stable
     steps:
       - name: Set environment variables
         run: |
@@ -44,7 +44,36 @@ jobs:
           echo "PYTHONPATH=/usr/local/icetray/lib:$PYTHONPATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/icetray/lib:/usr/local/icetray/cernroot/lib:/usr/local/icetray/lib/tools:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: Print available disk space before graphnet install
+      - name: Print available disk space before clean-up
+        run: df -h
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
+      - name: manually remove gcloud
+        shell: bash
+        run: sudo apt-get remove google-cloud-cli
+      - name: same as 'large-packages' but without 'google-cloud-sdk'
+        shell: bash
+        run: | 
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^mongodb-.*'
+          sudo apt-get remove -y '^mysql-.*'
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+      - name: Print available disk space after disk clean-up
         run: df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
@@ -60,9 +89,9 @@ jobs:
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples
           coverage run --source=graphnet -m pytest tests/examples/01_icetray
           coverage xml -o coverage.xml
-      #- name: Work around permission issue
-      #  run: |
-      #    git config --global --add safe.directory /__w/graphnet/graphnet
+      - name: Work around permission issue
+        run: |
+          git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Print available disk space before graphnet install
         run: df -h
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install git-all
       - name: Work around permission issue
         run: |
-      #    git config --global --add safe.directory /__w/graphnet/graphnet
+          git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:combo-stable-slim
+    container: icecube/icetray:stable-prod
     steps:
       - name: Set environment variables
         run: |
@@ -48,9 +48,9 @@ jobs:
         run: df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
-          pip3 install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
-          pip3 install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
-          pip3 install --upgrade psutil # Original version from IceTray Environment incompatible
+          pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
+          pip install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
+          pip install --upgrade psutil # Original version from IceTray Environment incompatible
       - name: Install package
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,10 @@ jobs:
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples
           coverage run --source=graphnet -m pytest tests/examples/01_icetray
           coverage xml -o coverage.xml
-      #- name: Work around permission issue
-      #  run: |
-      #    git config --global --add safe.directory /__w/graphnet/graphnet
+      - name: Work around permission issue
+        run: |
+          conda install -c anaconda git
+          git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,9 @@ jobs:
         run: df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
-          pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
-          pip install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
-          pip install --upgrade psutil # Original version from IceTray Environment incompatible
+          pip3 install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
+          pip3 install --ignore-installed PyYAML  # Distutils installed [https://github.com/pypa/pip/issues/5247]
+          pip3 install --upgrade psutil # Original version from IceTray Environment incompatible
       - name: Install package
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,9 @@ jobs:
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples
           coverage run --source=graphnet -m pytest tests/examples/01_icetray
           coverage xml -o coverage.xml
-      - name: Work around permission issue
-        run: |
-          conda install -c anaconda git
-          git config --global --add safe.directory /__w/graphnet/graphnet
+      #- name: Work around permission issue
+      #  run: |
+      #    git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           echo "PYTHONPATH=/usr/local/icetray/lib:$PYTHONPATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/usr/local/icetray/lib:/usr/local/icetray/cernroot/lib:/usr/local/icetray/lib/tools:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: Print available disk space before clean-up
+      - name: Print available disk space before graphnet install
         run: df -h
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -59,12 +59,20 @@ jobs:
           haskell: true
           large-packages: false
           swap-storage: true
+      - name: manually remove gcloud
+        shell: bash
+        run: sudo apt-get remove google-cloud-cli
       - name: same as 'large-packages' but without 'google-cloud-sdk'
         shell: bash
         run: | 
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^mongodb-.*'
+          sudo apt-get remove -y '^mysql-.*'
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get autoremove -y
           sudo apt-get clean
-      - name: Print available disk space after disk clean-up
-        run: df -h
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]
@@ -79,9 +87,13 @@ jobs:
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples
           coverage run --source=graphnet -m pytest tests/examples/01_icetray
           coverage xml -o coverage.xml
+      - name: install git
+        shell: bash
+        run: | 
+          sudo apt-get install git-all
       - name: Work around permission issue
         run: |
-          git config --global --add safe.directory /__w/graphnet/graphnet
+      #    git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Unit tests - IceTray
     needs: [ check-codeclimate-credentials ]
     runs-on: ubuntu-latest
-    container: icecube/icetray:combo-stable
+    container: icecube/icetray:icetray-prod-v1.8.1-ubuntu22.04-x64
     steps:
       - name: Set environment variables
         run: |
@@ -46,33 +46,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Print available disk space before graphnet install
         run: df -h
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: true
-      - name: manually remove gcloud
-        shell: bash
-        run: sudo apt-get remove google-cloud-cli
-      - name: same as 'large-packages' but without 'google-cloud-sdk'
-        shell: bash
-        run: | 
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y '^mongodb-.*'
-          sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          sudo apt-get autoremove -y
-          sudo apt-get clean
       - name: Upgrade packages already installed on icecube/icetray
         run: |
           pip install --upgrade astropy  # Installed version incompatible with numpy 1.23.0 [https://github.com/astropy/astropy/issues/12534]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,6 @@ jobs:
       - name: same as 'large-packages' but without 'google-cloud-sdk'
         shell: bash
         run: | 
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y '^mongodb-.*'
-          sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          sudo apt-get autoremove -y
           sudo apt-get clean
       - name: Print available disk space after disk clean-up
         run: df -h


### PR DESCRIPTION
Solves the `OSError: [Errno 28] No space left on device` issue in IceTray build for unit tests by switching the docker image from `combo:stable` to a newer and light-weight image `icetray-prod-v1.8.1-ubuntu20.04-X64`.

Downside is that this image does not come with git installed. So I had to comment out lines in `.github/workflows/build.yml` that solves some permission issues required for the code coverage report to be published. Opened an issue with this in  #609 . 

I think we should pass this fix so PRs are now longer held up, and solve #609 soon.

