### PR TITLE
update documentation workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,3 +145,24 @@ jobs:
           coverage run --source=graphnet -m pytest tests/  --ignore=tests/data/ --ignore=tests/deployment/ --ignore=tests/examples/ --ignore=tests/utilities
           coverage run -a --source=graphnet -m pytest tests/utilities
           coverage report -m
+
+  docs:
+    name: Check that documentation compiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install package
+        uses: ./.github/actions/install
+      - name: Build documentation
+        run: |
+          cd docs
+          make clean
+          sphinx-apidoc \
+            --module-first \
+            --separate \
+            --force \
+            -d 2 \
+            --templatedir=source/_templates/ \
+            -o source/api ../src/
+          sed -i "2s/.*/API/" source/api/graphnet.rst
+          make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           coverage report -m
 
   docs:
-    name: Check that documentation compiles
+    name: Documentation Compilation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   docker:
-    name: Build and publish
+    name: Build and Publish Docker Image
     if: github.repository == 'graphnet-team/graphnet'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   docs:
-    name: Build and publish
+    name: Build and publish Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Build documentation
         run: |
           cd docs
-          python parse_about.py -i ../paper/paper.md -o source/about.md
-          python parse_install.py -i ../README.md -o source/install.md
-          python parse_contributing.py -i ../CONTRIBUTING.md -o source/contribute.md
           make clean
           sphinx-apidoc \
             --module-first \


### PR DESCRIPTION
Merging #696 introduced [an error](https://github.com/graphnet-team/graphnet/actions/runs/8750400161/job/24013868071) to the documentation workflow, because I forgot to update the github workflow file. 

Error is caused by the removal of the three python scripts that convert `.md` to `.rst`. The github workflow definition in #696 still looks for these scripts, but because they're removed, the workflow fails.

This PR updates the workflow definition by removing references to these (now unnecessary) scripts, and adds a new workflow that checks that documentation compiles without errors, such that future pull requests with errors in documentation will fail PR checks.