### PR TITLE
enforce gpu arg in .predict_as_dataframe

### DIFF
--- a/examples/04_training/01_train_dynedge.py
+++ b/examples/04_training/01_train_dynedge.py
@@ -153,6 +153,7 @@ def main(
     results = model.predict_as_dataframe(
         validation_dataloader,
         additional_attributes=additional_attributes + ["event_no"],
+        gpus=config["fit"]["gpus"],
     )
 
     # Save predictions and model to file

--- a/examples/04_training/02_train_tito_model.py
+++ b/examples/04_training/02_train_tito_model.py
@@ -168,6 +168,7 @@ def main(
         validation_dataloader,
         additional_attributes=additional_attributes,
         prediction_columns=prediction_columns,
+        gpus=config["fit"]["gpus"],
     )
 
     # Save predictions and model to file

--- a/examples/04_training/03_train_dynedge_from_config.py
+++ b/examples/04_training/03_train_dynedge_from_config.py
@@ -122,6 +122,7 @@ def main(
     results = model.predict_as_dataframe(
         dataloaders["test"],
         additional_attributes=additional_attributes + ["event_no"],
+        gpus=config.fit["gpus"],
     )
     results.to_csv(f"{path}/results.csv")
 

--- a/examples/04_training/04_train_multiclassifier_from_configs.py
+++ b/examples/04_training/04_train_multiclassifier_from_configs.py
@@ -148,6 +148,7 @@ def main(
     results = model.predict_as_dataframe(
         test_dataloaders,
         additional_attributes=additional_attributes + ["event_no"],
+        gpus=config.fit["gpus"],
     )
     results.to_csv(f"{path}/results.csv")
 


### PR DESCRIPTION
Currently, the `gpus` argument from the CLI in our training examples doesn't get passed to `model.predict_as_dataframe`, essentially forcing the prediction to happen on CPU.

This has caused some confusion for users that have tried to extend the training examples into training scripts for their own use cases. 


This PR passes the argument to the `model.predict_as_dataframe`. 