### PR TITLE
Update torch and macos version

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -31,11 +31,11 @@ runs:
       shell: bash
     - name: Install dependencies
       run: |
-        pip install --upgrade pip>=20
-        pip install wheel setuptools==59.5.0
+        pip3 install --upgrade pip>=20
+        pip3 install wheel setuptools==59.5.0
       shell: bash
     - name: Install package
       run: |
         echo requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
-        pip install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
+        pip3 install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
       shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -31,11 +31,11 @@ runs:
       shell: bash
     - name: Install dependencies
       run: |
-        pip3 install --upgrade pip>=20
-        pip3 install wheel setuptools==59.5.0
+        pip install --upgrade pip>=20
+        pip install wheel setuptools==59.5.0
       shell: bash
     - name: Install package
       run: |
         echo requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
-        pip3 install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
+        pip install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
       shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -36,5 +36,6 @@ runs:
       shell: bash
     - name: Install package
       run: |
+        echo requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
         pip install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
 
   build-macos:
     name: Unit tests - macOS
-    runs-on: macos-latest-large
+    runs-on: macos-14-large
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
 
   build-macos:
     name: Unit tests - macOS
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
 
   build-macos:
     name: Unit tests - macOS
-    runs-on: macos-12
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
 
   build-macos:
     name: Unit tests - macOS
-    runs-on: macos-14-large
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         uses: ./.github/actions/install
         with:
           editable: true
-          hardware: "macos"
+          hardware: "cpu"
       - name: Print packages in pip
         run: |
             pip show torch

--- a/requirements/torch_macos.txt
+++ b/requirements/torch_macos.txt
@@ -1,2 +1,2 @@
---find-links https://download.pytorch.org/whl/torch_stable.html
+--find-links https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.2.0+cpu.html

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ EXTRAS_REQUIRE = {
         "versioneer",
     ],
     "torch": [
-        "torch>=2.1",
+        "torch==2.2",
         "torch-cluster>=1.6",
         "torch-scatter>=2.0",
         "torch-sparse>=0.6",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ EXTRAS_REQUIRE = {
         "versioneer",
     ],
     "torch": [
-        "torch==2.2",
+        "torch>=2.1,<2.3",
         "torch-cluster>=1.6",
         "torch-scatter>=2.0",
         "torch-sparse>=0.6",

--- a/src/graphnet/data/writers/graphnet_writer.py
+++ b/src/graphnet/data/writers/graphnet_writer.py
@@ -22,7 +22,7 @@ class GraphNeTWriter(Logger, ABC):
     from a single file.
 
     In addition, classes inheriting from `GraphNeTFileSaveMethod` must
-    set the `file_extension` property. What
+    set the `file_extension` property.
     """
 
     @abstractmethod

--- a/src/graphnet/data/writers/graphnet_writer.py
+++ b/src/graphnet/data/writers/graphnet_writer.py
@@ -22,7 +22,7 @@ class GraphNeTWriter(Logger, ABC):
     from a single file.
 
     In addition, classes inheriting from `GraphNeTFileSaveMethod` must
-    set the `file_extension` property.
+    set the `file_extension` property. What
     """
 
     @abstractmethod


### PR DESCRIPTION
Lately workflows on PR have failed for `macos` and now recently in #698 for all `build` workflows, despite no changes are made to the related code.

These errors are caused by two dependency changes:

`torch` recently moved from `2.2` -> `2.3` and our `setup.py` currently has `torch>2.1`. `PyG` is not compatible with `torch==2.3` yet, causing the build errors in #698.

`macos-latest` recently moved from `macos-13` -> `macos-14 (ARM)` causing the macos errors we've seen recently.

This PR fixes these issues by setting the `macos` workflow to run on `macos-13` and changing our torch versioning to `torch>=2.1,<2.3`