### PR TITLE
Update DataModule

### DIFF
--- a/src/graphnet/data/dataloader.py
+++ b/src/graphnet/data/dataloader.py
@@ -31,7 +31,7 @@ class DataLoader(torch.utils.data.DataLoader):
         dataset: Dataset,
         batch_size: int = 1,
         shuffle: bool = False,
-        num_workers: int = 10,
+        num_workers: int = 1,
         persistent_workers: bool = True,
         collate_fn: Callable = collate_fn,
         prefetch_factor: int = 2,

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -118,6 +118,10 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
                 )
             else:
                 self._test_dataloader_kwargs = {}
+        else:
+            self._train_dataloader_kwargs = train_dl_args
+            self._validation_dataloader_kwargs = val_dl_args
+            self._test_dataloader_kwargs = test_dl_args or {}
 
     def _add_context(
         self, dataloader_args: Dict[str, Any], dataloader_type: str

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -126,9 +126,9 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
 
         Datasets relying on threaded libraries often require the
         multiprocessing context to be set to "spawn". This method will check
-        the arguments for this entry and throw and error if the field is
-        already assigned to a wrong value. If the value is not specified, it is
-        added automatically with a log entry.
+        the arguments for this entry and throw an error if the field is already
+        assigned to a wrong value. If the value is not specified, it is added
+        automatically with a log entry.
         """
         arg = "multiprocessing_context"
         if arg in dataloader_args:

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -111,10 +111,9 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
                 assert test_dl_args is not None
                 test_dl_args = self._add_context(test_dl_args, "test")
 
-        else:
-            self._train_dataloader_kwargs = train_dl_args
-            self._validation_dataloader_kwargs = val_dl_args
-            self._test_dataloader_kwargs = test_dl_args or {}
+        self._train_dataloader_kwargs = train_dl_args
+        self._validation_dataloader_kwargs = val_dl_args
+        self._test_dataloader_kwargs = test_dl_args or {}
 
     def _add_context(
         self, dataloader_args: Dict[str, Any], dataloader_type: str

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -105,19 +105,12 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
             )
 
         if self._dataset == ParquetDataset:
-            self._train_dataloader_kwargs = self._add_context(
-                train_dl_args, "training"
-            )
-            self._validation_dataloader_kwargs = self._add_context(
-                val_dl_args, "validation"
-            )
+            train_dl_args = self._add_context(train_dl_args, "training")
+            val_dl_args = self._add_context(val_dl_args, "validation")
             if self._test_selection is not None:
                 assert test_dl_args is not None
-                self._test_dataloader_kwargs = self._add_context(
-                    test_dl_args, "test"
-                )
-            else:
-                self._test_dataloader_kwargs = {}
+                test_dl_args = self._add_context(test_dl_args, "test")
+
         else:
             self._train_dataloader_kwargs = train_dl_args
             self._validation_dataloader_kwargs = val_dl_args

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -57,6 +57,9 @@ class ParquetDataset(Dataset):
     ):
         """Construct Dataset.
 
+            NOTE: DataLoaders using this Dataset should have
+            "multiprocessing_context = 'spawn'" set to avoid thread locking.
+
         Args:
             path: Path to the file(s) from which this `Dataset` should read.
             pulsemaps: Name(s) of the pulse map series that should be used to

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -90,7 +90,7 @@ def dataset_setup(dataset_ref: pytest.FixtureRequest) -> tuple:
         "graph_definition": graph_definition,
     }
 
-    dataloader_kwargs = {"batch_size": 2, "num_workers": 1}
+    dataloader_kwargs = {"batch_size": 2, "num_workers": 1, "shuffle": True}
 
     return dataset_ref, dataset_kwargs, dataloader_kwargs
 
@@ -209,6 +209,11 @@ def test_single_dataset_with_selections(
 
     # Training dataloader should have more batches
     assert len(train_dataloader) > len(val_dataloader)
+
+    # validation loader should have shuffle = False by default
+    assert isinstance(val_dataloader.sampler, SequentialSampler)
+    # test loader should have shuffle = False by default
+    assert isinstance(test_dataloader.sampler, SequentialSampler)
 
 
 @pytest.mark.parametrize(

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -151,7 +151,7 @@ def test_single_dataset_without_selections(
     # validation loader should have shuffle = False by default
     assert isinstance(val_dataloader.sampler, SequentialSampler)
     # Should have identical batch_size
-    assert val_dataloader.batch_size != train_dataloader.batch_size
+    assert val_dataloader.batch_size == train_dataloader.batch_size
     # Training dataloader should contain more batches
     assert len(train_dataloader) > len(val_dataloader)
 


### PR DESCRIPTION
This PR revisits the bug documented in #683 which I thought was previously fixed in #686.

Because Polars uses optimization strategies when executing code, it will behave slightly differently under the hood depending on the data. In some cases it will use multithreading while in other cases it won't. #683 is caused by thread lock from polars multithreaded operations, and I thought in #686 that I had removed the line causing the issue, but when revisiting this on a different dataset, I found that the issue was now caused from other lines of polars code.

Issues with polars and "forking" multiprocessing context is mentioned [here](https://docs.pola.rs/user-guide/misc/multiprocessing/).

I have found what appears to be a definitive solution to the bug. By simply specifying

```python
dataloader = DataLoader(...,
                        multiprocessing_context = "spawn",
                        ..)

```
when creating dataloaders with the `ParquetDataset`, the threadlocking disappears.

This PR addresses this specific requirement to the `ParquetDataset` by checking for the argument and providing (hopefully) helpful logger messages (see screenshot).
![image](https://github.com/graphnet-team/graphnet/assets/48880272/bf6916bd-b007-4903-b3ab-9c3d8c3243cf)

I also took the liberty of having `test_dataloader_kwargs` and the `val_dataloader_kwargs` default to `train_dataloader_kwargs` in cases where there is a test/val dataloader but no arguments for their respective dataloaders.

