### PR TITLE
Automatic ensemble new

### DIFF
--- a/src/graphnet/data/dataloader.py
+++ b/src/graphnet/data/dataloader.py
@@ -65,7 +65,9 @@ class DataLoader(torch.utils.data.DataLoader):
             )
 
             if isinstance(config.path, list):
-                datasets: Union[Dict[str, Dataset], Dict[str, EnsembleDataset]] = {}  # type: ignore
+                datasets: Union[
+                    Dict[str, Dataset], Dict[str, EnsembleDataset], Dict
+                ] = {}
                 dataset_col: Dict[str, list] = {}
                 for key in config.selection.keys():
                     dataset_col[key] = []

--- a/tests/utilities/test_dataset_config.py
+++ b/tests/utilities/test_dataset_config.py
@@ -269,22 +269,3 @@ def test_dataset_config_files(backend: str) -> None:
         )
         == 0
     )
-
-
-@pytest.mark.order(6)
-@pytest.mark.parametrize("backend", ["sqlite"])
-def test_multiple_dataset_config_dict_selection(backend: str) -> None:
-    """Test constructing Dataset with multiple data paths."""
-    # Arrange
-    config_path = CONFIG_PATHS[backend]
-
-    # Single dataset
-    config = DatasetConfig.load(config_path)
-    dataset = Dataset.from_config(config)
-    # Construct multiple datasets
-    config_ensemble = DatasetConfig.load(config_path)
-    config_ensemble.path = [config_ensemble.path, config_ensemble.path]
-
-    ensemble_dataset = Dataset.from_config(config)
-
-    assert len(dataset) * 2 == len(ensemble_dataset)

--- a/tests/utilities/test_dataset_config.py
+++ b/tests/utilities/test_dataset_config.py
@@ -269,3 +269,22 @@ def test_dataset_config_files(backend: str) -> None:
         )
         == 0
     )
+
+
+@pytest.mark.order(6)
+@pytest.mark.parametrize("backend", ["sqlite"])
+def test_multiple_dataset_config_dict_selection(backend: str) -> None:
+    """Test constructing Dataset with multiple data paths."""
+    # Arrange
+    config_path = CONFIG_PATHS[backend]
+
+    # Single dataset
+    config = DatasetConfig.load(config_path)
+    dataset = Dataset.from_config(config)
+    # Construct multiple datasets
+    config_ensemble = DatasetConfig.load(config_path)
+    config_ensemble.path = [config_ensemble.path, config_ensemble.path]
+
+    ensemble_dataset = Dataset.from_config(config)
+
+    assert len(dataset) * 2 == len(ensemble_dataset)


### PR DESCRIPTION
the following is an implementation of the feature mentioned in #720. 

I had to include a type ignore on line 68. which I personally was not too happy with, but I did not manage to satisfy the pre-commit hooks without it. 

The solution uses the pre-existing `EnsembleDataset` class to automatically combine databases from a list of databases. 