### PR TITLE
Fix deprecated I3Tray imports

### DIFF
--- a/docker/gnn-benchmarking/apply.py
+++ b/docker/gnn-benchmarking/apply.py
@@ -6,7 +6,7 @@ from os import makedirs
 from os.path import join, dirname
 from typing import List
 
-from I3Tray import I3Tray  # pyright: reportMissingImports=false
+from icecube.icetray import I3Tray  # pyright: reportMissingImports=false
 
 from graphnet.deployment.i3modules import I3InferenceModule
 from graphnet.data.extractors.i3featureextractor import (

--- a/examples/01_icetray/04_i3_module_in_native_icetray_example.py
+++ b/examples/01_icetray/04_i3_module_in_native_icetray_example.py
@@ -19,7 +19,7 @@ from graphnet.utilities.logging import Logger
 
 if has_icecube_package() or TYPE_CHECKING:
     from icecube import icetray, dataio  # pyright: reportMissingImports=false
-    from I3Tray import I3Tray
+    from icecube.icetray import I3Tray
 
     from graphnet.deployment.i3modules import (
         I3InferenceModule,

--- a/src/graphnet/deployment/icecube/i3deployer.py
+++ b/src/graphnet/deployment/icecube/i3deployer.py
@@ -11,7 +11,7 @@ from graphnet.deployment import Deployer
 
 if has_icecube_package() or TYPE_CHECKING:
     from icecube import icetray, dataio  # pyright: reportMissingImports=false
-    from I3Tray import I3Tray
+    from icecube.icetray import I3Tray
 
 
 class I3Deployer(Deployer):

--- a/tests/deployment/queso_test.py
+++ b/tests/deployment/queso_test.py
@@ -19,7 +19,7 @@ from graphnet.utilities.imports import has_icecube_package
 
 if has_icecube_package() or TYPE_CHECKING:
     from icecube import icetray, dataio  # pyright: reportMissingImports=false
-    from I3Tray import I3Tray
+    from icecube.icetray import I3Tray
 
     from graphnet.deployment.i3modules import (
         I3InferenceModule,


### PR DESCRIPTION
Fix for https://github.com/graphnet-team/graphnet/issues/765. Just changing `from I3Tray import I3Tray` to `from icecube.icetray import I3Tray` for a few files.