### PR TITLE
bump requirement files to `torch=2.2`

### DIFF
--- a/requirements/torch_cpu.txt
+++ b/requirements/torch_cpu.txt
@@ -1,2 +1,2 @@
 --find-links https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.1.0+cpu.html
+--find-links https://data.pyg.org/whl/torch-2.2.0+cpu.html

--- a/requirements/torch_gpu.txt
+++ b/requirements/torch_gpu.txt
@@ -1,4 +1,4 @@
 # Contains packages requirements for GPU installation
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.1.0+cu118
---find-links https://data.pyg.org/whl/torch-2.1.0+cu118.html
+--find-links https://data.pyg.org/whl/torch-2.2.0+cu118.html

--- a/requirements/torch_macos.txt
+++ b/requirements/torch_macos.txt
@@ -1,2 +1,2 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
---find-links https://data.pyg.org/whl/torch-2.1.0+cpu.html
+--find-links https://data.pyg.org/whl/torch-2.2.0+cpu.html


### PR DESCRIPTION
This PR changes the torch version suggested in the `requirements/` to `2.2`, which was released a few days ago. Without this change, automated workflows will fail. 