### PR TITLE
add missing `abs` to `Track` label

### DIFF
--- a/src/graphnet/training/labels.py
+++ b/src/graphnet/training/labels.py
@@ -102,5 +102,7 @@ class Track(Label):
 
     def __call__(self, graph: Data) -> torch.tensor:
         """Compute label for `graph`."""
-        label = (torch.abs(graph[self._pid_key]) == 14) & (graph[self._int_key] == 1)
+        is_numu = torch.abs(graph[self._pid_key]) == 14
+        is_cc = graph[self._int_key] == 1
+        label = is_numu & is_cc
         return label.type(torch.int)

--- a/src/graphnet/training/labels.py
+++ b/src/graphnet/training/labels.py
@@ -102,5 +102,5 @@ class Track(Label):
 
     def __call__(self, graph: Data) -> torch.tensor:
         """Compute label for `graph`."""
-        label = (graph[self._pid_key] == 14) & (graph[self._int_key] == 1)
+        label = (torch.abs(graph[self._pid_key]) == 14) & (graph[self._int_key] == 1)
         return label.type(torch.int)

--- a/src/graphnet/training/labels.py
+++ b/src/graphnet/training/labels.py
@@ -104,5 +104,4 @@ class Track(Label):
         """Compute label for `graph`."""
         is_numu = torch.abs(graph[self._pid_key]) == 14
         is_cc = graph[self._int_key] == 1
-        label = is_numu & is_cc
-        return label.type(torch.int)
+        return (is_numu & is_cc).type(torch.int)


### PR DESCRIPTION
In our current implementation of the `Track` label, there is a missing `torch.abs` - resulting in a faulty label.

This PR adds the `torch.abs`.