### PR TITLE
Jammy flow integration

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -38,4 +38,5 @@ runs:
       run: |
         echo requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
         pip install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
+        pip install git+https://github.com/thoglu/jammy_flows.git
       shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -38,5 +38,5 @@ runs:
       run: |
         echo requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
         pip install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
-        pip install git+https://github.com/thoglu/jammy_flows.git ${{ env.PIP_FLAGS }}
+        pip install git+https://github.com/thoglu/jammy_flows.git
       shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -38,5 +38,5 @@ runs:
       run: |
         echo requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
         pip install -r requirements/torch_${{ inputs.hardware }}.txt ${{ env.PIP_FLAGS }} .${{ inputs.extras }}
-        pip install git+https://github.com/thoglu/jammy_flows.git
+        pip install git+https://github.com/thoglu/jammy_flows.git ${{ env.PIP_FLAGS }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,14 @@ jobs:
         uses: ./.github/actions/install
         with:
           editable: true
+      - name: Print packages in pip
+        run: |
+          pip show torch
+          pip show torch-geometric
+          pip show torch-cluster
+          pip show torch-sparse
+          pip show torch-scatter
+          pip show jammy_flows
       - name: Run unit tests and generate coverage report
         run: |
           coverage run --source=graphnet -m pytest tests/ --ignore=tests/examples/04_training --ignore=tests/utilities 
@@ -109,6 +117,7 @@ jobs:
           pip show torch-cluster
           pip show torch-sparse
           pip show torch-scatter
+          pip show jammy_flows
       - name: Run unit tests and generate coverage report
         run: |
           set -o pipefail  # To propagate exit code from pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,16 +10,20 @@ repos:
     rev: 4.0.1
     hooks:
     - id: flake8
+      language_version: python3
   - repo: https://github.com/pycqa/docformatter
     rev: v1.5.0
     hooks:
     - id: docformatter
+      language_version: python3
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.1.1
     hooks:
     - id: pydocstyle
+      language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:
     - id: mypy
       args: [--follow-imports=silent, --disallow-untyped-defs, --disallow-incomplete-defs, --disallow-untyped-calls]
+      language_version: python3

--- a/docs/source/installation/quick-start.html
+++ b/docs/source/installation/quick-start.html
@@ -107,20 +107,20 @@
     }
 
     if (os == "linux" && cuda != "cpu" && torch != "no_torch"){
-      $("#command pre").text(`git clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_${$("#command").attr("cuda")}.txt -e .[torch,develop]`);
+      $("#command pre").text(`git clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_${$("#command").attr("cuda")}.txt -e .[torch,develop]\n\n#Optionally, install jammy_flows for normalizing flow support:\npip install git+https://github.com/thoglu/jammy_flows.git`);
     }
     else if (os == "linux" && cuda == "cpu" && torch != "no_torch"){
-      $("#command pre").text(`git clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_${$("#command").attr("cuda")}.txt -e .[torch,develop]`);
+      $("#command pre").text(`git clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_${$("#command").attr("cuda")}.txt -e .[torch,develop]\n\n#Optionally, install jammy_flows for normalizing flow support:\npip install git+https://github.com/thoglu/jammy_flows.git`);
     }
     else if (os == "linux" && cuda == "cpu" && torch == "no_torch"){
-      $("#command pre").text(`# Installations without PyTorch are intended for file conversion only\ngit clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_${$("#command").attr("cuda")}.txt -e .[develop]`);
+      $("#command pre").text(`# Installations without PyTorch are intended for file conversion only\ngit clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_${$("#command").attr("cuda")}.txt -e .[develop]\n\n#Optionally, install jammy_flows for normalizing flow support:\npip install git+https://github.com/thoglu/jammy_flows.git`);
     }
 
     if (os == "macos" && cuda == "cpu" && torch != "no_torch"){
-      $("#command pre").text(`git clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_macos.txt -e .[torch,develop]`);
+      $("#command pre").text(`git clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_macos.txt -e .[torch,develop]\n\n#Optionally, install jammy_flows for normalizing flow support:\npip install git+https://github.com/thoglu/jammy_flows.git`);
     }
     if (os == "macos" && cuda == "cpu" && torch == "no_torch"){
-      $("#command pre").text(`# Installations without PyTorch are intended for file conversion only\ngit clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_macos.txt -e .[develop]`);
+      $("#command pre").text(`# Installations without PyTorch are intended for file conversion only\ngit clone https://github.com/graphnet-team/graphnet.git\ncd graphnet\n\npip install -r requirements/torch_macos.txt -e .[develop]\n\n#Optionally, install jammy_flows for normalizing flow support:\npip install git+https://github.com/thoglu/jammy_flows.git`);
     }
   }
 

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -13,11 +13,21 @@ from graphnet.models import NormalizingFlow
 from graphnet.models.detector.prometheus import Prometheus
 from graphnet.models.gnn import DynEdge
 from graphnet.models.graphs import KNNGraph
-from graphnet.models.task.task import StandardFlowTask
 from graphnet.training.callbacks import PiecewiseLinearLR
 from graphnet.training.utils import make_train_validation_dataloader
 from graphnet.utilities.argparse import ArgumentParser
 from graphnet.utilities.logging import Logger
+from graphnet.utilities.imports import has_jammy_flows_package
+
+# Make sure the jammy flows is installed
+try:
+    assert has_jammy_flows_package
+except AssertionError:
+    raise AssertionError(
+        "This example requires the package`jammy_flow` "
+        " to be installed. It appears that the package is "
+        " not installed. Please install the package."
+    )
 
 # Constants
 features = FEATURES.PROMETHEUS

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -9,7 +9,6 @@ from torch.optim.adam import Adam
 
 from graphnet.constants import EXAMPLE_DATA_DIR, EXAMPLE_OUTPUT_DIR
 from graphnet.data.constants import FEATURES, TRUTH
-from graphnet.models import NormalizingFlow
 from graphnet.models.detector.prometheus import Prometheus
 from graphnet.models.gnn import DynEdge
 from graphnet.models.graphs import KNNGraph
@@ -22,6 +21,7 @@ from graphnet.utilities.imports import has_jammy_flows_package
 # Make sure the jammy flows is installed
 try:
     assert has_jammy_flows_package()
+    from graphnet.models import NormalizingFlow
 except AssertionError:
     raise AssertionError(
         "This example requires the package`jammy_flow` "

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -209,7 +209,7 @@ Train conditional NormalizingFlow without the use of config files.
         "gpus",
         ("max-epochs", 1),
         "early-stopping-patience",
-        ("batch-size", 50),
+        ("batch-size", 16),
         "num-workers",
     )
 

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -21,7 +21,7 @@ from graphnet.utilities.imports import has_jammy_flows_package
 
 # Make sure the jammy flows is installed
 try:
-    assert has_jammy_flows_package
+    assert has_jammy_flows_package()
 except AssertionError:
     raise AssertionError(
         "This example requires the package`jammy_flow` "

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -1,0 +1,225 @@
+"""Example of training a conditional NormalizingFlow."""
+
+import os
+from typing import Any, Dict, List, Optional
+
+from pytorch_lightning.loggers import WandbLogger
+import torch
+from torch.optim.adam import Adam
+
+from graphnet.constants import EXAMPLE_DATA_DIR, EXAMPLE_OUTPUT_DIR
+from graphnet.data.constants import FEATURES, TRUTH
+from graphnet.models import NormalizingFlow
+from graphnet.models.detector.prometheus import Prometheus
+from graphnet.models.gnn import DynEdge
+from graphnet.models.graphs import KNNGraph
+from graphnet.models.task.task import StandardFlowTask
+from graphnet.training.callbacks import PiecewiseLinearLR
+from graphnet.training.utils import make_train_validation_dataloader
+from graphnet.utilities.argparse import ArgumentParser
+from graphnet.utilities.logging import Logger
+
+# Constants
+features = FEATURES.PROMETHEUS
+truth = TRUTH.PROMETHEUS
+
+
+def main(
+    path: str,
+    pulsemap: str,
+    target: str,
+    truth_table: str,
+    gpus: Optional[List[int]],
+    max_epochs: int,
+    early_stopping_patience: int,
+    batch_size: int,
+    num_workers: int,
+    wandb: bool = False,
+) -> None:
+    """Run example."""
+    # Construct Logger
+    logger = Logger()
+
+    # Initialise Weights & Biases (W&B) run
+    if wandb:
+        # Make sure W&B output directory exists
+        wandb_dir = "./wandb/"
+        os.makedirs(wandb_dir, exist_ok=True)
+        wandb_logger = WandbLogger(
+            project="example-script",
+            entity="graphnet-team",
+            save_dir=wandb_dir,
+            log_model=True,
+        )
+
+    logger.info(f"features: {features}")
+    logger.info(f"truth: {truth}")
+
+    # Configuration
+    config: Dict[str, Any] = {
+        "path": path,
+        "pulsemap": pulsemap,
+        "batch_size": batch_size,
+        "num_workers": num_workers,
+        "target": target,
+        "early_stopping_patience": early_stopping_patience,
+        "fit": {
+            "gpus": gpus,
+            "max_epochs": max_epochs,
+        },
+    }
+
+    archive = os.path.join(EXAMPLE_OUTPUT_DIR, "train_model_without_configs")
+    run_name = "dynedge_{}_example".format(config["target"])
+    if wandb:
+        # Log configuration to W&B
+        wandb_logger.experiment.config.update(config)
+
+    # Define graph representation
+    graph_definition = KNNGraph(detector=Prometheus())
+
+    (
+        training_dataloader,
+        validation_dataloader,
+    ) = make_train_validation_dataloader(
+        db=config["path"],
+        graph_definition=graph_definition,
+        pulsemaps=config["pulsemap"],
+        features=features,
+        truth=truth,
+        batch_size=config["batch_size"],
+        num_workers=config["num_workers"],
+        truth_table=truth_table,
+        selection=None,
+    )
+
+    # Building model
+
+    backbone = DynEdge(
+        nb_inputs=graph_definition.nb_outputs,
+        global_pooling_schemes=["min", "max", "mean", "sum"],
+    )
+
+    model = NormalizingFlow(
+        graph_definition=graph_definition,
+        backbone=backbone,
+        optimizer_class=Adam,
+        target_labels=config["target"],
+        optimizer_kwargs={"lr": 1e-03, "eps": 1e-03},
+        scheduler_class=PiecewiseLinearLR,
+        scheduler_kwargs={
+            "milestones": [
+                0,
+                len(training_dataloader) / 2,
+                len(training_dataloader) * config["fit"]["max_epochs"],
+            ],
+            "factors": [1e-2, 1, 1e-02],
+        },
+        scheduler_config={
+            "interval": "step",
+        },
+    )
+
+    # Training model
+    model.fit(
+        training_dataloader,
+        validation_dataloader,
+        early_stopping_patience=config["early_stopping_patience"],
+        logger=wandb_logger if wandb else None,
+        **config["fit"],
+    )
+
+    # Get predictions
+    additional_attributes = model.target_labels
+    assert isinstance(additional_attributes, list)  # mypy
+
+    results = model.predict_as_dataframe(
+        validation_dataloader,
+        additional_attributes=additional_attributes + ["event_no"],
+        gpus=config["fit"]["gpus"],
+    )
+
+    # Save predictions and model to file
+    db_name = path.split("/")[-1].split(".")[0]
+    path = os.path.join(archive, db_name, run_name)
+    logger.info(f"Writing results to {path}")
+    os.makedirs(path, exist_ok=True)
+
+    # Save results as .csv
+    results.to_csv(f"{path}/results.csv")
+
+    # Save full model (including weights) to .pth file - not version safe
+    # Note: Models saved as .pth files in one version of graphnet
+    #       may not be compatible with a different version of graphnet.
+    model.save(f"{path}/model.pth")
+
+    # Save model config and state dict - Version safe save method.
+    # This method of saving models is the safest way.
+    model.save_state_dict(f"{path}/state_dict.pth")
+    model.save_config(f"{path}/model_config.yml")
+
+
+if __name__ == "__main__":
+
+    # Parse command-line arguments
+    parser = ArgumentParser(
+        description="""
+Train conditional NormalizingFlow without the use of config files.
+"""
+    )
+
+    parser.add_argument(
+        "--path",
+        help="Path to dataset file (default: %(default)s)",
+        default=f"{EXAMPLE_DATA_DIR}/sqlite/prometheus/prometheus-events.db",
+    )
+
+    parser.add_argument(
+        "--pulsemap",
+        help="Name of pulsemap to use (default: %(default)s)",
+        default="total",
+    )
+
+    parser.add_argument(
+        "--target",
+        help=(
+            "Name of feature to use as regression target (default: "
+            "%(default)s)"
+        ),
+        default="total_energy",
+    )
+
+    parser.add_argument(
+        "--truth-table",
+        help="Name of truth table to be used (default: %(default)s)",
+        default="mc_truth",
+    )
+
+    parser.with_standard_arguments(
+        "gpus",
+        ("max-epochs", 1),
+        "early-stopping-patience",
+        ("batch-size", 16),
+        "num-workers",
+    )
+
+    parser.add_argument(
+        "--wandb",
+        action="store_true",
+        help="If True, Weights & Biases are used to track the experiment.",
+    )
+
+    args, unknown = parser.parse_known_args()
+
+    main(
+        args.path,
+        args.pulsemap,
+        args.target,
+        args.truth_table,
+        args.gpus,
+        args.max_epochs,
+        args.early_stopping_patience,
+        args.batch_size,
+        args.num_workers,
+        args.wandb,
+    )

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -209,7 +209,7 @@ Train conditional NormalizingFlow without the use of config files.
         "gpus",
         ("max-epochs", 1),
         "early-stopping-patience",
-        ("batch-size", 16),
+        ("batch-size", 50),
         "num-workers",
     )
 

--- a/src/graphnet/data/dataconverter.py
+++ b/src/graphnet/data/dataconverter.py
@@ -337,6 +337,8 @@ class DataConverter(ABC, Logger):
             files_to_merge = self._output_files
         elif files is not None:
             # Proceed to merge specified by user.
+            if isinstance(files, str):
+                files = [files] # Cast to list if user forgot
             files_to_merge = files
         else:
             # Raise error

--- a/src/graphnet/data/dataconverter.py
+++ b/src/graphnet/data/dataconverter.py
@@ -1,5 +1,4 @@
 """Contains `DataConverter`."""
-
 from typing import List, Union, OrderedDict, Dict, Tuple, Any, Optional, Type
 from abc import abstractmethod, ABC
 
@@ -103,7 +102,8 @@ class DataConverter(ABC, Logger):
         self._output_files = [
             os.path.join(
                 self._output_dir,
-                self._create_file_name(file) + self._save_method.file_extension,
+                self._create_file_name(file)
+                + self._save_method.file_extension,
             )
             for file in input_files
         ]
@@ -263,7 +263,9 @@ class DataConverter(ABC, Logger):
                 global_index.value += n_ids  # type: ignore[name-defined]
         else:
             starting_index = self._index
-            event_nos = np.arange(starting_index, starting_index + n_ids, 1).tolist()
+            event_nos = np.arange(
+                starting_index, starting_index + n_ids, 1
+            ).tolist()
             self._index += n_ids
 
         return event_nos
@@ -318,7 +320,9 @@ class DataConverter(ABC, Logger):
             self._output_files.extend(list(sorted(output_files[:])))
 
     @final
-    def merge_files(self, files: Optional[List[str]] = None, **kwargs: Any) -> None:
+    def merge_files(
+        self, files: Optional[List[str]] = None, **kwargs: Any
+    ) -> None:
         """Merge converted files.
 
             `DataConverter` will call the `.merge_files` method in the
@@ -333,8 +337,6 @@ class DataConverter(ABC, Logger):
             files_to_merge = self._output_files
         elif files is not None:
             # Proceed to merge specified by user.
-            if isinstance(files, str):
-                files = [files]  # Cast to list if user forgot
             files_to_merge = files
         else:
             # Raise error

--- a/src/graphnet/data/dataconverter.py
+++ b/src/graphnet/data/dataconverter.py
@@ -1,4 +1,5 @@
 """Contains `DataConverter`."""
+
 from typing import List, Union, OrderedDict, Dict, Tuple, Any, Optional, Type
 from abc import abstractmethod, ABC
 
@@ -102,8 +103,7 @@ class DataConverter(ABC, Logger):
         self._output_files = [
             os.path.join(
                 self._output_dir,
-                self._create_file_name(file)
-                + self._save_method.file_extension,
+                self._create_file_name(file) + self._save_method.file_extension,
             )
             for file in input_files
         ]
@@ -263,9 +263,7 @@ class DataConverter(ABC, Logger):
                 global_index.value += n_ids  # type: ignore[name-defined]
         else:
             starting_index = self._index
-            event_nos = np.arange(
-                starting_index, starting_index + n_ids, 1
-            ).tolist()
+            event_nos = np.arange(starting_index, starting_index + n_ids, 1).tolist()
             self._index += n_ids
 
         return event_nos
@@ -320,9 +318,7 @@ class DataConverter(ABC, Logger):
             self._output_files.extend(list(sorted(output_files[:])))
 
     @final
-    def merge_files(
-        self, files: Optional[List[str]] = None, **kwargs: Any
-    ) -> None:
+    def merge_files(self, files: Optional[List[str]] = None, **kwargs: Any) -> None:
         """Merge converted files.
 
             `DataConverter` will call the `.merge_files` method in the
@@ -338,7 +334,7 @@ class DataConverter(ABC, Logger):
         elif files is not None:
             # Proceed to merge specified by user.
             if isinstance(files, str):
-                files = [files] # Cast to list if user forgot
+                files = [files]  # Cast to list if user forgot
             files_to_merge = files
         else:
             # Raise error

--- a/src/graphnet/models/__init__.py
+++ b/src/graphnet/models/__init__.py
@@ -11,3 +11,4 @@ GNN
 from .model import Model
 from .standard_model import StandardModel
 from .standard_averaged_model import StandardAveragedModel
+from .normalizing_flow import NormalizingFlow

--- a/src/graphnet/models/__init__.py
+++ b/src/graphnet/models/__init__.py
@@ -6,9 +6,10 @@ subclassing `torch.nn.Module`, meaning that users only need to import a few,
 existing, purpose-built components and chain them together to form a complete
 GNN
 """
-
-
+from graphnet.utilities.imports import has_jammy_flows_package
 from .model import Model
 from .standard_model import StandardModel
 from .standard_averaged_model import StandardAveragedModel
-from .normalizing_flow import NormalizingFlow
+
+if has_jammy_flows_package():
+    from .normalizing_flow import NormalizingFlow

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -292,6 +292,7 @@ class EasySyntax(Model):
         dataloader: DataLoader,
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
+        **trainer_kwargs,
     ) -> List[Tensor]:
         """Return predictions for `dataloader`."""
         self.inference()
@@ -305,6 +306,7 @@ class EasySyntax(Model):
             gpus=gpus,
             distribution_strategy=distribution_strategy,
             callbacks=callbacks,
+            **trainer_kwargs,
         )
 
         predictions_list = inference_trainer.predict(self, dataloader)
@@ -325,6 +327,7 @@ class EasySyntax(Model):
         additional_attributes: Optional[List[str]] = None,
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
+        **trainer_kwargs,
     ) -> pd.DataFrame:
         """Return predictions for `dataloader` as a DataFrame.
 
@@ -357,6 +360,7 @@ class EasySyntax(Model):
             dataloader=dataloader,
             gpus=gpus,
             distribution_strategy=distribution_strategy,
+            **trainer_kwargs,
         )
         predictions = (
             torch.cat(predictions_torch, dim=1).detach().cpu().numpy()

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -16,7 +16,6 @@ import pandas as pd
 from pytorch_lightning.loggers import Logger as LightningLogger
 
 from graphnet.training.callbacks import ProgressBar
-from graphnet.models.graphs import GraphDefinition
 from graphnet.models.model import Model
 from graphnet.models.task import StandardLearnedTask
 
@@ -292,7 +291,7 @@ class EasySyntax(Model):
         dataloader: DataLoader,
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
-        **trainer_kwargs,
+        **trainer_kwargs: Any,
     ) -> List[Tensor]:
         """Return predictions for `dataloader`."""
         self.inference()
@@ -327,7 +326,7 @@ class EasySyntax(Model):
         additional_attributes: Optional[List[str]] = None,
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
-        **trainer_kwargs,
+        **trainer_kwargs: Any,
     ) -> pd.DataFrame:
         """Return predictions for `dataloader` as a DataFrame.
 

--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -34,7 +34,7 @@ class GraphDefinition(Model):
         sensor_mask: Optional[List[int]] = None,
         string_mask: Optional[List[int]] = None,
         sort_by: str = None,
-        repeat_labels: bool =False,
+        repeat_labels: bool = False,
     ):
         """Construct ´GraphDefinition´. The ´detector´ holds.
 
@@ -63,9 +63,9 @@ class GraphDefinition(Model):
             add_inactive_sensors: If True, inactive sensors will be appended
                 to the graph with padded pulse information. Defaults to False.
             sensor_mask: A list of sensor id's to be masked from the graph. Any
-                sensor listed here will be removed from the graph. 
+                sensor listed here will be removed from the graph.
                     Defaults to None.
-            string_mask: A list of string id's to be masked from the graph. 
+            string_mask: A list of string id's to be masked from the graph.
                 Defaults to None.
             sort_by: Name of node feature to sort by. Defaults to None.
             repeat_labels: If True, labels will be repeated to match the
@@ -415,12 +415,13 @@ class GraphDefinition(Model):
         """
         # Write attributes, either target labels, truth info or original
         # features.
+
         for truth_dict in truth_dicts:
             for key, value in truth_dict.items():
                 try:
                     label = torch.tensor(value)
                     if self._repeat_labels:
-                        label = label.repeat(graph.x.shape[0],1)    
+                        label = label.repeat(graph.x.shape[0], 1)
                     graph[key] = label
                 except TypeError:
                     # Cannot convert `value` to Tensor due to its data type,
@@ -460,6 +461,6 @@ class GraphDefinition(Model):
         for key, fn in custom_label_functions.items():
             label = fn(graph)
             if self._repeat_labels:
-                label = label.repeat(graph.x.shape[0],1)
+                label = label.repeat(graph.x.shape[0], 1)
             graph[key] = label
         return graph

--- a/src/graphnet/models/graphs/graph_definition.py
+++ b/src/graphnet/models/graphs/graph_definition.py
@@ -34,6 +34,7 @@ class GraphDefinition(Model):
         sensor_mask: Optional[List[int]] = None,
         string_mask: Optional[List[int]] = None,
         sort_by: str = None,
+        repeat_labels: bool =False,
     ):
         """Construct ´GraphDefinition´. The ´detector´ holds.
 
@@ -62,9 +63,14 @@ class GraphDefinition(Model):
             add_inactive_sensors: If True, inactive sensors will be appended
                 to the graph with padded pulse information. Defaults to False.
             sensor_mask: A list of sensor id's to be masked from the graph. Any
-                sensor listed here will be removed from the graph. Defaults to None.
-            string_mask: A list of string id's to be masked from the graph. Defaults to None.
+                sensor listed here will be removed from the graph. 
+                    Defaults to None.
+            string_mask: A list of string id's to be masked from the graph. 
+                Defaults to None.
             sort_by: Name of node feature to sort by. Defaults to None.
+            repeat_labels: If True, labels will be repeated to match the
+                the number of rows in the output of the GraphDefinition.
+                Defaults to False.
         """
         # Base class constructor
         super().__init__(name=__name__, class_name=self.__class__.__name__)
@@ -80,6 +86,7 @@ class GraphDefinition(Model):
         self._sensor_mask = sensor_mask
         self._string_mask = string_mask
         self._add_inactive_sensors = add_inactive_sensors
+        self._repeat_labels = repeat_labels
 
         self._resolve_masks()
 
@@ -411,7 +418,10 @@ class GraphDefinition(Model):
         for truth_dict in truth_dicts:
             for key, value in truth_dict.items():
                 try:
-                    graph[key] = torch.tensor(value)
+                    label = torch.tensor(value)
+                    if self._repeat_labels:
+                        label = label.repeat(graph.x.shape[0],1)    
+                    graph[key] = label
                 except TypeError:
                     # Cannot convert `value` to Tensor due to its data type,
                     # e.g. `str`.
@@ -448,5 +458,8 @@ class GraphDefinition(Model):
     ) -> Data:
         # Add custom labels to the graph
         for key, fn in custom_label_functions.items():
-            graph[key] = fn(graph)
+            label = fn(graph)
+            if self._repeat_labels:
+                label = label.repeat(graph.x.shape[0],1)
+            graph[key] = label
         return graph

--- a/src/graphnet/models/graphs/graphs.py
+++ b/src/graphnet/models/graphs/graphs.py
@@ -1,6 +1,6 @@
 """A module containing different graph representations in GraphNeT."""
 
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict, Union, Any
 import torch
 from numpy.random import Generator
 
@@ -23,7 +23,7 @@ class KNNGraph(GraphDefinition):
         seed: Optional[Union[int, Generator]] = None,
         nb_nearest_neighbours: int = 8,
         columns: List[int] = [0, 1, 2],
-        **kwargs
+        **kwargs: Any,
     ) -> None:
         """Construct k-nn graph representation.
 
@@ -54,7 +54,7 @@ class KNNGraph(GraphDefinition):
             input_feature_names=input_feature_names,
             perturbation_dict=perturbation_dict,
             seed=seed,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -72,7 +72,7 @@ class EdgelessGraph(GraphDefinition):
         dtype: Optional[torch.dtype] = torch.float,
         perturbation_dict: Optional[Dict[str, float]] = None,
         seed: Optional[Union[int, Generator]] = None,
-        **kwargs
+        **kwargs: Any,
     ) -> None:
         """Construct isolated nodes graph representation.
 
@@ -97,5 +97,5 @@ class EdgelessGraph(GraphDefinition):
             input_feature_names=input_feature_names,
             perturbation_dict=perturbation_dict,
             seed=seed,
-            **kwargs
+            **kwargs,
         )

--- a/src/graphnet/models/graphs/graphs.py
+++ b/src/graphnet/models/graphs/graphs.py
@@ -23,6 +23,7 @@ class KNNGraph(GraphDefinition):
         seed: Optional[Union[int, Generator]] = None,
         nb_nearest_neighbours: int = 8,
         columns: List[int] = [0, 1, 2],
+        **kwargs
     ) -> None:
         """Construct k-nn graph representation.
 
@@ -53,6 +54,7 @@ class KNNGraph(GraphDefinition):
             input_feature_names=input_feature_names,
             perturbation_dict=perturbation_dict,
             seed=seed,
+            **kwargs
         )
 
 
@@ -70,6 +72,7 @@ class EdgelessGraph(GraphDefinition):
         dtype: Optional[torch.dtype] = torch.float,
         perturbation_dict: Optional[Dict[str, float]] = None,
         seed: Optional[Union[int, Generator]] = None,
+        **kwargs
     ) -> None:
         """Construct isolated nodes graph representation.
 
@@ -94,4 +97,5 @@ class EdgelessGraph(GraphDefinition):
             input_feature_names=input_feature_names,
             perturbation_dict=perturbation_dict,
             seed=seed,
+            **kwargs
         )

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -1,0 +1,115 @@
+"""Standard model class(es)."""
+
+from typing import Any, Dict, List, Optional, Union, Type
+import torch
+from torch import Tensor
+from torch_geometric.data import Data
+from torch.optim import Adam
+
+from graphnet.models.gnn.gnn import GNN
+from .easy_model import EasySyntax
+from graphnet.models.task import StandardFlowTask
+from graphnet.models.graphs import GraphDefinition
+from graphnet.models.utils import get_fields
+
+
+class NormalizingFlow(EasySyntax):
+    """A Standard way of combining model components in GraphNeT.
+
+    This model is compatible with the vast majority of supervised learning
+    tasks such as regression, binary and multi-label classification.
+
+    Capable of producing both event-level and pulse-level predictions.
+    """
+
+    def __init__(
+        self,
+        graph_definition: GraphDefinition,
+        target_labels: str,
+        backbone: GNN = None,
+        condition_on: Union[str, List[str], None] = None,
+        flow_layers: str = 'gggt',
+        optimizer_class: Type[torch.optim.Optimizer] = Adam,
+        optimizer_kwargs: Optional[Dict] = None,
+        scheduler_class: Optional[type] = None,
+        scheduler_kwargs: Optional[Dict] = None,
+        scheduler_config: Optional[Dict] = None,
+    ) -> None:
+        """Construct `NormalizingFlow`."""
+
+        # Handle args
+        if backbone is not None:
+            assert isinstance(backbone, GNN)
+            hidden_size = backbone.nb_outputs
+        else:
+            if isinstance(condition_on, str):
+                condition_on = [condition_on]
+            hidden_size = len(condition_on)
+
+        # Build Flow Task
+        task = StandardFlowTask(hidden_size=hidden_size,
+                                flow_layers=flow_layers,
+                                target_labels = target_labels)
+
+
+        # Base class constructor
+        super().__init__(
+            tasks=task,
+            optimizer_class=optimizer_class,
+            optimizer_kwargs=optimizer_kwargs,
+            scheduler_class=scheduler_class,
+            scheduler_kwargs=scheduler_kwargs,
+            scheduler_config=scheduler_config,
+        )
+
+        # Member variable(s)
+        self._graph_definition = graph_definition
+        self.backbone = backbone
+        self._condition_on = condition_on
+
+    def forward(
+        self, data: Union[Data, List[Data]]
+    ) -> List[Union[Tensor, Data]]:
+        """Forward pass, chaining model components."""
+        if self.backbone is not None:
+            x = self._backbone(data)
+        elif self._condition_on is not None:
+            x = get_fields(data = data, 
+                           fields = self._condition_on)
+        return self._tasks[0](x, data)
+
+    def _backbone(
+        self, data: Union[Data, List[Data]]
+    ) -> List[Union[Tensor, Data]]:
+        if isinstance(data, Data):
+            data = [data]
+        x_list = []
+        for d in data:
+            x = self.backbone(d)
+            x_list.append(x)
+        x = torch.cat(x_list, dim=0)
+        return x
+        
+
+    def shared_step(self, batch: List[Data], batch_idx: int) -> Tensor:
+        """Perform shared step.
+
+        Applies the forward pass and the following loss calculation, shared
+        between the training and validation step.
+        """
+        loss = self(batch)
+        return torch.mean(loss, dim = 0)
+
+    def validate_tasks(self) -> None:
+        """Verify that self._tasks contain compatible elements."""
+        accepted_tasks =  (StandardFlowTask)
+        for task in self._tasks:
+            assert isinstance(task, accepted_tasks)
+
+    def sample(self, data, n_samples, target_range =  [0,1000]):
+        self._sample = True
+        self._n_samples = n_samples
+        self._target_range = target_range
+        labels, nllh = self(data)
+        self._sample = False
+        return labels, nllh

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -35,7 +35,37 @@ class NormalizingFlow(EasySyntax):
         scheduler_kwargs: Optional[Dict] = None,
         scheduler_config: Optional[Dict] = None,
     ) -> None:
-        """Construct `NormalizingFlow`."""
+        """Build NormalizingFlow to learn (conditional) normalizing flows.
+
+        NormalizingFlow is able to build, train and evaluate a wide suite of
+        normalizing flows. Instead of optimizing a loss function, flows
+        minimize a learned pdf of your data, providing you with a posterior
+        distribution for every example instead of point-like predictions.
+
+        `NormalizingFlow` can be conditioned on existing fields in the
+        DataRepresentation or latent representations from `Models`.
+
+        Args:
+            graph_definition: The `GraphDefinition` to train the model on.
+            target_labels: Name of target(s) to learn the pdf of.
+            backbone: Architecture used to produce latent representations of
+            the input data on which the pdf will be conditioned.
+            Defaults to None.
+            condition_on: List of fields in Data objects to condition the
+            pdf on. Defaults to None.
+            flow_layers: A string defining the flow layers.
+            See https://thoglu.github.io/jammy_flows/usage/introduction.html
+            for details. Defaults to "gggt".
+            optimizer_class: Optimizer to use. Defaults to Adam.
+            optimizer_kwargs: Optimzier arguments. Defaults to None.
+            scheduler_class: Learning rate scheduler to use. Defaults to None.
+            scheduler_kwargs: Arguments to learning rate scheduler.
+            Defaults to None.
+            scheduler_config: Defaults to None.
+
+        Raises:
+            ValueError: if both `backbone` and `condition_on` is specified.
+        """
         # Checks
         if (backbone is not None) & (condition_on is not None):
             # If user wants to condition on both

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -14,12 +14,12 @@ from graphnet.models.utils import get_fields
 
 
 class NormalizingFlow(EasySyntax):
-    """A Standard way of combining model components in GraphNeT.
+    """A model for building (conditional) normalizing flows in GraphNeT.
 
-    This model is compatible with the vast majority of supervised learning
-    tasks such as regression, binary and multi-label classification.
-
-    Capable of producing both event-level and pulse-level predictions.
+    This model relies on `jammy_flows` for building and evaluating
+    normalizing flows.
+    https://thoglu.github.io/jammy_flows/usage/introduction.html
+    for details.
     """
 
     def __init__(

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -111,6 +111,7 @@ class NormalizingFlow(EasySyntax):
         self._graph_definition = graph_definition
         self.backbone = backbone
         self._condition_on = condition_on
+        self._norm = torch.nn.BatchNorm1d(hidden_size)
 
     def forward(self, data: Union[Data, List[Data]]) -> Tensor:
         """Forward pass, chaining model components."""
@@ -120,6 +121,7 @@ class NormalizingFlow(EasySyntax):
         for d in data:
             if self.backbone is not None:
                 x = self._backbone(d)
+                x = self._norm(x)
             elif self._condition_on is not None:
                 assert isinstance(self._condition_on, list)
                 x = get_fields(data=d, fields=self._condition_on)

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -96,7 +96,7 @@ class NormalizingFlow(EasySyntax):
             x = self._tasks[0](x, d)
             x_list.append(x)
         x = torch.cat(x_list, dim=0)
-        return x
+        return [x]
 
     def _backbone(
         self, data: Union[Data, List[Data]]
@@ -111,6 +111,9 @@ class NormalizingFlow(EasySyntax):
         between the training and validation step.
         """
         loss = self(batch)
+        if isinstance(loss, list):
+            assert len(loss) == 1
+            loss = loss[0]
         return torch.mean(loss, dim=0)
 
     def validate_tasks(self) -> None:

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -45,6 +45,9 @@ class NormalizingFlow(EasySyntax):
         `NormalizingFlow` can be conditioned on existing fields in the
         DataRepresentation or latent representations from `Models`.
 
+        NormalizingFlow is built upon https://github.com/thoglu/jammy_flows,
+        and we refer to their documentation for details on the flows.
+
         Args:
             graph_definition: The `GraphDefinition` to train the model on.
             target_labels: Name of target(s) to learn the pdf of.

--- a/src/graphnet/models/normalizing_flow.py
+++ b/src/graphnet/models/normalizing_flow.py
@@ -36,6 +36,16 @@ class NormalizingFlow(EasySyntax):
         scheduler_config: Optional[Dict] = None,
     ) -> None:
         """Construct `NormalizingFlow`."""
+        # Checks
+        if (backbone is not None) & (condition_on is not None):
+            # If user wants to condition on both
+            raise ValueError(
+                f"{self.__class__.__name__} got values for both "
+                "`backbone` and `condition_on`, but can only"
+                "condition on one of those. Please specify just "
+                "one of these arguments."
+            )
+
         # Handle args
         if backbone is not None:
             assert isinstance(backbone, GNN)

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -454,7 +454,7 @@ class StandardFlowTask(Task):
         x = self._forward(x, labels)
         return self._transform_prediction(x)
 
-    def sample(self, x, data, n_samples, target_range):
+    def sample(self, x, data: int, n_samples, target_range):
         self.inference()
         with torch.no_grad():
             labels = Uniform(target_range[0], target_range[1]).sample((n_samples, 1)) 

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -461,7 +461,7 @@ class StandardFlowTask(Task):
         labels = labels.to(self.dtype)
         # Set the initial parameters of flow close to truth
         # This speeds up training and helps with NaN
-        if self._initialized is False:
+        if (self._initialized is False) & (self.training):
             self._flow.init_params(data=deepcopy(labels).cpu())
             self._flow.to(self.device)
             self._initialized = True  # This is only done once

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -423,7 +423,7 @@ class StandardFlowTask(Task):
         """Return number of conditional inputs assumed by task."""
         return self._hidden_size
 
-    def _forward(self, x: Tensor, y: Tensor) -> Tensor:  # type: ignore
+    def _forward(self, x: Optional[Tensor], y: Tensor) -> Tensor:  # type: ignore
         if x is not None:
             if x.shape[0] != y.shape[0]:
                 raise AssertionError(
@@ -443,9 +443,10 @@ class StandardFlowTask(Task):
     ) -> Union[Tensor, Data]:
         """Forward pass."""
         # Manually cast pdf to correct dtype - is there a better way?
-        self._flow = self._flow.to(x.dtype)
+        self._flow = self._flow.to(self.dtype)
         # Get target values
-        labels = get_fields(data=data, fields=self._target_labels).to(x.dtype)
+        labels = get_fields(data=data, fields=self._target_labels)
+        labels = labels.to(self.dtype)
         # Set the initial parameters of flow close to truth
         # This speeds up training and helps with NaN
         if self._initialized is False:

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -10,8 +10,6 @@ import torch
 from torch import Tensor
 from torch.nn import Linear
 from torch_geometric.data import Data
-import jammy_flows
-from torch.distributions.uniform import Uniform
 
 if TYPE_CHECKING:
     # Avoid cyclic dependency
@@ -20,6 +18,10 @@ if TYPE_CHECKING:
 from graphnet.models import Model
 from graphnet.utilities.decorators import final
 from graphnet.models.utils import get_fields
+from graphnet.utilities.imports import has_jammy_flows_package
+
+if has_jammy_flows_package():
+    import jammy_flows
 
 
 class Task(Model):

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -396,6 +396,7 @@ class StandardFlowTask(Task):
         self,
         hidden_size: Union[int, None],
         flow_layers: str = "gggt",
+        target_norm: float = 1000.0,
         **task_kwargs: Any,
     ):
         """Construct `StandardFlowTask`.
@@ -405,6 +406,8 @@ class StandardFlowTask(Task):
             flow_layers: A string indicating the flow layer types. See
              https://thoglu.github.io/jammy_flows/usage/introduction.html
              for details.
+            target_norm: A normalization constant used to divide the target
+            values. Value is applied to all targets. Defaults to 1000.
             hidden_size: The number of columns on which the normalizing flow
             is conditioned on. May be `None`, indicating non-conditional flow.
         """
@@ -420,6 +423,7 @@ class StandardFlowTask(Task):
             conditional_input_dim=hidden_size,
         )
         self._initialized = False
+        self._norm = target_norm
 
     @property
     def default_prediction_labels(self) -> List[str]:
@@ -431,6 +435,7 @@ class StandardFlowTask(Task):
         return self._hidden_size
 
     def _forward(self, x: Optional[Tensor], y: Tensor) -> Tensor:  # type: ignore
+        y = y / self._norm
         if x is not None:
             if x.shape[0] != y.shape[0]:
                 raise AssertionError(

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -386,7 +386,11 @@ class IdentityTask(StandardLearnedTask):
 
 
 class StandardFlowTask(Task):
-    """A `Task` for `NormalizingFlow`s in GraphNeT."""
+    """A `Task` for `NormalizingFlow`s in GraphNeT.
+
+    This Task requires the support package`jammy_flows` for constructing and
+    evaluating normalizing flows.
+    """
 
     def __init__(
         self,
@@ -394,14 +398,15 @@ class StandardFlowTask(Task):
         flow_layers: str = "gggt",
         **task_kwargs: Any,
     ):
-        """Construct `StandardLearnedTask`.
+        """Construct `StandardFlowTask`.
 
         Args:
             target_labels: A list of names for the targets of this Task.
-            flow_layers: A string indicating the flow layer types.
-            hidden_size: The number of columns in the output of
-                         the last latent layer of `Model` using this Task.
-                         Available through `Model.nb_outputs`
+            flow_layers: A string indicating the flow layer types. See
+             https://thoglu.github.io/jammy_flows/usage/introduction.html
+             for details.
+            hidden_size: The number of columns on which the normalizing flow
+            is conditioned on. May be `None`, indicating non-conditional flow.
         """
         # Base class constructor
 

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -454,7 +454,7 @@ class StandardFlowTask(Task):
         x = self._forward(x, labels)
         return self._transform_prediction(x)
 
-    def sample(self, x, data: float, n_samples, target_range):
+    def sample(self, x, data: int, n_samples, target_range):
         self.inference()
         with torch.no_grad():
             labels = Uniform(target_range[0], target_range[1]).sample((n_samples, 1)) 

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -454,7 +454,7 @@ class StandardFlowTask(Task):
         x = self._forward(x, labels)
         return self._transform_prediction(x)
 
-    def sample(self, x, data: int, n_samples, target_range):
+    def sample(self, x, data: float, n_samples, target_range):
         self.inference()
         with torch.no_grad():
             labels = Uniform(target_range[0], target_range[1]).sample((n_samples, 1)) 

--- a/src/graphnet/models/utils.py
+++ b/src/graphnet/models/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for `graphnet.models`."""
 
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Union
 from torch_geometric.nn import knn_graph
 from torch_geometric.data import Batch
 import torch
@@ -105,10 +105,14 @@ def array_to_sequence(
     x[~mask] = padding_value
     return x, mask, seq_length
 
-def get_fields(data: List[Data], fields: List[str]) -> Tensor:
-        labels = []
-        if not isinstance(data, list):
-            data = [data]
-        for label in list(fields):
-            labels.append(torch.cat([d[label].reshape(-1,1) for d in data], dim=0))
-        return torch.cat(labels, dim = 1)
+
+def get_fields(data: Union[Data, List[Data]], fields: List[str]) -> Tensor:
+    """Extract named fields in Data object."""
+    labels = []
+    if not isinstance(data, list):
+        data = [data]
+    for label in list(fields):
+        labels.append(
+            torch.cat([d[label].reshape(-1, 1) for d in data], dim=0)
+        )
+    return torch.cat(labels, dim=1)

--- a/src/graphnet/models/utils.py
+++ b/src/graphnet/models/utils.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor, LongTensor
 
 from torch_geometric.utils import homophily
+from torch_geometric.data import Data
 
 
 def calculate_xyzt_homophily(
@@ -103,3 +104,11 @@ def array_to_sequence(
     mask = torch.ne(x[:, :, 1], excluding_value)
     x[~mask] = padding_value
     return x, mask, seq_length
+
+def get_fields(data: List[Data], fields: List[str]) -> Tensor:
+        labels = []
+        if not isinstance(data, list):
+            data = [data]
+        for label in list(fields):
+            labels.append(torch.cat([d[label].reshape(-1,1) for d in data], dim=0))
+        return torch.cat(labels, dim = 1)

--- a/src/graphnet/utilities/imports.py
+++ b/src/graphnet/utilities/imports.py
@@ -33,6 +33,20 @@ def has_torch_package() -> bool:
         return False
 
 
+def has_jammy_flows_package() -> bool:
+    """Check if the `jammy_flows` package is available."""
+    try:
+        import jammmy_flows  # pyright: reportMissingImports=false
+
+        return True
+    except ImportError:
+        Logger(log_folder=None).warning_once(
+            "`jammy_flows` not available. Normalizing Flow functionality is "
+            "missing."
+        )
+        return False
+
+
 def requires_icecube(test_function: Callable) -> Callable:
     """Decorate `test_function` for use only if `icecube` module is present."""
 

--- a/src/graphnet/utilities/imports.py
+++ b/src/graphnet/utilities/imports.py
@@ -36,7 +36,7 @@ def has_torch_package() -> bool:
 def has_jammy_flows_package() -> bool:
     """Check if the `jammy_flows` package is available."""
     try:
-        import jammmy_flows  # pyright: reportMissingImports=false
+        import jammy_flows  # pyright: reportMissingImports=false
 
         return True
     except ImportError:


### PR DESCRIPTION
This PR adds support for Normalizing Flows via the [jammy_flows](https://github.com/thoglu/jammy_flows) package, and therefore supersedes #649. The benefit of using `jammy_flows `is that it contains many different normalizing flows, and that we avoid maintaining that code ourselves :-).

The package is not listed as a direct dependency but used as an optional support package. 

Specifically, this PR introduces the following major changes:

1.  `StandardFlowTask` now uses jammy_flows to construct pdfs of any kind that it supports. These pdfs can be both conditional and non-conditional. Conditional flows can be conditioned on latent model output, event-level information or pulse-level information. 
2. A new model class is added: ` NormalizingFlow` which work with the `StandardFlowTask`. Usage is similar to `StandardModel`.
3. An example of training a conditional flow is added under `examples/04_training/07_train_normalizing_flow.py`
4. `has_jammy_flows_package()` is added under `graphnet.utils.imports` to check if its installed, and is used in a few places to make sure that the code runs also for people who choose not to install jammy_flows.


Minor changes:
1. `repeat_labels` is added as an argument to `GraphDefinition` - if `True`, event-level information, .e.g `energy` is repeated row-wise to match the number of pulses in the event. This feature was added in this PR to make it possible to build flows that learn pulse-level pdfs conditioned on event-level information.
2.  Installation matrix is updated to provide a note on the installation of jammy flows
3. Github workflows is adjusted to run **with** jammy_flows installed.
4. `**kwargs` for `Trainer` is added for `predict`-methods in `EasySyntax` to allow the same level of control over `Trainer` arguments as we have for `.fit` 
