### PR TITLE
Bugfix to #685 and #683

### DIFF
--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -316,7 +316,6 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
         Returns:
             Training selection, Validation selection.
         """
-        print(selection)
         assert isinstance(selection, (int, list))
         if isinstance(selection, int):
             flat_selection = [selection]

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -1,7 +1,6 @@
 """Base `Dataloader` class(es) used in `graphnet`."""
 from typing import Dict, Any, Optional, List, Tuple, Union
 import pytorch_lightning as pl
-from torch.utils.data import DataLoader
 from copy import deepcopy
 from sklearn.model_selection import train_test_split
 import pandas as pd
@@ -13,7 +12,7 @@ from graphnet.data.dataset import (
     ParquetDataset,
 )
 from graphnet.utilities.logging import Logger
-from graphnet.training.utils import collate_fn
+from graphnet.data.dataloader import DataLoader
 
 
 class GraphNeTDataModule(pl.LightningDataModule, Logger):
@@ -66,21 +65,12 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
         self._validation_dataloader_kwargs = validation_dataloader_kwargs or {}
         self._test_dataloader_kwargs = test_dataloader_kwargs or {}
 
-        self._resolve_dataloader_kwargs()
         # If multiple dataset paths are given, we should use EnsembleDataset
         self._use_ensemble_dataset = isinstance(
             self._dataset_args["path"], list
         )
 
         self.setup("fit")
-
-    def _resolve_dataloader_kwargs(self) -> None:
-        if "collate_fn" not in self._train_dataloader_kwargs:
-            self._train_dataloader_kwargs["collate_fn"] = collate_fn
-        if "collate_fn" not in self._validation_dataloader_kwargs:
-            self._validation_dataloader_kwargs["collate_fn"] = collate_fn
-        if "collate_fn" not in self._test_dataloader_kwargs:
-            self._test_dataloader_kwargs["collate_fn"] = collate_fn
 
     def prepare_data(self) -> None:
         """Prepare the dataset for training."""

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -13,6 +13,7 @@ from graphnet.data.dataset import (
     ParquetDataset,
 )
 from graphnet.utilities.logging import Logger
+from graphnet.training.utils import collate_fn
 
 
 class GraphNeTDataModule(pl.LightningDataModule, Logger):
@@ -65,12 +66,21 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
         self._validation_dataloader_kwargs = validation_dataloader_kwargs or {}
         self._test_dataloader_kwargs = test_dataloader_kwargs or {}
 
+        self._resolve_dataloader_kwargs()
         # If multiple dataset paths are given, we should use EnsembleDataset
         self._use_ensemble_dataset = isinstance(
             self._dataset_args["path"], list
         )
 
         self.setup("fit")
+
+    def _resolve_dataloader_kwargs(self) -> None:
+        if "collate_fn" not in self._train_dataloader_kwargs:
+            self._train_dataloader_kwargs["collate_fn"] = collate_fn
+        if "collate_fn" not in self._validation_dataloader_kwargs:
+            self._validation_dataloader_kwargs["collate_fn"] = collate_fn
+        if "collate_fn" not in self._test_dataloader_kwargs:
+            self._test_dataloader_kwargs["collate_fn"] = collate_fn
 
     def prepare_data(self) -> None:
         """Prepare the dataset for training."""

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -30,7 +30,6 @@ from graphnet.models.graphs import GraphDefinition
 from graphnet.data.dataset import Dataset
 from graphnet.exceptions.exceptions import ColumnMissingException
 
-
 # Force spawn-method
 try:
     torch.multiprocessing.set_start_method("spawn")
@@ -202,7 +201,6 @@ class ParquetDataset(Dataset):
         """Calculate the number of events in each batch."""
         sizes = []
         for batch_id in self._indices:
-            print(batch_id)
             path = os.path.join(
                 self._path,
                 self._truth_table,
@@ -304,7 +302,6 @@ class ParquetDataset(Dataset):
             file_path = os.path.join(
                 self._path, table_name, f"{table_name}_{file_idx}.parquet"
             )
-            print(file_idx)
             df = pol.read_parquet(file_path).sort(self._index_column)
             if (table_name in self._pulsemaps) or (
                 table_name == self._node_truth_table

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -31,6 +31,13 @@ from graphnet.data.dataset import Dataset
 from graphnet.exceptions.exceptions import ColumnMissingException
 
 
+# Force spawn-method
+try:
+    torch.multiprocessing.set_start_method("spawn")
+except RuntimeError:
+    pass
+
+
 class ParquetDataset(Dataset):
     """Dataset class for Parquet-files converted with `ParquetWriter`."""
 

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -284,13 +284,10 @@ class ParquetDataset(Dataset):
             )
             data = df.select(columns)
             if isinstance(data[columns[0]][0], Series):
-                # Force spawn-method
-                try:
-                    torch.multiprocessing.set_start_method("spawn")
-                except RuntimeError:
-                    pass
-                data = data.explode(columns)
-            array = data.to_numpy()
+                x = [data[col][0].to_numpy().reshape(-1, 1) for col in columns]
+                array = np.concatenate(x, axis=1)
+            else:
+                array = data.to_numpy()
         else:
             array = np.array()
         return array

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -30,12 +30,6 @@ from graphnet.models.graphs import GraphDefinition
 from graphnet.data.dataset import Dataset
 from graphnet.exceptions.exceptions import ColumnMissingException
 
-# Force spawn-method
-try:
-    torch.multiprocessing.set_start_method("spawn")
-except RuntimeError:
-    pass
-
 
 class ParquetDataset(Dataset):
     """Dataset class for Parquet-files converted with `ParquetWriter`."""
@@ -290,6 +284,11 @@ class ParquetDataset(Dataset):
             )
             data = df.select(columns)
             if isinstance(data[columns[0]][0], Series):
+                # Force spawn-method
+                try:
+                    torch.multiprocessing.set_start_method("spawn")
+                except RuntimeError:
+                    pass
                 data = data.explode(columns)
             array = data.to_numpy()
         else:


### PR DESCRIPTION
Closes #683, closes #685 .

#683 was solved by switching a single line from polars `df.explode(columns)` which utilizes multiprocessing to a pure numpy-based solution. This numpy-based solution gave a significant speed up to `ParquetDataset.__getitem__`. In #677 I found the  `ParquetDataset.__getitem__` to be ~1.8 times slower than it's SQLite counterpart on a 1 million event sample. Following this PR,  `ParquetDataset.__getitem__` is ~1.2 times slower than its SQLite counterpart on the same sample. 