### PR TITLE
Update Type hints in `GraphNeTDataModule`

### DIFF
--- a/src/graphnet/data/curated_datamodule.py
+++ b/src/graphnet/data/curated_datamodule.py
@@ -31,8 +31,8 @@ class CuratedDataset(GraphNeTDataModule):
         features: Optional[List[str]] = None,
         backend: str = "parquet",
         train_dataloader_kwargs: Optional[Dict[str, Any]] = None,
-        validation_dataloader_kwargs: Optional[Dict[str, Any]] = None,
-        test_dataloader_kwargs: Optional[Dict[str, Any]] = None,
+        validation_dataloader_kwargs: Dict[str, Any] = None,
+        test_dataloader_kwargs: Dict[str, Any] = None,
     ) -> None:
         """Construct CuratedDataset.
 

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -26,10 +26,7 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
         dataset_args: Dict[str, Any],
         selection: Optional[Union[List[int], List[List[int]]]] = None,
         test_selection: Optional[Union[List[int], List[List[int]]]] = None,
-        train_dataloader_kwargs: Dict[str, Any] = {
-            "batch_size": 2,
-            "num_workers": 1,
-        },
+        train_dataloader_kwargs: Dict[str, Any] = None,
         validation_dataloader_kwargs: Dict[str, Any] = None,
         test_dataloader_kwargs: Dict[str, Any] = None,
         train_val_split: Optional[List[float]] = [0.9, 0.10],
@@ -66,6 +63,9 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
         self._test_selection = test_selection
         self._train_val_split = train_val_split or [0.0]
         self._rng = split_seed
+
+        if train_dataloader_kwargs is None:
+            train_dataloader_kwargs = {"batch_size": 2, "num_workers": 1}
 
         self._set_dataloader_kwargs(
             train_dataloader_kwargs,


### PR DESCRIPTION
Since merging #689, code quality checks have failed due to a type hint mismatch in `CuratedDataset`. [See this](https://github.com/graphnet-team/graphnet/actions/runs/8685544066/job/23815228729).

As a result, new PRs like #676 will automatically fail this check. 

It's not clear to me how this was possible in the first place, as #689 passed all checks before merging.

To resolve the error, this PR corrects the type hints.