### PR TITLE
Add Models for TRIDENT Detector in Graphnet

### DIFF
--- a/src/graphnet/models/MiddleReconModel.py
+++ b/src/graphnet/models/MiddleReconModel.py
@@ -1,0 +1,500 @@
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Union, Type
+
+import numpy as np
+import torch
+from pytorch_lightning import Callback, Trainer
+from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
+from torch import Tensor
+from torch.optim import Adam
+from torch.utils.data import DataLoader, SequentialSampler
+from torch_geometric.data import Data
+import pandas as pd
+from pytorch_lightning.loggers import Logger as LightningLogger
+
+from graphnet.training.callbacks import ProgressBar
+from graphnet.models.model import Model
+from pytorch_lightning.strategies import DDPStrategy
+
+class MiddleReconModel(Model):
+    """A suggested Model class that comes with simple user syntax.
+
+    This class delivers simple user syntax for training and prediction, while
+    imposing minimal constraints on structure.
+    """
+
+    def __init__(
+        self,
+        *,
+        backbone: Model = None,
+        optimizer_class: Type[torch.optim.Optimizer] = Adam,
+        optimizer_kwargs: Optional[Dict] = None,
+        scheduler_class: Optional[type] = None,
+        scheduler_kwargs: Optional[Dict] = None,
+        scheduler_config: Optional[Dict] = None,
+    ) -> None:
+        """Construct `StandardModel`."""
+        # Base class constructor
+        super().__init__(name=__name__, class_name=self.__class__.__name__)
+
+        # Member variable(s)
+        self._optimizer_class = optimizer_class
+        self._optimizer_kwargs = optimizer_kwargs or dict()
+        self._scheduler_class = scheduler_class
+        self._scheduler_kwargs = scheduler_kwargs or dict()
+        self._scheduler_config = scheduler_config or dict()
+        self.backbone = backbone
+
+    def compute_loss(
+        self, outputs: Tensor, data: List[Data], verbose: bool = False
+    ) -> Tensor:
+        """Compute and sum losses."""
+        data_merged: Dict[str, Tensor] = {}
+        data_merged['inject_pos'] = torch.cat([d['inject_pos'] for d in data], dim=0).float()
+        # print(outputs)
+        # print(data['inject_pos'])
+        loss = torch.nn.functional.mse_loss(outputs, data_merged['inject_pos'])
+
+        if verbose:
+            self.info(f"Loss: {loss.item()}")
+        return loss
+
+    def forward(
+        self, data: Union[Data, List[Data]]
+    ) -> Tensor:
+        """Forward pass, chaining model components."""
+        if isinstance(data, Data):
+            data = [data]
+        output_list, pred_list = [], []
+        for d in data:
+            output,pred = self.backbone(d)
+            output_list.append(output.float())
+            pred_list.append(pred.float())
+        outputs = torch.cat(output_list, dim=0)
+        preds = torch.cat(pred_list, dim=0)
+
+        return outputs, preds
+
+    def shared_step(self, batch: List[Data], batch_idx: int) -> Tensor:
+        """Perform shared step.
+
+        Applies the forward pass and the following loss calculation, shared
+        between the training and validation step.
+        """
+        outputs, preds = self(batch)
+        loss = self.compute_loss(outputs, batch)
+        return loss
+
+    @staticmethod
+    def _construct_trainer(
+        max_epochs: int = 10,
+        gpus: Optional[Union[List[int], int]] = None,
+        callbacks: Optional[List[Callback]] = None,
+        logger: Optional[LightningLogger] = None,
+        log_every_n_steps: int = 1,
+        gradient_clip_val: Optional[float] = None,
+        # distribution_strategy: Optional[str] = "ddp",
+        strategy: Optional[Union[str, DDPStrategy]] = None,
+        **trainer_kwargs: Any,
+    ) -> Trainer:
+        if gpus:
+            accelerator = "gpu"
+            devices = gpus
+        else:
+            accelerator = "cpu"
+            devices = 1
+
+        trainer = Trainer(
+            accelerator=accelerator,
+            devices=devices,
+            max_epochs=max_epochs,
+            callbacks=callbacks,
+            log_every_n_steps=log_every_n_steps,
+            logger=logger,
+            gradient_clip_val=gradient_clip_val,
+            strategy=strategy,
+            **trainer_kwargs,
+        )
+
+        return trainer
+
+    def fit(
+        self,
+        train_dataloader: DataLoader,
+        val_dataloader: Optional[DataLoader] = None,
+        *,
+        max_epochs: int = 10,
+        early_stopping_patience: int = 5,
+        gpus: Optional[Union[List[int], int]] = None,
+        callbacks: Optional[List[Callback]] = None,
+        ckpt_path: Optional[str] = None,
+        logger: Optional[LightningLogger] = None,
+        log_every_n_steps: int = 1,
+        gradient_clip_val: Optional[float] = None,
+        distribution_strategy: Optional[str] = "ddp",
+        **trainer_kwargs: Any,
+    ) -> None:
+        # Checks
+        if callbacks is None:
+            # We create the bare-minimum callbacks for you.
+            callbacks = self._create_default_callbacks(
+                val_dataloader=val_dataloader,
+                early_stopping_patience=early_stopping_patience,
+            )
+            self.debug("No Callbacks specified. Default callbacks added.")
+        else:
+            # You are on your own!
+            self.debug("Initializing training with user-provided callbacks.")
+            pass
+        self._print_callbacks(callbacks)
+        has_early_stopping = self._contains_callback(callbacks, EarlyStopping)
+        has_model_checkpoint = self._contains_callback(
+            callbacks, ModelCheckpoint
+        )
+
+        if (has_early_stopping) & (has_model_checkpoint is False):
+            self.warning(
+                "No ModelCheckpoint found in callbacks. Best-fit model will"
+                " not automatically be loaded after training!"
+                ""
+            )
+        strategy = DDPStrategy(find_unused_parameters=True) if distribution_strategy == "ddp" else distribution_strategy
+        self.train(mode=True)
+        trainer = self._construct_trainer(
+            max_epochs=max_epochs,
+            gpus=gpus,
+            callbacks=callbacks,
+            logger=logger,
+            log_every_n_steps=log_every_n_steps,
+            gradient_clip_val=gradient_clip_val,
+            # distribution_strategy=distribution_strategy,
+            strategy=strategy,
+            **trainer_kwargs,
+        )
+
+        try:
+            trainer.fit(
+                self, train_dataloader, val_dataloader, ckpt_path=ckpt_path
+            )
+        except KeyboardInterrupt:
+            self.warning("[ctrl+c] Exiting gracefully.")
+            pass
+
+        # Load weights from best-fit model after training if possible
+        if has_early_stopping & has_model_checkpoint:
+            for callback in callbacks:
+                if isinstance(callback, ModelCheckpoint):
+                    checkpoint_callback = callback
+            self.load_state_dict(
+                torch.load(checkpoint_callback.best_model_path)["state_dict"]
+            )
+            self.info("Best-fit weights from EarlyStopping loaded.")
+
+    def _print_callbacks(self, callbacks: List[Callback]) -> None:
+        callback_names = []
+        for cbck in callbacks:
+            callback_names.append(cbck.__class__.__name__)
+        self.info(
+            f"Training initiated with callbacks: {', '.join(callback_names)}"
+        )
+
+    def _contains_callback(
+        self, callbacks: List[Callback], callback: Callback
+    ) -> bool:
+        """Check if `callback` is in `callbacks`."""
+        for cbck in callbacks:
+            if isinstance(cbck, callback):
+                return True
+        return False
+
+    def configure_optimizers(self) -> Dict[str, Any]:
+        """Configure the model's optimizer(s)."""
+        optimizer = self._optimizer_class(
+            self.parameters(), **self._optimizer_kwargs
+        )
+        config = {
+            "optimizer": optimizer,
+        }
+        if self._scheduler_class is not None:
+            scheduler = self._scheduler_class(
+                optimizer, **self._scheduler_kwargs
+            )
+            config.update(
+                {
+                    "lr_scheduler": {
+                        "scheduler": scheduler,
+                        **self._scheduler_config,
+                    },
+                }
+            )
+        return config
+
+    def training_step(
+        self, train_batch: Union[Data, List[Data]], batch_idx: int
+    ) -> Tensor:
+        """Perform training step."""
+        if isinstance(train_batch, Data):
+            train_batch = [train_batch]
+        loss = self.shared_step(train_batch, batch_idx)
+        self.log(
+            "train_loss",
+            loss,
+            batch_size=self._get_batch_size(train_batch),
+            prog_bar=True,
+            on_epoch=True,
+            on_step=False,
+            sync_dist=True,
+        )
+
+        current_lr = self.trainer.optimizers[0].param_groups[0]["lr"]
+        self.log("lr", current_lr, prog_bar=True, on_step=True)
+        return loss
+
+    def validation_step(
+        self, val_batch: Union[Data, List[Data]], batch_idx: int
+    ) -> Tensor:
+        """Perform validation step."""
+        if isinstance(val_batch, Data):
+            val_batch = [val_batch]
+        loss = self.shared_step(val_batch, batch_idx)
+        self.log(
+            "val_loss",
+            loss,
+            batch_size=self._get_batch_size(val_batch),
+            prog_bar=True,
+            on_epoch=True,
+            on_step=False,
+            sync_dist=True,
+        )
+        return loss
+    
+    def predict_step(
+        self, batch: Union[Data, List[Data]], batch_idx: int
+    ):
+        """Perform prediction step."""
+        if isinstance(batch, Data):
+            batch = [batch]
+        outputs, preds = self(batch)
+        return {"outputs": outputs, "preds": preds}
+
+    def inference(self) -> None:
+        """Activate inference mode."""
+        self.eval()
+
+    def train(self, mode: bool = True) -> "Model":
+        """Deactivate inference mode."""
+        super().train(mode)
+        return self
+
+    def predict(
+        self,
+        dataloader: DataLoader,
+        gpus: Optional[Union[List[int], int]] = None,
+        distribution_strategy: Optional[str] = "auto",
+    ) -> dict:
+        """Return predictions for `dataloader`."""
+        self.inference()
+        self.train(mode=False)
+
+        callbacks = self._create_default_callbacks(
+            val_dataloader=None,
+        )
+
+        inference_trainer = self._construct_trainer(
+            gpus=gpus,
+            distribution_strategy=distribution_strategy,
+            callbacks=callbacks,
+        )
+
+        predictions_list = inference_trainer.predict(self, dataloader)
+        assert len(predictions_list), "Got no predictions"
+
+        outputs = [l['outputs'] for l in predictions_list]
+        outputs: List[Tensor] = [
+            torch.cat([output[ix] for output in outputs], dim=0)
+            for ix in range(len(outputs[0]))
+        ]
+
+        predictions = [l['preds'] for l in predictions_list]
+        predictions: List[Tensor] = [
+            torch.cat([preds[ix] for preds in predictions], dim=0)
+            for ix in range(len(predictions[0]))
+        ]
+        return {"outputs": outputs, "preds": predictions}
+
+
+    def predict_as_dataframe(
+        self,
+        dataloader: DataLoader,
+        prediction_columns: Optional[List[str]] = None,
+        *,
+        additional_attributes: Optional[List[str]] = None,
+        gpus: Optional[Union[List[int], int]] = None,
+        distribution_strategy: Optional[str] = "auto",
+    ) -> pd.DataFrame:
+        """Return predictions for `dataloader` as a DataFrame.
+
+        Include `additional_attributes` as additional columns in the output
+        DataFrame.
+        """
+        if prediction_columns is None:
+            prediction_columns = self.prediction_labels
+
+        if additional_attributes is None:
+            additional_attributes = []
+        assert isinstance(additional_attributes, list)
+
+        if (
+            not isinstance(dataloader.sampler, SequentialSampler)
+            and additional_attributes
+        ):
+            print(dataloader.sampler)
+            raise UserWarning(
+                "DataLoader has a `sampler` that is not `SequentialSampler`, "
+                "indicating that shuffling is enabled. Using "
+                "`predict_as_dataframe` with `additional_attributes` assumes "
+                "that the sequence of batches in `dataloader` are "
+                "deterministic. Either call this method a `dataloader` which "
+                "doesn't resample batches; or do not request "
+                "`additional_attributes`."
+            )
+        self.info(f"Column names for predictions are: \n {prediction_columns}")
+        predictions_torch = self.predict(
+            dataloader=dataloader,
+            gpus=gpus,
+            distribution_strategy=distribution_strategy,
+        )
+        outputs, predictions = predictions_torch["outputs"], predictions_torch["preds"]
+        predictions = (
+            torch.cat(predictions, dim=1).detach().cpu().numpy()
+        )
+        assert len(prediction_columns) == predictions.shape[1], (
+            f"Number of provided column names ({len(prediction_columns)}) and "
+            f"number of output columns ({predictions.shape[1]}) don't match."
+        )
+
+        # Check if predictions are on event- or pulse-level
+        pulse_level_predictions = len(predictions) > len(dataloader.dataset)
+
+        # Get additional attributes
+        attributes: Dict[str, List[np.ndarray]] = OrderedDict(
+            [(attr, []) for attr in additional_attributes]
+        )
+        for batch in dataloader:
+            for attr in attributes:
+                attribute = batch[attr]
+                if isinstance(attribute, torch.Tensor):
+                    attribute = attribute.detach().cpu().numpy()
+
+                # Check if node level predictions
+                # If true, additional attributes are repeated
+                # to make dimensions fit
+                if pulse_level_predictions:
+                    if len(attribute) < np.sum(
+                        batch.n_pulses.detach().cpu().numpy()
+                    ):
+                        attribute = np.repeat(
+                            attribute, batch.n_pulses.detach().cpu().numpy()
+                        )
+                attributes[attr].extend(attribute)
+
+        # Confirm that attributes match length of predictions
+        skip_attributes = []
+        for attr in attributes.keys():
+            try:
+                assert len(attributes[attr]) == len(predictions)
+            except AssertionError:
+                self.warning_once(
+                    "Could not automatically adjust length"
+                    f" of additional attribute '{attr}' to match length of"
+                    f" predictions.This error can be caused by heavy"
+                    " disagreement between number of examples in the"
+                    " dataset vs. actual events in the dataloader, e.g. "
+                    " heavy filtering of events in `collate_fn` passed to"
+                    " `dataloader`. This can also be caused by requesting"
+                    " pulse-level attributes for `Task`s that produce"
+                    " event-level predictions. Attribute skipped."
+                )
+                skip_attributes.append(attr)
+
+        # Remove bad attributes
+        for attr in skip_attributes:
+            attributes.pop(attr)
+            additional_attributes.remove(attr)
+
+        data = np.concatenate(
+            [predictions]
+            + [
+                np.asarray(values)[:, np.newaxis]
+                for values in attributes.values()
+            ],
+            axis=1,
+        )
+
+        results = pd.DataFrame(
+            data, columns=prediction_columns + additional_attributes
+        )
+        outputs = pd.DataFrame(
+            outputs.detach().cpu().numpy(),
+        )
+        return results, outputs
+
+    def _create_default_callbacks(
+        self,
+        val_dataloader: DataLoader,
+        early_stopping_patience: Optional[int] = None,
+    ) -> List:
+        """Create default callbacks.
+
+        Used in cases where no callbacks are specified by the user in .fit
+        """
+        callbacks = [ProgressBar()]
+        if val_dataloader is not None:
+            assert early_stopping_patience is not None
+            # Add Early Stopping
+            callbacks.append(
+                EarlyStopping(
+                    monitor="val_loss",
+                    patience=early_stopping_patience,
+                )
+            )
+            # Add Model Check Point
+            callbacks.append(
+                ModelCheckpoint(
+                    save_top_k=1,
+                    monitor="val_loss",
+                    mode="min",
+                    filename=f"{self.backbone.__class__.__name__}"
+                    + "-{epoch}-{val_loss:.2f}-{train_loss:.2f}",
+                )
+            )
+            self.info(
+                "EarlyStopping has been added"
+                f" with a patience of {early_stopping_patience}."
+            )
+        return callbacks
+
+    def _add_early_stopping(
+        self, val_dataloader: DataLoader, callbacks: List
+    ) -> List:
+        if val_dataloader is None:
+            return callbacks
+        has_early_stopping = False
+        assert isinstance(callbacks, list)
+        for callback in callbacks:
+            if isinstance(callback, EarlyStopping):
+                has_early_stopping = True
+
+        if not has_early_stopping:
+            callbacks.append(
+                EarlyStopping(
+                    monitor="val_loss",
+                    patience=5,
+                )
+            )
+            self.warning_once(
+                "Got validation dataloader but no EarlyStopping callback. An "
+                "EarlyStopping callback has been added automatically with "
+                "patience=5 and monitor = 'val_loss'."
+            )
+        return callbacks

--- a/src/graphnet/models/gnn/TridentNet.py
+++ b/src/graphnet/models/gnn/TridentNet.py
@@ -1,0 +1,162 @@
+import torch
+from graphnet.models import Model
+from torch_geometric.data import Data
+import torch
+import torch_geometric
+default_net_setting = { 
+            "conv_params": [
+                (16, (64, 64, 64)),
+                (16, (128, 128, 128)),
+                (16, (256, 256, 256)),
+                (16, (512, 512, 512)),
+            ],
+            "fc_params": [
+                (0.1, 256),
+                (0.05, 32),
+            ],
+            # "global_dim": 128,
+            "input_features": 6,
+            "output_classes": 3,
+        }
+
+class StaticEdgeConv(torch_geometric.nn.MessagePassing):
+    def __init__(self, in_channels, out_channels):
+        super(StaticEdgeConv, self).__init__(aggr='max')
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(2 * in_channels + in_channels, out_channels[0], bias=False),
+            torch_geometric.nn.BatchNorm(out_channels[0]),
+            torch.nn.ReLU(),
+            torch.nn.Linear(out_channels[0], out_channels[1], bias=False),
+            torch_geometric.nn.BatchNorm(out_channels[1]),
+            torch.nn.ReLU(),
+            torch.nn.Linear(out_channels[1], out_channels[2], bias=False),
+            torch_geometric.nn.BatchNorm(out_channels[2]),
+            torch.nn.ReLU()
+        )
+    def forward(self, x, edge_index, k, u=None):
+
+        return self.propagate(edge_index, size=(x.size(0), x.size(0)), x=x, u=u)
+
+    def message(self, edge_index, x_i, x_j, u_i, u_j):
+        tmp = torch.cat([u_i, x_i, x_j], dim = 1)
+
+        out_mlp = self.mlp(tmp)
+
+        return out_mlp
+
+    def update(self, aggr_out):
+        return aggr_out
+
+class DynamicEdgeConv(StaticEdgeConv):
+    def __init__(self, in_channels, out_channels, k=7):
+        super(DynamicEdgeConv, self).__init__(in_channels, out_channels)
+        self.k = k
+        self.skip_mlp = torch.nn.Sequential(
+            torch.nn.Linear(in_channels, out_channels[2], bias=False),
+            torch_geometric.nn.BatchNorm(out_channels[2]),
+        )
+        self.act = torch.nn.ReLU()
+
+    def forward(self, pts, fts, batch=None, u=None):
+        edges = torch_geometric.nn.knn_graph(pts, self.k, batch, loop=False, flow=self.flow)
+        aggrg = super(DynamicEdgeConv, self).forward(fts, edges, self.k, u[batch])
+        # aggrg = self.gcns(fts, edges)
+        x = self.skip_mlp(fts)
+        out = torch.add(aggrg, x)
+        return self.act(out)
+
+
+class TridentTrackNet(Model):
+    def __init__(self, settings, DEVICE):
+        super().__init__()
+        previous_output_shape = settings['input_features']
+
+        self.input_bn = torch_geometric.nn.BatchNorm(settings['input_features'])
+
+        self.global_process = torch.nn.ModuleList()
+
+        self.global_process.append(
+                torch.nn.Sequential(
+                    torch.nn.Linear(previous_output_shape, previous_output_shape),
+                    torch_geometric.nn.BatchNorm(previous_output_shape),
+                    torch.nn.ReLU()
+                )
+            )
+
+        self.conv_process = torch.nn.ModuleList()
+        for layer_idx, layer_param in enumerate(settings['conv_params']):
+            K, channels = layer_param
+            self.conv_process.append(DynamicEdgeConv(previous_output_shape, channels, k=K).to(DEVICE))
+            
+            self.global_process.append(
+                torch.nn.Sequential(
+                    torch.nn.Linear(previous_output_shape + channels[-1], channels[-1]),
+                    torch_geometric.nn.BatchNorm(channels[-1]),
+                    torch.nn.ReLU()
+                )
+            )
+            previous_output_shape = channels[-1]
+
+        self.fc_process = torch.nn.ModuleList()
+        for layer_idx, layer_param in enumerate(settings['fc_params']):
+            drop_rate, units = layer_param
+            seq = torch.nn.Sequential(
+                torch.nn.Linear(previous_output_shape, units),
+                torch.nn.Dropout(p=drop_rate),
+                torch.nn.ReLU()
+            ).to(DEVICE)
+            self.fc_process.append(seq)
+            previous_output_shape = units
+
+        self.output_mlp_linear = torch.nn.Linear(previous_output_shape, settings['output_classes'])
+        self.output_activation = torch.nn.Softmax(dim=1)
+
+    def LineFit(self, t, r, weights, event_no):
+        from torch_geometric import nn as tgnn
+        sum_weights = tgnn.global_add_pool(weights, event_no)
+        t0 = tgnn.global_add_pool(t*weights, event_no)
+        x0 = tgnn.global_add_pool(r[:,0]*weights, event_no)
+        y0 = tgnn.global_add_pool(r[:,1]*weights, event_no)
+        z0 = tgnn.global_add_pool(r[:,2]*weights, event_no)
+
+        xt = tgnn.global_add_pool(r[:,0]*t*weights, event_no)
+        yt = tgnn.global_add_pool(r[:,1]*t*weights, event_no)
+        zt = tgnn.global_add_pool(r[:,2]*t*weights, event_no)
+        tt = tgnn.global_add_pool(t*t*weights, event_no)
+
+        n = torch.stack([
+            xt - x0*t0 / sum_weights,
+            yt - y0*t0 / sum_weights,
+            zt - z0*t0 / sum_weights
+        ], dim=1)
+        n = n / (tt - t0*t0/sum_weights).view(-1, 1).float()
+        return n
+
+    def post_process(self, predict, batch):
+        node_pos = batch.x[:,0:3].float()
+        node_t = batch.t1st.float()
+        node_weight = batch.nhits.float()
+        preds = self.LineFit(node_t, node_pos+predict, node_weight, batch.batch)
+        return preds
+
+
+    def forward(self, batch: Data):
+        fts = self.input_bn(batch.x.float())
+        pts = batch.x[:,0:3].float()
+
+        u = torch_geometric.nn.global_mean_pool(fts, batch.batch)
+        u = self.global_process[0](u)
+
+        for idx, layer in enumerate(self.conv_process):
+            fts = layer(pts, fts, batch=batch.batch, u=u)
+            u = torch.cat([u, torch_geometric.nn.global_mean_pool(fts, batch.batch)], dim = 1)
+            u = self.global_process[idx+1](u)
+            pts = fts
+
+        x = fts
+        for layer in self.fc_process:
+            x = layer(x)
+
+        x = self.output_mlp_linear(x)
+        return x, self.post_process(x, batch)
+        

--- a/src/graphnet/models/graphs/TRIDENTGraphDefinition.py
+++ b/src/graphnet/models/graphs/TRIDENTGraphDefinition.py
@@ -1,0 +1,141 @@
+import numpy as np
+from typing import List, Optional, Dict, Any, Callable
+import torch
+from torch_geometric.data import Data
+from graphnet.models.graphs import GraphDefinition
+from TRIDENTNodeDefinition import TRIDENTNodeDefinition
+from torch_geometric.data import Data
+from graphnet.models.detector.detector import Detector
+from graphnet.constants import PROMETHEUS_GEOMETRY_TABLE_DIR
+import os
+import math
+
+class TRIDENT(Detector):
+    geometry_table_path = os.path.join(
+        PROMETHEUS_GEOMETRY_TABLE_DIR, "trident.parquet"
+    )
+    xyz = ["sensor_pos_x", "sensor_pos_y", "sensor_pos_z"]
+    string_id_column = "sensor_string_id"
+    sensor_id_column = "sensor_id"
+
+    def feature_map(self) -> Dict[str, Callable]:
+        feature_map = {
+            "sensor_pos_x": self._sensor_pos_xy,
+            "sensor_pos_y": self._sensor_pos_xy,
+            "sensor_pos_z": self._sensor_pos_z,
+            "t": self._t,
+        }
+        return feature_map
+
+    def _sensor_pos_xy(self, x: torch.tensor) -> torch.tensor:
+        return x
+
+    def _sensor_pos_z(self, x: torch.tensor) -> torch.tensor:
+        return x
+
+    def _t(self, x: torch.tensor) -> torch.tensor:
+        return x# / 1.05e04
+
+
+class TRIDENTGraphDefinition(GraphDefinition):
+    def __init__(
+        self,
+        detector: TRIDENT = TRIDENT(),
+        node_definition: TRIDENTNodeDefinition = TRIDENTNodeDefinition(),
+        input_feature_names: Optional[List[str]] = None,
+    ) -> None:
+        
+        super().__init__(
+            detector=detector,
+            node_definition=node_definition,
+            )
+
+    def forward(  # type: ignore
+        self,
+        input_features: np.ndarray,
+        input_feature_names: List[str],
+        truth_dicts: Optional[List[Dict[str, Any]]] = None,
+        custom_label_functions: Optional[Dict[str, Callable[..., Any]]] = None,
+        loss_weight_column: Optional[str] = None,
+        loss_weight: Optional[float] = None,
+        loss_weight_default_value: Optional[float] = None,
+        data_path: Optional[str] = None,
+    ) -> Data:
+        
+        # print("MyGraphDefinition.forward input_features: ", input_features)
+        # Checks
+        self._validate_input(
+            input_features=input_features,
+            input_feature_names=input_feature_names,
+        )
+        
+        # Transform to pytorch tensor
+        input_features = torch.tensor(input_features, dtype=self.dtype)
+
+        # Standardize / Scale  node features
+        input_features = self._detector(input_features, input_feature_names)
+        
+        # Create graph & get new node feature names
+        graph, node_feature_names = self._node_definition(input_features)
+
+        # Enforce dtype
+        graph.x = graph.x.type(self.dtype)
+
+        # Attach number of pulses as static attribute.
+        graph.n_pulses = torch.tensor(len(input_features), dtype=torch.int32)
+
+        # Assign edges
+        if self._edge_definition is not None:
+            graph = self._edge_definition(graph)
+
+        # Attach data path - useful for Ensemble datasets.
+        if data_path is not None:
+            graph["dataset_path"] = data_path
+
+        # Attach loss weights if they exist
+        graph = self._add_loss_weights(
+            graph=graph,
+            loss_weight=loss_weight,
+            loss_weight_column=loss_weight_column,
+            loss_weight_default_value=loss_weight_default_value,
+        )
+
+        # Attach default truth labels and node truths
+        if truth_dicts is not None:
+            graph = self._add_truth(graph=graph, truth_dicts=truth_dicts)
+
+        # Attach custom truth labels
+        if custom_label_functions is not None:
+            graph = self._add_custom_labels(
+                graph=graph, custom_label_functions=custom_label_functions
+            )
+
+
+        # Attach node features as seperate fields. MAY NOT CONTAIN 'x'
+        graph = self._add_features_individually(
+            graph=graph, node_feature_names=node_feature_names
+        )
+
+        if len(input_features) > 0:
+            first_hit = input_features[torch.min(input_features[:, 3],dim=0)[1]]
+            graph.pos = torch.stack([graph.nx*graph.norm_xyz,graph.ny*graph.norm_xyz,graph.nz*graph.norm_xyz],dim=1)
+            graph.vertex = torch.stack([graph.initial_state_x,graph.initial_state_y,graph.initial_state_z],dim=1) - first_hit[0:3]
+            graph.inject_pos = self.inject_pos(graph)
+            
+        # Add GraphDefinition Stamp
+        graph["graph_definition"] = self.__class__.__name__
+        return graph    
+    
+    def inject_pos(self, graph):
+
+        n_water = 1.385  # for pure water
+        costh = 1 / n_water
+        tanth = math.sqrt(1 - costh*costh) / costh
+        graph.vertex = graph.vertex.view(-1)
+        graph.direction = graph.direction.view(-1)
+
+        vr = graph.pos - graph.vertex
+        l = (vr * graph.direction).sum(dim=1).view(-1,1)
+        d = ((vr**2).sum(dim=1).view(-1,1) - l**2).clip(min=0)**0.5
+        inject_pos = graph.vertex + (l -  d / tanth) * graph.direction - graph.pos
+        return inject_pos

--- a/src/graphnet/models/graphs/nodes/TRIDENTNodeDefinition.py
+++ b/src/graphnet/models/graphs/nodes/TRIDENTNodeDefinition.py
@@ -1,0 +1,80 @@
+import numpy as np
+from typing import List
+import torch
+from torch_geometric.data import Data
+from graphnet.models.graphs.nodes import NodeDefinition
+
+class TRIDENTNodeDefinition(NodeDefinition):
+
+    def __init__(
+        self,
+        output_feature_names: List[str] = [
+            "nx","ny","nz","t1st","nhits","norm_xyz",
+        ],
+        keys: List[str] = [
+            "sensor_pos_x",
+            "sensor_pos_y",
+            "sensor_pos_z",
+            "t",
+        ],
+        id_columns: List[str] = ["sensor_pos_x", "sensor_pos_y", "sensor_pos_z"],
+        time_column: str = "t",
+    ) -> None:
+        
+        self._keys = keys
+        self._input_feature_names = self._keys
+        self.output_feature_names = output_feature_names
+        super().__init__(input_feature_names=self._input_feature_names)
+
+        self._id_columns = [self._keys.index(key) for key in id_columns]
+        self._time_index = self._keys.index(time_column)
+
+    def _define_output_feature_names(
+        self, input_feature_names: List[str]
+    ) -> List[str]:
+        return self.output_feature_names
+
+    def _construct_nodes(self, x: torch.Tensor) -> Data:
+        print(f'Start. x shape: {x.shape}')
+        x = x.numpy()
+
+        if x.shape[0] == 0:
+            num_features = 6
+            zero_array = np.zeros((1, num_features))
+            return Data(x=torch.tensor(zero_array, dtype=torch.float))
+        
+        charge_index: int = len(self._keys)
+        norm_index: int = charge_index + 1
+        # Add charge and norm columns
+        x = np.insert(x, charge_index, np.zeros(x.shape[0]), axis=1)
+        x = np.insert(x, norm_index, np.zeros(x.shape[0]), axis=1)
+
+        # Sort by time, select origin as first hit dom
+        x = x[x[:, self._time_index].argsort()]
+        x[:, self._time_index] -= x[0, self._time_index]
+        x[:,self._id_columns] -= x[0, self._id_columns]
+
+        # Fill norm column
+        x[:, norm_index] = np.linalg.norm(x[:, self._id_columns], axis=1)
+        
+        x[:, self._id_columns] /= x[:, norm_index].reshape(-1, 1).clip(min=1e-6)
+        x[:, self._time_index] *= 0.2998
+
+        # Fill charge column
+        doms = x[:, self._id_columns]
+        unique_values, inverse, dom_counts = np.unique(doms, return_inverse=True, return_counts=True, axis=0)
+    
+        x[:, charge_index] = dom_counts[inverse] #/ len(doms)
+        
+        # group doms and set time to median time
+        x_= []
+        for ids in unique_values:
+            mask = np.where((x[:, self._id_columns] == ids).all(axis=1))[0]
+            t_median = np.median(x[mask, self._time_index])
+            x_.append([*ids, t_median, *x[mask[0], charge_index:]])
+        
+        x = np.array(x_)        
+        #node: [nx, ny, nz, t-t0, nhits, norm]
+        print(f'End. x shape: {x.shape}')
+        print(f'Num hits: {x[:, 4].sum()}')       
+        return Data(x=torch.tensor(x,dtype=torch.float))


### PR DESCRIPTION
This PR extends the Graphnet project to include support for the TRIDENT detector by adding specific code files for training and testing. The changes include four new files which are described in detail below.

### Changes Made:

- `TRIDENTNodeDefinition.py`: Defines the node structure `TRIDENTGraphDefinition` used for training with TRIDENT data.
- `TRIDENTGraphDefinition.py`: Contains both the `TRIDENT` detector information and the graph definition class `TRIDENTGraphDefinition` to represent the TRIDENT detector structure and graph type.
- `MiddleReconModel.py`: Defines the model `MiddleReconModel` used in TRIDENT training. Key fuctions include:
  `compute_loss`, `forward`, `shared_step`, `construct_trainer`, `fit`, `_print_callbacks`, `_contains_callback`, `configure_optimizers`, `training_step`, `validation_step`, `predict_step`, `inference`, `train`, `predict`, `predict_as_dataframe`, `_create_default_callbacks` and `_add_early_stopping`.
- `TridentNet.py`: Contains three network classes used in TRIDENT training: `StaticEdgeConv`, `DynamicEdgeConv`, and `TridentTrackNet`.

### Additional Notes:

- We would also like to seek some advice on where it would make more sense to place the added code files.
