### PR TITLE
Addressing issue #753 by adding feature mapping for the Fourier Encoder

### DIFF
--- a/examples/04_training/06_train_icemix_model.py
+++ b/examples/04_training/06_train_icemix_model.py
@@ -149,7 +149,7 @@ def main(
             "add_norm_layer": True,
             "skip_readout": True,
         },
-        feature_mapping=[0, 1, 2, 3, None, None],
+        fourier_mapping = [0, 1, 2, 3, None, None],
     )
     task = DirectionReconstructionWithKappa(
         hidden_size=backbone.nb_outputs,

--- a/examples/04_training/06_train_icemix_model.py
+++ b/examples/04_training/06_train_icemix_model.py
@@ -149,7 +149,7 @@ def main(
             "add_norm_layer": True,
             "skip_readout": True,
         },
-        n_features=len(features),
+        feature_mapping=[0, 1, 2, 3, None, None],
     )
     task = DirectionReconstructionWithKappa(
         hidden_size=backbone.nb_outputs,

--- a/src/graphnet/models/components/embedding.py
+++ b/src/graphnet/models/components/embedding.py
@@ -55,9 +55,9 @@ class FourierEncoder(LightningModule):
 
     This module incorporates sinusoidal positional embeddings and auxiliary
     embeddings to process input sequences and produce meaningful
-    representations. The module assumes that the input data is in the format of
-    (x, y, z, time, charge, auxiliary), being the first four features
-    mandatory.
+    representations. The features x, y, z and time are mandatory, while charge
+    and auxiliary are optional. Please use the mapping to ensure correct fourier
+    encoding.
     """
 
     def __init__(
@@ -66,7 +66,7 @@ class FourierEncoder(LightningModule):
         mlp_dim: Optional[int] = None,
         output_dim: int = 384,
         scaled: bool = False,
-        n_features: int = 6,
+        mapping: list = [0, 1, 2, 3, 4, 5],
     ):
         """Construct `FourierEncoder`.
 
@@ -79,23 +79,29 @@ class FourierEncoder(LightningModule):
                 depending on `n_features`.
             output_dim: Dimension of the output (I.e. number of columns).
             scaled: Whether or not to scale the embeddings.
-            n_features: The number of features in the input data.
+            mapping: Mapping of the data to [x,y,z,time,charge,auxiliary]. Use None for missing features.
         """
         super().__init__()
-
+        self.mapping_str = ["x", "y", "z", "time", "charge", "auxiliary"]
+        self.mapping = mapping
+        self.n_features = len([i for i in mapping if i is not None])
         self.sin_emb = SinusoidalPosEmb(dim=seq_length, scaled=scaled)
         self.sin_emb2 = SinusoidalPosEmb(dim=seq_length // 2, scaled=scaled)
 
-        if n_features < 4:
+        assert len(mapping) == 6, "Fourier mapping must have 6 elements. Use None for missing features."
+        assert all([isinstance(i, int) or i is None for i in mapping]), "Use int or None in fourier mapping."
+
+        if any([i is None for i in mapping[:4]]):
+            missing = [self.mapping_str[i] for i in range(4) if mapping[i] is None]
             raise ValueError(
-                f"At least x, y, z and time of the DOM are required. Got only "
-                f"{n_features} features."
+                f"x, y, z and time of the DOM are required."
+                f"{missing} missing in mapping."
             )
-        elif n_features >= 6:
+        elif self.n_features == 6:
             self.aux_emb = nn.Embedding(2, seq_length // 2)
             hidden_dim = 6 * seq_length
         else:
-            hidden_dim = int((n_features + 0.5) * seq_length)
+            hidden_dim = int((self.n_features + 0.5) * seq_length)
 
         if mlp_dim is None:
             mlp_dim = hidden_dim
@@ -107,7 +113,6 @@ class FourierEncoder(LightningModule):
             nn.Linear(mlp_dim, output_dim),
         )
 
-        self.n_features = n_features
 
     def forward(
         self,
@@ -115,16 +120,21 @@ class FourierEncoder(LightningModule):
         seq_length: Tensor,
     ) -> Tensor:
         """Forward pass."""
+        if max(self.mapping)+1 > x.shape[2]:
+            raise IndexError(f"Fourier mapping does not fit given data."
+                             f"Feature space of data is too small (size {x.shape[2]})," 
+                             f"given fourier mapping requires at least {max(self.mapping) + 1}.")
+
         length = torch.log10(seq_length.to(dtype=x.dtype))
-        embeddings = [self.sin_emb(4096 * x[:, :, :3]).flatten(-2)]  # Position
+        embeddings = [self.sin_emb(4096 * x[:, :, self.mapping[:3]]).flatten(-2)]  # Position
 
         if self.n_features >= 5:
-            embeddings.append(self.sin_emb(1024 * x[:, :, 4]))  # Charge
+            embeddings.append(self.sin_emb(1024 * x[:, :, self.mapping[4]]))  # Charge
 
-        embeddings.append(self.sin_emb(4096 * x[:, :, 3]))  # Time
+        embeddings.append(self.sin_emb(4096 * x[:, :, self.mapping[3]]))  # Time
 
-        if self.n_features >= 6:
-            embeddings.append(self.aux_emb(x[:, :, 5].long()))  # Auxiliary
+        if self.n_features == 6:
+            embeddings.append(self.aux_emb(x[:, :, self.mapping[5]].long()))  # Auxiliary
 
         embeddings.append(
             self.sin_emb2(length).unsqueeze(1).expand(-1, max(seq_length), -1)

--- a/src/graphnet/models/gnn/icemix.py
+++ b/src/graphnet/models/gnn/icemix.py
@@ -43,7 +43,7 @@ class DeepIce(GNN):
         scaled_emb: bool = False,
         include_dynedge: bool = False,
         dynedge_args: Dict[str, Any] = None,
-        n_features: int = 6,
+        fourier_mapping: list = [0,1,2,3,4,5]
     ):
         """Construct `DeepIce`.
 
@@ -62,7 +62,8 @@ class DeepIce(GNN):
                 provided, DynEdge will be initialized with the original Kaggle
                 Competition settings. If `include_dynedge` is False, this
                 argument have no impact.
-            n_features: The number of features in the input data.
+            fourier_mapping: Mapping of the data to [x,y,z,time,charge,auxiliary] 
+                for the FourierEncoder. Use None for missing features.
         """
         super().__init__(seq_length, hidden_dim)
         fourier_out_dim = hidden_dim // 2 if include_dynedge else hidden_dim
@@ -71,7 +72,7 @@ class DeepIce(GNN):
             mlp_dim=None,
             output_dim=fourier_out_dim,
             scaled=scaled_emb,
-            n_features=n_features,
+            mapping = fourier_mapping,
         )
         self.rel_pos = SpacetimeEncoder(head_size)
         self.sandwich = nn.ModuleList(

--- a/src/graphnet/models/graphs/nodes/nodes.py
+++ b/src/graphnet/models/graphs/nodes/nodes.py
@@ -357,8 +357,8 @@ class IceMixNodes(NodeDefinition):
                     f"input_feature_names {input_feature_names}"
                 )
             self.all_features = input_feature_names + [
-                "scatt_lenght",
-                "abs_lenght",
+                "scatt_length",
+                "abs_length",
             ]
             self.f_scattering, self.f_absoprtion = ice_transparency(**ice_args)
         else:


### PR DESCRIPTION
**Fix for issue #753 :**
- `FourierEncoder` (which is used in IceMix model) previously assumed a specific structure for the feature dimension, which caused issues with certain datasets (e.g. using standard `FEATURES.ICECUBE86`).
- Now, `FourierEncoder` accepts a simple list of `int` or `None` to map the corresponding features of the data to the features used in `FourierEncoder`.
- The Fourier mapping can be passed during the initialization of the `DeepIce` model. Specifying `n_features` is no longer required.

**Minor Fixes:**
- Fixed small typos within `IceMixNodes`.