### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 exclude: '^(versioneer.py|src/graphnet/_version.py|docs/)'
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
     - id: black
       language_version: python3
       args: [--config=black.toml]
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
     - id: flake8
       language_version: python3
   - repo: https://github.com/pycqa/docformatter
-    rev: v1.5.0
+    rev: v1.7.5
     hooks:
     - id: docformatter
       language_version: python3
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
     - id: pydocstyle
       language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.13.0
     hooks:
     - id: mypy
       args: [--follow-imports=silent, --disallow-untyped-defs, --disallow-incomplete-defs, --disallow-untyped-calls]


### PR DESCRIPTION
Try to fix the broken pre-commit as described in issue #757. We might have to force this commit through even if the hooks fail due to the nature of what this is trying to fix...

All that was done in this commit was run pre-commit autoupdate and commiting the changes to the [.pre-commit-config.yaml](https://github.com/graphnet-team/graphnet/pull/758/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9)

This is where I got the idea that this might fix the issue https://stackoverflow.com/questions/79057817/invalidmanifesterror-at-key-language-expected-one-of-but-got-python-venv