### PR TITLE
add isolated nodes

### DIFF
--- a/src/graphnet/models/components/embedding.py
+++ b/src/graphnet/models/components/embedding.py
@@ -84,6 +84,7 @@ class FourierEncoder(LightningModule):
         super().__init__()
 
         self.sin_emb = SinusoidalPosEmb(dim=seq_length, scaled=scaled)
+        self.aux_emb = nn.Embedding(2, seq_length // 2)
         self.sin_emb2 = SinusoidalPosEmb(dim=seq_length // 2, scaled=scaled)
 
         if n_features < 4:
@@ -92,7 +93,7 @@ class FourierEncoder(LightningModule):
                 f"{n_features} features."
             )
         elif n_features >= 6:
-            self.aux_emb = nn.Embedding(2, seq_length // 2)
+
             hidden_dim = 6 * seq_length
         else:
             hidden_dim = int((n_features + 0.5) * seq_length)

--- a/src/graphnet/models/components/embedding.py
+++ b/src/graphnet/models/components/embedding.py
@@ -84,7 +84,6 @@ class FourierEncoder(LightningModule):
         super().__init__()
 
         self.sin_emb = SinusoidalPosEmb(dim=seq_length, scaled=scaled)
-        self.aux_emb = nn.Embedding(2, seq_length // 2)
         self.sin_emb2 = SinusoidalPosEmb(dim=seq_length // 2, scaled=scaled)
 
         if n_features < 4:
@@ -93,6 +92,7 @@ class FourierEncoder(LightningModule):
                 f"{n_features} features."
             )
         elif n_features >= 6:
+            self.aux_emb = nn.Embedding(2, seq_length // 2)
             hidden_dim = 6 * seq_length
         else:
             hidden_dim = int((n_features + 0.5) * seq_length)

--- a/src/graphnet/models/graphs/__init__.py
+++ b/src/graphnet/models/graphs/__init__.py
@@ -7,4 +7,4 @@ and their features.
 
 
 from .graph_definition import GraphDefinition
-from .graphs import KNNGraph, IsolatedNodes
+from .graphs import KNNGraph, EdgelessGraph

--- a/src/graphnet/models/graphs/__init__.py
+++ b/src/graphnet/models/graphs/__init__.py
@@ -7,4 +7,4 @@ and their features.
 
 
 from .graph_definition import GraphDefinition
-from .graphs import KNNGraph
+from .graphs import KNNGraph, IsolatedNodes

--- a/src/graphnet/models/graphs/graphs.py
+++ b/src/graphnet/models/graphs/graphs.py
@@ -56,8 +56,11 @@ class KNNGraph(GraphDefinition):
         )
 
 
-class IsolatedNodes(GraphDefinition):
-    """A Graph representation where each node is isolated."""
+class EdgelessGraph(GraphDefinition):
+    """A Data representation without edge assignment.
+
+    I.e the resulting representation is created without an EdgeDefinition.
+    """
 
     def __init__(
         self,

--- a/src/graphnet/models/graphs/graphs.py
+++ b/src/graphnet/models/graphs/graphs.py
@@ -54,3 +54,41 @@ class KNNGraph(GraphDefinition):
             perturbation_dict=perturbation_dict,
             seed=seed,
         )
+
+
+class IsolatedNodes(GraphDefinition):
+    """A Graph representation where each node is isolated."""
+
+    def __init__(
+        self,
+        detector: Detector,
+        node_definition: NodeDefinition = None,
+        input_feature_names: Optional[List[str]] = None,
+        dtype: Optional[torch.dtype] = torch.float,
+        perturbation_dict: Optional[Dict[str, float]] = None,
+        seed: Optional[Union[int, Generator]] = None,
+    ) -> None:
+        """Construct isolated nodes graph representation.
+
+        Args:
+            detector: Detector that represents your data.
+            node_definition: Definition of nodes in the graph.
+            input_feature_names: Name of input feature columns.
+            dtype: data type for node features.
+            perturbation_dict: Dictionary mapping a feature name to a standard
+                               deviation according to which the values for this
+                               feature should be randomly perturbed. Defaults
+                               to None.
+            seed: seed or Generator used to randomly sample perturbations.
+                  Defaults to None.
+        """
+        # Base class constructor
+        super().__init__(
+            detector=detector,
+            node_definition=node_definition or NodesAsPulses(),
+            edge_definition=None,
+            dtype=dtype,
+            input_feature_names=input_feature_names,
+            perturbation_dict=perturbation_dict,
+            seed=seed,
+        )


### PR DESCRIPTION
Adds a simple graph definition which simply does not construct a edge definition. Useful when the connection between the nodes is either not needed or constructed later in the model during run time. 