### PR TITLE
Improvements to parquet dataloading, sampling, batch sampling

### DIFF
--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -285,7 +285,8 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
         if "batch_sampler" in dataloader_args.keys():
             if "sampler" not in dataloader_args.keys():
                 raise KeyError(
-                    "When specifying a `batch_sampler`, you must also provide `sampler`."
+                    "When specifying a `batch_sampler`,"
+                    "you must also provide `sampler`."
                 )
             # If there were no kwargs provided, set it to empty dict
             if "batch_sampler_kwargs" not in dataloader_args.keys():

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -195,13 +195,6 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
             if self._val_selection is not None:
                 self._val_dataset = self._create_dataset(self._val_selection)
 
-            # if self._len_match_batch:  # TODO: the same for val -PW
-            #     batch_size =  self._train_batch_sampler_kwargs["batch_size"]
-            #     self._train_random_chunk_sampler = RandomChunkSampler(self._train_dataset,
-            #                                                           chunks=self._train_dataset.chunk_sizes)
-            #     self._train_len_match_batch_sampler = LenMatchBatchSampler(self._train_random_chunk_sampler,
-            #                                                                batch_size=batch_size,
-            #                                                                drop_last=True)
         return
 
     @property

--- a/src/graphnet/data/dataset/__init__.py
+++ b/src/graphnet/data/dataset/__init__.py
@@ -5,7 +5,10 @@ from graphnet.utilities.imports import has_torch_package
 if has_torch_package():
     import torch.multiprocessing
     from .dataset import EnsembleDataset, Dataset, ColumnMissingException
-    from .samplers import RandomChunkSampler, LenMatchBatchSampler
+    from .samplers import (
+        RandomChunkSampler,
+        LenMatchBatchSampler,
+    )
     from .parquet.parquet_dataset import ParquetDataset
     from .sqlite.sqlite_dataset import SQLiteDataset
 

--- a/src/graphnet/data/dataset/__init__.py
+++ b/src/graphnet/data/dataset/__init__.py
@@ -5,6 +5,7 @@ from graphnet.utilities.imports import has_torch_package
 if has_torch_package():
     import torch.multiprocessing
     from .dataset import EnsembleDataset, Dataset, ColumnMissingException
+    from .samplers import RandomChunkSampler, LenMatchBatchSampler
     from .parquet.parquet_dataset import ParquetDataset
     from .sqlite.sqlite_dataset import SQLiteDataset
 

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -5,6 +5,7 @@ from typing import (
     List,
     Optional,
     Union,
+    Any,
 )
 
 import numpy as np
@@ -92,7 +93,7 @@ class ParquetDataset(Dataset):
                 `"10000 random events ~ event_no % 5 > 0"` or `"20% random
                 events ~ event_no % 5 > 0"`).
             graph_definition: Method that defines the graph representation.
-            cache_size: Number of batches to cache in memory.
+            cache_size: Number of files to cache in memory.
                         Must be at least 1. Defaults to 1.
             labels: Dictionary of labels to be added to the dataset.
         """
@@ -123,8 +124,8 @@ class ParquetDataset(Dataset):
         self._path: str = self._path
         # Member Variables
         self._cache_size = cache_size
-        self._batch_sizes = self._calculate_sizes()
-        self._batch_cumsum = np.cumsum(self._batch_sizes)
+        self._chunk_sizes = self._calculate_sizes()
+        self._chunk_cumsum = np.cumsum(self._chunk_sizes)
         self._file_cache = self._initialize_file_cache(
             truth_table=truth_table,
             node_truth_table=node_truth_table,
@@ -179,9 +180,14 @@ class ParquetDataset(Dataset):
         )
         return event_index
 
+    @property
+    def chunk_sizes(self) -> List[int]:
+        """Return a list of the chunk sizes."""
+        return self._chunk_sizes
+
     def __len__(self) -> int:
         """Return length of dataset, i.e. number of training examples."""
-        return sum(self._batch_sizes)
+        return sum(self._chunk_sizes)
 
     def _get_all_indices(self) -> List[int]:
         """Return a list of all unique values in `self._index_column`."""
@@ -189,22 +195,22 @@ class ParquetDataset(Dataset):
         return np.arange(0, len(files), 1)
 
     def _calculate_sizes(self) -> List[int]:
-        """Calculate the number of events in each batch."""
+        """Calculate the number of events in each chunk."""
         sizes = []
-        for batch_id in self._indices:
+        for chunk_id in self._indices:
             path = os.path.join(
                 self._path,
                 self._truth_table,
-                f"{self.truth_table}_{batch_id}.parquet",
+                f"{self.truth_table}_{chunk_id}.parquet",
             )
             sizes.append(len(pol.read_parquet(path)))
         return sizes
 
     def _get_row_idx(self, sequential_index: int) -> int:
         """Return the row index corresponding to a `sequential_index`."""
-        file_idx = bisect_right(self._batch_cumsum, sequential_index)
+        file_idx = bisect_right(self._chunk_cumsum, sequential_index)
         if file_idx > 0:
-            idx = int(sequential_index - self._batch_cumsum[file_idx - 1])
+            idx = int(sequential_index - self._chunk_cumsum[file_idx - 1])
         else:
             idx = sequential_index
         return idx
@@ -241,9 +247,9 @@ class ParquetDataset(Dataset):
             columns = [columns]
 
         if sequential_index is None:
-            file_idx = np.arange(0, len(self._batch_cumsum), 1)
+            file_idx = np.arange(0, len(self._chunk_cumsum), 1)
         else:
-            file_idx = [bisect_right(self._batch_cumsum, sequential_index)]
+            file_idx = [bisect_right(self._chunk_cumsum, sequential_index)]
 
         file_indices = [self._indices[idx] for idx in file_idx]
 

--- a/src/graphnet/data/dataset/samplers.py
+++ b/src/graphnet/data/dataset/samplers.py
@@ -1,0 +1,232 @@
+"""`Sampler` and `BatchSampler` objects for `graphnet`."""
+from typing import (
+    Any,
+    List,
+    Optional,
+    Tuple,
+    Iterator,
+    Sequence,
+)
+
+from collections import defaultdict
+from multiprocessing import Pool, cpu_count, get_context
+
+import numpy as np
+import torch
+from torch.utils.data import Sampler, BatchSampler
+
+
+class RandomChunkSampler(Sampler[int]):
+    """A `Sampler` that randomly selects chunks.
+
+    MIT License
+
+    Copyright (c) 2023 DrHB
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+
+    def __init__(
+        self,
+        data_source: Sequence[Any],
+        chunks: List[int],
+        num_samples: Optional[int] = None,
+        generator: Optional[torch.Generator] = None,
+    ) -> None:
+        """Construct `RandomChunkSampler`."""
+        # chunks - a list of chunk sizes
+        self._data_source = data_source
+        self._num_samples = num_samples
+        self._chunks = chunks
+
+        # Create a random number generator if one was not provided
+        if generator is None:
+            seed = int(torch.empty((), dtype=torch.int64).random_().item())
+            self._generator = torch.Generator()
+            self._generator.manual_seed(seed)
+        else:
+            self._generator = generator
+
+        if not isinstance(self.num_samples, int) or self.num_samples <= 0:
+            raise ValueError(
+                "num_samples should be a positive integer "
+                "value, but got num_samples={}".format(self.num_samples)
+            )
+
+    @property
+    def data_source(self) -> Sequence[Any]:
+        """Return the data source."""
+        return self._data_source
+
+    @property
+    def num_samples(self) -> int:
+        """Return the number of samples in the data source."""
+        if self._num_samples is None:
+            return len(self.data_source)
+        return self._num_samples
+
+    def __len__(self) -> int:
+        """Return the number of sampled."""
+        return self.num_samples
+
+    @property
+    def chunks(self) -> List[int]:
+        """Return the list of chunks."""
+        return self._chunks
+
+    def __iter__(self) -> Iterator[List[int]]:
+        """Return a list of indices from a randomly sampled chunk."""
+        cumsum = np.cumsum(self.chunks)
+        chunk_list = torch.randperm(
+            len(self.chunks), generator=self.generator
+        ).tolist()
+
+        # sample indexes chunk by chunk
+        yield_samples = 0
+        for i in chunk_list:
+            chunk_len = self.chunks[i]
+            offset = cumsum[i - 1] if i > 0 else 0
+            samples = (
+                offset + torch.randperm(chunk_len, generator=self.generator)
+            ).tolist()
+            if len(samples) <= self.num_samples - yield_samples:
+                yield_samples += len(samples)
+            else:
+                samples = samples[: self.num_samples - yield_samples]
+                yield_samples = self.num_samples
+            yield from samples
+
+
+def gather_buckets(
+    params: Tuple[List[int], Sequence[Any], int],
+) -> Tuple[List[List[int]], List[List[int]]]:
+    """Gather buckets of events.
+
+    The function that will be used to gather buckets of events by the
+    `LenMatchBatchSampler`. When using multiprocessing, each worker will call
+    this function.
+
+    Args:
+        params: A tuple containg the list of indices to process,
+        the data_source (typically a `Dataset`), and the batch size.
+
+    Returns:
+        batches: A list containing batches.
+        remaining_batches: Incomplete batches.
+    """
+    indices, data_source, batch_size = params
+    buckets = defaultdict(list)
+    batches = []
+
+    for idx in indices:
+        s = data_source[idx]
+        L = max(1, s.num_nodes // 16)
+        buckets[L].append(idx)
+        if len(buckets[L]) == batch_size:
+            batches.append(list(buckets[L]))
+            buckets[L] = []
+
+    # Include any remaining items in partially filled buckets
+    remaining_batches = [b for b in buckets.values() if b]
+    return batches, remaining_batches
+
+
+class LenMatchBatchSampler(BatchSampler):
+    """A `BatchSampler` that batches similar length events.
+
+    MIT License
+
+    Copyright (c) 2023 DrHB
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+
+    def __init__(
+        self,
+        sampler: Sampler,
+        batch_size: int,
+        drop_last: Optional[bool] = False,
+    ) -> None:
+        """Construct `LenMatchBatchSampler`."""
+        super().__init__(
+            sampler=sampler, batch_size=batch_size, drop_last=drop_last
+        )
+
+    def __iter__(self) -> Iterator[List[int]]:
+        """Return length-matched batches."""
+        indices = list(self.sampler)
+        data_source = self.sampler.data_source
+
+        n_workers = min(cpu_count(), 6)
+        chunk_size = len(indices) // n_workers
+
+        # Split indices into nearly equal-sized chunks
+        chunks = [
+            indices[i * chunk_size : (i + 1) * chunk_size]
+            for i in range(n_workers)
+        ]
+        if len(indices) % n_workers != 0:
+            chunks.append(indices[n_workers * chunk_size :])
+
+        yielded = 0
+        with get_context("spawn").Pool(processes=n_workers) as pool:
+            results = pool.map(
+                gather_buckets,
+                [(chunk, data_source, self.batch_size) for chunk in chunks],
+            )
+
+        merged_batches = []
+        remaining_indices = []
+        for batches, remaining in results:
+            merged_batches.extend(batches)
+            remaining_indices.extend(remaining)
+
+        for batch in merged_batches:
+            yield batch
+            yielded += 1
+
+        # Process any remaining indices
+        leftover = [idx for batch in remaining_indices for idx in batch]
+        batch = []
+        for idx in leftover:
+            batch.append(idx)
+            if len(batch) == self.batch_size:
+                yield batch
+                yielded += 1
+                batch = []
+
+        if len(batch) > 0 and not self.drop_last:
+            yield batch
+            yielded += 1

--- a/src/graphnet/data/dataset/samplers.py
+++ b/src/graphnet/data/dataset/samplers.py
@@ -1,4 +1,29 @@
-"""`Sampler` and `BatchSampler` objects for `graphnet`."""
+"""`Sampler` and `BatchSampler` objects for `graphnet`.
+
+MIT License
+
+Copyright (c) 2023 DrHB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+_____________________
+"""
+
 from typing import (
     Any,
     List,
@@ -21,30 +46,8 @@ from graphnet.utilities.logging import Logger
 class RandomChunkSampler(Sampler[int]):
     """A `Sampler` that randomly selects chunks.
 
-    MIT License
-
-    Copyright (c) 2023 DrHB
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
-    _____________________
-
-    Original implementation: https://github.com/DrHB/icecube-2nd-place/blob/main/src/dataset.py
+    Original implementation:
+    https://github.com/DrHB/icecube-2nd-place/blob/main/src/dataset.py
     """
 
     def __init__(
@@ -157,30 +160,8 @@ def gather_len_matched_buckets(
 class LenMatchBatchSampler(BatchSampler, Logger):
     """A `BatchSampler` that batches similar length events.
 
-    MIT License
-
-    Copyright (c) 2023 DrHB
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
-    _____________________
-
-    Original implementation: https://github.com/DrHB/icecube-2nd-place/blob/main/src/dataset.py
+    Original implementation:
+    https://github.com/DrHB/icecube-2nd-place/blob/main/src/dataset.py
     """
 
     def __init__(
@@ -195,20 +176,21 @@ class LenMatchBatchSampler(BatchSampler, Logger):
     ) -> None:
         """Construct `LenMatchBatchSampler`.
 
-        This `BatchSampler` groups data with similar lengths to be more efficient
-        in operations like masking for MultiHeadAttention. Since batch samplers
-        run on the main process and can result in a CPU bottleneck, `num_workers`
-        can be specified to use multiprocessing for creating the batches. The
-        `bucket_width` argument specifies how wide the bins are for grouping batches.
-        For example, with `bucket_width=16`, data with length [1, 16] are grouped into
-        a bucket, data with length [17, 32] into another, etc.
+        This `BatchSampler` groups data with similar lengths to be more
+        efficient in operations like masking for MultiHeadAttention. Since
+        batch samplers run on the main process and can result in a CPU
+        bottleneck, `num_workers` can be specified to use multiprocessing for
+        creating the batches. The `bucket_width` argument specifies how wide
+        the bins are for grouping batches. For example, with `bucket_width=16`,
+        data with length [1, 16] are grouped into a bucket, data with length
+        [17, 32] into another, etc.
 
         Args:
             sampler: A `Sampler` object that selects/draws data in some way.
             batch_size: Batch size.
             num_workers: Number of workers to spawn to create batches.
             bucket_width: Size of length buckets for grouping data.
-            chunks_per_segment: Number of chunks to group together for processing.
+            chunks_per_segment: Number of chunks to group together.
             multiprocessing_context: Start method for multiprocessing.
             drop_last: (Optional) Drop the last incomplete batch.
         """
@@ -237,7 +219,7 @@ class LenMatchBatchSampler(BatchSampler, Logger):
             n_chunks = len(self.sampler.chunks)
             n_segments = n_chunks // self._chunks_per_segment
 
-            # Split indices into nearly equal-sized segments amongst the workers
+            # Split indices into nearly equal-sized segments amongst workers
             segments = [
                 range(
                     sum(self.sampler.chunks[: i * self._chunks_per_segment]),


### PR DESCRIPTION
This pull request implements some changes to improve the speed of loading data with `ParquetDataset` using samplers, and a few minor changes.

The first change is the ability to add a `Sampler` and/or a `BatchSampler` into `GraphNeTDataModule` when the `DataLoader` is created. Generally, the sampler and batch sampler will need access to the dataset before being used in the dataloader, so they are created in `_create_dataloader`.

The other large change is the implementation of `RandomChunkSampler` and `LenMatchBatchSampler` from the 2nd place Kaggle competition winners. Essentially, the `RandomChunkSampler` will pick files randomly and the `LenMatchBatchSampler` will group events of similar length into batches. This is particularly useful for transformers since less time is spent padding/truncating sequences.

Right now, the sampler and batch sampler settings live in the dataloader kwargs. For example:
```python
train_dataloader_kwargs={
    "batch_size": 256,
    "num_workers": 4,
    "multiprocessing_context": "spawn",
    "sampler": RandomChunkSampler,
    "sampler_kwargs": {},
    "batch_sampler": LenMatchBatchSampler,
    "batch_sampler_kwargs": {
        "batch_size": config["batch_size"],
        "num_workers": 4,
        "drop_last": True,
        "multiprocessing_context": "spawn",
    }, 
},
```
This has some pros and cons. The method for creating these objects in `GraphNeTDataModule` in `_create_dataloader` means that the train, test, and validation dataloaders can each have their own samplers/batch samplers. However, this means that the extra keys in the kwargs must be removed before creating the dataloader.

I should clarify that the implementation of the `LenMatchBatchSampler` is a little different than the original implementation. I noticed that the batch sampler was a CPU bottleneck for training when using large batch sizes. I think this is because batch samplers run on the main process, so I implemented a method to use multiprocessing to speed that up. This means that you will have fewer cores loading in files, but I found that forming batches was actually the main bottleneck for my use case. When `num_workers > 0`, the files are grouped into segments for each worker to process. For example, when `chunks_per_segment = 8`, each worker will length-match batches from 8 files and return any leftover/incomplete batches. When all of the complete batches are finished, the leftovers are combined to form batches. The `num_workers = 0` case should be very close to the original implementation.

In terms of performance, I saw a 2-4x increase in training speed (batches/sec) when training large transformer models w/ large batch sizes compared to the normal sampling methods.

A smaller change is renaming the "batch" labeled variables in `ParquetDataset` to "chunk" to clarify that they are not batches. In fact, I don't think any sort of batching should occur in the dataloaders.

