### PR TITLE
Autofix: I3InferenceModule doesn't recognize a list of length 1

### DIFF
--- a/src/graphnet/deployment/icecube/inference_module.py
+++ b/src/graphnet/deployment/icecube/inference_module.py
@@ -133,14 +133,15 @@ class I3InferenceModule(DeploymentModule):
         """Apply model to `Data` and case-handling."""
         if data is not None:
             predictions = self._inference(data)
-            if isinstance(predictions, list):
+            if isinstance(predictions, list) and len(predictions) > 1:
                 predictions = predictions[0]
-                self.warning(
-                    f"{self.__class__.__name__} assumes one Task "
-                    f"but got {len(predictions)}. Only the first will"
-                    " be used."
+                logger = Logger()
+                logger.warning_once(
+                    f"{self.__class__.__name__} assumes one Task 
+                    f"but got {len(predictions)}. Only the first will be used."
                 )
-        else:
+            elif isinstance(predictions, list):
+                predictions = predictions[0]
             self.warning(
                 "At least one event has no pulses "
                 " - padding {self.prediction_columns} with NaN."


### PR DESCRIPTION
This change modifies the I3InferenceModule to avoid spamming warnings when there's only one task. It now checks the length of the predictions list and uses warning_once to prevent repeated warnings. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    