### PR TITLE
Fix unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ INSTALL_REQUIRES = [
     "configupdater",
     "dill>=0.3",
     "matplotlib>=3.5",
-    "numpy>=1.21",
+    "numpy>=1.23",
     "pandas>=1.3",
     "pyarrow",
     "pydantic",


### PR DESCRIPTION
Certain build tests fails with 

```
x = x.numpy()
   
RuntimeError: Numpy is not available
```
which suggests a problem with numpy versions. 