### PR TITLE
Quick fix for proper handling of empty pulsemaps.

### DIFF
--- a/src/graphnet/models/graphs/nodes/nodes.py
+++ b/src/graphnet/models/graphs/nodes/nodes.py
@@ -269,6 +269,8 @@ class NodeAsDOMTimeSeries(NodeDefinition):
         """Construct nodes from raw node features ´x´."""
         # Cast to Numpy
         x = x.numpy()
+        if x.shape[0] == 0:
+            return Data(x=torch.tensor(np.column_stack([x, []])))
         # if there is no charge column add a dummy column of zeros with the same shape as the time column
         if self._charge_index is None:
             charge_index: int = len(self._keys)


### PR DESCRIPTION
As the title indicates this is a very short fix that ensure that the `NodeAsDOMTimeSeries` class properly handles the situation of an empty pulsemap (meaning it returns and empty data object.). Currently the the line on https://github.com/graphnet-team/graphnet/blob/4ffa0f1412d3a7932e6c292a5bfde429ba7423bb/src/graphnet/models/graphs/nodes/nodes.py#L284 throws an error.