### PR TITLE
Change import of `homophily` in `models.utils.py`

### DIFF
--- a/src/graphnet/models/utils.py
+++ b/src/graphnet/models/utils.py
@@ -6,7 +6,7 @@ from torch_geometric.data import Batch
 import torch
 from torch import Tensor, LongTensor
 
-from torch_geometric.utils.homophily import homophily
+from torch_geometric.utils import homophily
 
 
 def calculate_xyzt_homophily(


### PR DESCRIPTION
In a recent change in PyG, the module `torch_geometric.utils.homophily` was re-named to `torc_geometric.utils._homophily` and as a result, the import statement `from torch_geometric.utils.homophily import homophily` in `graphnet.models.utils.py` fails. This has caused recent checks to fails on PRs, see #662. 

This PR changes the import statement

 `from torch_geometric.utils.homophily import homophily`

to 

 `from torch_geometric.utils import homophily`

This change is backwards compatible.