### PR TITLE
handling of empty DB when merging

### DIFF
--- a/src/graphnet/data/utilities/sqlite_utilities.py
+++ b/src/graphnet/data/utilities/sqlite_utilities.py
@@ -46,6 +46,8 @@ def get_primary_keys(database: str) -> Tuple[Dict[str, str], str]:
         query = 'SELECT name FROM sqlite_master WHERE type == "table"'
         table_names = [table[0] for table in conn.execute(query).fetchall()]
 
+        assert len(table_names) > 0, "No tables found in database."
+
         integer_primary_key = {}
         for table in table_names:
             query = f"SELECT l.name FROM pragma_table_info('{table}') as l WHERE l.pk = 1;"

--- a/src/graphnet/data/writers/sqlite_writer.py
+++ b/src/graphnet/data/writers/sqlite_writer.py
@@ -160,7 +160,14 @@ class SQLiteWriter(GraphNeTWriter):
         for file_count, input_file in tqdm(enumerate(files), colour="green"):
 
             # Extract table names and index column name in database
-            tables, primary_key = get_primary_keys(database=input_file)
+            try:
+                tables, primary_key = get_primary_keys(database=input_file)
+            except AssertionError as e:
+                if "No tables found in database." in str(e):
+                    self.warning(f"Database {input_file} is empty. Skipping.")
+                    continue
+                else:
+                    raise e
 
             for table_name in tables.keys():
                 # Extract all data in the table from the given database


### PR DESCRIPTION
This PR introduces an assertion that checks the automatically pulled tables of the database file. Furthermore in the `_merge_databases` of the `SQLiteWriter` this assertation leads to a warning and then the file being skipped rather than an error that aborts the merging of the databases.

While empty databases should not appear to often this handling is in my opinion better since the merging of databases is a step in our conversion process which is not parallelized and therefore extremely slow. we also do not have a way of restarting the merging if it was interrupted mid way through meaning that any progress will be lost. 

Since a warning is cast the user can then determine whether they want to start over the merging or continue without the content (if any) of the file causing the issue. 