### PR TITLE
combined_extractor

### DIFF
--- a/src/graphnet/data/extractors/__init__.py
+++ b/src/graphnet/data/extractors/__init__.py
@@ -1,2 +1,3 @@
 """Module containing data-specific extractor modules."""
 from .extractor import Extractor
+from .combine_extractors import CombinedExtractor

--- a/src/graphnet/data/extractors/combine_extractors.py
+++ b/src/graphnet/data/extractors/combine_extractors.py
@@ -1,0 +1,34 @@
+"""Module for combining multiple extractors into a single extractor."""
+from graphnet.data.extractors.icecube.i3extractor import I3Extractor
+from typing import List, Dict
+
+from icecube import icetray
+
+
+class CombinedExtractor(I3Extractor):
+    """Class for combining multiple extractors.
+
+    This class is used to combine multiple extractors into a single extractor
+    with a new name.
+    """
+
+    def __init__(self, extractors: List[I3Extractor], extractor_name: str):
+        """Construct CombinedExtractor.
+
+        Args:
+        extractors: List of extractors to combine.
+        extractor_name: Name of the new extractor.
+        """
+        super().__init__(extractor_name=extractor_name)
+        self._extractors = extractors
+
+    def __call__(self, frame: "icetray.I3Frame") -> Dict[str, float]:
+        """Extract data from frame using all extractors.
+
+        Args:
+        frame: I3Frame to extract data from.
+        """
+        output = {}
+        for extractor in self._extractors:
+            output.update(extractor(frame))
+        return output

--- a/src/graphnet/data/extractors/combine_extractors.py
+++ b/src/graphnet/data/extractors/combine_extractors.py
@@ -16,7 +16,7 @@ class CombinedExtractor(I3Extractor):
         """Construct CombinedExtractor.
 
         Args:
-        extractors: List of extractors to combine.
+        extractors: List of extractors to combine. The extractors must all return data on the same level; e.g. all event-level data or pulse-level data. Mixing tables that contain event-level and pulse-level information will fail.
         extractor_name: Name of the new extractor.
         """
         super().__init__(extractor_name=extractor_name)

--- a/src/graphnet/data/extractors/combine_extractors.py
+++ b/src/graphnet/data/extractors/combine_extractors.py
@@ -1,8 +1,12 @@
 """Module for combining multiple extractors into a single extractor."""
+from typing import TYPE_CHECKING
+
+from graphnet.utilities.imports import has_icecube_package
 from graphnet.data.extractors.icecube.i3extractor import I3Extractor
 from typing import List, Dict
 
-from icecube import icetray
+if has_icecube_package() or TYPE_CHECKING:
+    from icecube import icetray  # pyright: reportMissingImports=false
 
 
 class CombinedExtractor(I3Extractor):


### PR DESCRIPTION
This pr adds the `CombinedExtractor` class, which can be used to combine other extractor classes renaming the name of the extractor. For the SQLite databases this allows to save the information from multiple extractors into the same table. 