### PR TITLE
Added `extra_repr` and `__repr__ ` methods to `Model` and `ModelConfig` classes

### DIFF
--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -447,3 +447,28 @@ class GraphDefinition(Model):
         for key, fn in custom_label_functions.items():
             graph[key] = fn(graph)
         return graph
+
+    def extra_repr_recursive(self, dictionary: dict, indent: int = 4) -> str:
+        """Recursively format a dictionary for extra_repr."""
+        result = "{\n"
+        for key, value in dictionary.items():
+            if key == "class_name":
+                continue
+            result += " " * indent + f"'{key}': "
+            if isinstance(value, dict):
+                result += self.extra_repr_recursive(value, indent + 4)
+            elif isinstance(value, Model):
+                result += value.__repr__()
+            else:
+                result += repr(value)
+            result += ",\n"
+        result += " " * (indent - 4) + "}"
+        return result
+
+    def extra_repr(self) -> str:
+        """Provide a more detailed description of the object print.
+
+        Returns:
+            str: A string representation containing detailed information about the object.
+        """
+        return f"{self.__class__.__name__}(\n{self.extra_repr_recursive(self._config.__dict__)})"

--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -447,28 +447,3 @@ class GraphDefinition(Model):
         for key, fn in custom_label_functions.items():
             graph[key] = fn(graph)
         return graph
-
-    def extra_repr_recursive(self, dictionary: dict, indent: int = 4) -> str:
-        """Recursively format a dictionary for extra_repr."""
-        result = "{\n"
-        for key, value in dictionary.items():
-            if key == "class_name":
-                continue
-            result += " " * indent + f"'{key}': "
-            if isinstance(value, dict):
-                result += self.extra_repr_recursive(value, indent + 4)
-            elif isinstance(value, Model):
-                result += value.__repr__()
-            else:
-                result += repr(value)
-            result += ",\n"
-        result += " " * (indent - 4) + "}"
-        return result
-
-    def extra_repr(self) -> str:
-        """Provide a more detailed description of the object print.
-
-        Returns:
-            str: A string representation containing detailed information about the object.
-        """
-        return f"{self.__class__.__name__}(\n{self.extra_repr_recursive(self._config.__dict__)})"

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -107,6 +107,13 @@ class Model(
 
         return source._construct_model(trust, load_modules)
 
+    def set_verbose_print_recursively(self, verbose_print: bool) -> None:
+        """Set verbose_print recursively for all Model modules."""
+        for module in self.modules():
+            if isinstance(module, Model):
+                module.verbose_print = verbose_print
+        self.verbose_print = verbose_print
+
     def extra_repr(self) -> str:
         """Provide a more detailed description of the object print.
 

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -22,7 +22,7 @@ class Model(
     Logger, Configurable, LightningModule, ABC, metaclass=ModelConfigSaverABC
 ):
     """Base class for all components in graphnet."""
-
+    verbose_print = True
     @staticmethod
     def _get_batch_size(data: List[Data]) -> int:
         return sum([torch.numel(torch.unique(d.batch)) for d in data])
@@ -109,9 +109,15 @@ class Model(
         """Provide a more detailed description of the object print.
 
         Returns:
-            str: A string representation containing detailed information about the object.
+            str: A string representation containing detailed information 
+            about the object.
         """
-        return f"{self.__class__.__name__}(\n{self.extra_repr_recursive(self._config.__dict__)})"
+        return self._extra_repr() if self.verbose_print else ""
+    
+    def _extra_repr(self) -> str:
+        """Detailed information about the object."""
+        return f"""{self.__class__.__name__}(\n{self.extra_repr_recursive(
+            self._config.__dict__)})"""
 
     def extra_repr_recursive(self, dictionary: dict, indent: int = 4) -> str:
         """Recursively format a dictionary for extra_repr."""

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -56,7 +56,7 @@ class Model(
         torch.save(state_dict, path)
         self.info(f"Model state_dict saved to {path}")
 
-    def load_state_dict(
+    def load_state_dict(  # type: ignore[override]
         self, path: Union[str, Dict], **kargs: Optional[Any]
     ) -> "Model":  # pylint: disable=arguments-differ
         """Load model `state_dict` from `path`."""
@@ -104,3 +104,28 @@ class Model(
         ), f"Argument `source` of type ({type(source)}) is not a `ModelConfig"
 
         return source._construct_model(trust, load_modules)
+
+    def extra_repr(self) -> str:
+        """Provide a more detailed description of the object print.
+
+        Returns:
+            str: A string representation containing detailed information about the object.
+        """
+        return f"{self.__class__.__name__}(\n{self.extra_repr_recursive(self._config.__dict__)})"
+
+    def extra_repr_recursive(self, dictionary: dict, indent: int = 4) -> str:
+        """Recursively format a dictionary for extra_repr."""
+        result = "{\n"
+        for key, value in dictionary.items():
+            if key == "class_name":
+                continue
+            result += " " * indent + f"'{key}': "
+            if isinstance(value, dict):
+                result += self.extra_repr_recursive(value, indent + 4)
+            elif isinstance(value, Model):
+                result += value.__repr__()
+            else:
+                result += repr(value)
+            result += ",\n"
+        result += " " * (indent - 4) + "}"
+        return result

--- a/src/graphnet/models/model.py
+++ b/src/graphnet/models/model.py
@@ -22,7 +22,9 @@ class Model(
     Logger, Configurable, LightningModule, ABC, metaclass=ModelConfigSaverABC
 ):
     """Base class for all components in graphnet."""
+
     verbose_print = True
+
     @staticmethod
     def _get_batch_size(data: List[Data]) -> int:
         return sum([torch.numel(torch.unique(d.batch)) for d in data])
@@ -109,11 +111,11 @@ class Model(
         """Provide a more detailed description of the object print.
 
         Returns:
-            str: A string representation containing detailed information 
+            str: A string representation containing detailed information
             about the object.
         """
         return self._extra_repr() if self.verbose_print else ""
-    
+
     def _extra_repr(self) -> str:
         """Detailed information about the object."""
         return f"""{self.__class__.__name__}(\n{self.extra_repr_recursive(

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -249,6 +249,28 @@ class ModelConfig(BaseConfig):
 
         return {self.__class__.__name__: config_dict}
 
+    def __repr__(self) -> str:
+        """Return a string representation of the object."""
+        arguments_str = self._format_arguments(self.arguments)
+        return f"{self.__class__.__name__}(\n{arguments_str}\n)"
+
+    def _format_arguments(
+        self, arguments: Dict[str, Any], indent: int = 4
+    ) -> str:
+        """Format the arguments dictionary into a string representation."""
+        lines = []
+        for arg, value in arguments.items():
+            if isinstance(value, ModelConfig):
+                value_str = repr(value)
+            elif isinstance(value, dict):
+                value_str = self._format_arguments(value, indent + 4)
+            else:
+                value_str = repr(value)
+
+            lines.append(f"{' ' * indent}'{arg}': {value_str},")
+
+        return "{\n" + "\n".join(lines) + "\n" + " " * (indent - 4) + "}"
+
 
 def save_model_config(init_fn: Callable) -> Callable:
     """Save the arguments to `__init__` functions as a member `ModelConfig`."""

--- a/tests/utilities/test_model_config.py
+++ b/tests/utilities/test_model_config.py
@@ -122,8 +122,9 @@ def test_complete_model_config(path: str = "/tmp/complete_model.yml") -> None:
             "transform_prediction_and_target"
         ](x_)
     )
-
-    assert repr(constructed_model) == repr(model)
+    model.verbose_print = False
+    constructed_model.verbose_print = False
+    assert constructed_model.extra_repr() == model.extra_repr()
 
 
 @pytest.mark.run(after="test_complete_model_config")

--- a/tests/utilities/test_model_config.py
+++ b/tests/utilities/test_model_config.py
@@ -122,9 +122,9 @@ def test_complete_model_config(path: str = "/tmp/complete_model.yml") -> None:
             "transform_prediction_and_target"
         ](x_)
     )
-    model.verbose_print = False
-    constructed_model.verbose_print = False
-    assert constructed_model.extra_repr() == model.extra_repr()
+    model.set_verbose_print_recursively(False)
+    constructed_model.set_verbose_print_recursively(False)
+    assert repr(model) == repr(constructed_model)
 
 
 @pytest.mark.run(after="test_complete_model_config")


### PR DESCRIPTION
Implemented `extra_repr` and `__repr__` for GraphDefinition and ModelConfig classes
Resolved issue #650 
While Running Following Code
```python
from graphnet.models.graphs.graph_definition import GraphDefinition
from graphnet.models.detector import IceCube86

graph_def = graph_definition=GraphDefinition(detector=IceCube86())
print(graph_def)
```
### output
```bash
GraphDefinition(
  GraphDefinition(
  {
      'arguments': {
          'detector': ModelConfig(
  {
  
  }
  ),
          'node_definition': ModelConfig(
  {
      'input_feature_names': None,
  }
  ),
          'edge_definition': None,
          'input_feature_names': None,
          'dtype': torch.float32,
          'perturbation_dict': None,
          'seed': None,
          'add_inactive_sensors': False,
          'sensor_mask': None,
          'string_mask': None,
          'sort_by': None,
      },
  })
  (_detector): IceCube86()
  (_node_definition): NodesAsPulses()
)
```