### PR TITLE
added detector geometry attibutes to Kaggle detector class

### DIFF
--- a/src/graphnet/models/detector/icecube.py
+++ b/src/graphnet/models/detector/icecube.py
@@ -50,7 +50,7 @@ class IceCube86(Detector):
 
 class IceCubeKaggle(Detector):
     """`Detector` class for Kaggle Competition."""
-    
+
     geometry_table_path = os.path.join(
         ICECUBE_GEOMETRY_TABLE_DIR, "icecube86.parquet"
     )

--- a/src/graphnet/models/detector/icecube.py
+++ b/src/graphnet/models/detector/icecube.py
@@ -50,6 +50,13 @@ class IceCube86(Detector):
 
 class IceCubeKaggle(Detector):
     """`Detector` class for Kaggle Competition."""
+    
+    geometry_table_path = os.path.join(
+        ICECUBE_GEOMETRY_TABLE_DIR, "icecube86.parquet"
+    )
+    xyz = ["x", "y", "z"]
+    string_id_column = "string"
+    sensor_id_column = "sensor_id"
 
     def feature_map(self) -> Dict[str, Callable]:
         """Map standardization functions to each dimension of input data."""


### PR DESCRIPTION
Add needed attributes missing. It was giving an error when using this class.

feature `x` will throw a warning when using it as a feature, but this is some incompatibility from the dataset definition itself.

Closes #684