### PR TITLE
Fixed cu121 at torch_cu121.txt

### DIFF
--- a/requirements/torch_cu121.txt
+++ b/requirements/torch_cu121.txt
@@ -1,4 +1,4 @@
 # Contains packages requirements for GPU installation
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.2.0+cu118
+torch==2.2.0+cu121
 --find-links https://data.pyg.org/whl/torch-2.2.0+cu121.html


### PR DESCRIPTION
Update PyTorch requirement to use CUDA 12.1

The previous requirements file specified PyTorch 2.2.0 with CUDA 11.8 (cu118). However, based on the available packages from the PyTorch stable and PyTorch Geometric (PyG) URLs, PyTorch 2.2.0 is only available with CUDA 12.1 (cu121) for GPU installation.

This commit updates the requirements to use the correct CUDA version:
- Change `torch==2.2.0+cu118` to `torch==2.2.0+cu121`