### PR TITLE
Disable affine option for LearnedTask

### DIFF
--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -245,7 +245,7 @@ class LearnedTask(Task):
                          the last latent layer of `Model` using this Task.
                          Available through `Model.nb_outputs`
             loss_function: Loss function appropriate to the task.
-            disable_affine: Disable linear layer mapping hidden layer size
+            disable_affine: Disable linear layer mapping from hidden layer size
                             to number of inputs.
         """
         # Base class constructor

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -235,6 +235,7 @@ class LearnedTask(Task):
         self,
         hidden_size: int,
         loss_function: "LossFunction",
+        disable_affine: bool = False,
         **task_kwargs: Any,
     ):
         """Construct `LearnedTask`.
@@ -244,13 +245,20 @@ class LearnedTask(Task):
                          the last latent layer of `Model` using this Task.
                          Available through `Model.nb_outputs`
             loss_function: Loss function appropriate to the task.
+            disable_affine: Disable linear layer mapping hidden layer size
+                            to number of inputs.
         """
         # Base class constructor
         super().__init__(**task_kwargs)
 
         # Mapping from last hidden layer to required size of input
         self._loss_function = loss_function
-        self._affine = Linear(hidden_size, self.nb_inputs)
+        self._disable_affine = disable_affine
+        
+        if self._disable_affine:
+            self._affine = Linear(hidden_size, self.nb_inputs)
+        else:
+            self._affine = None
 
     @abstractmethod
     def _forward(  # type: ignore
@@ -281,7 +289,8 @@ class LearnedTask(Task):
         target dimensions.
         """
         self._regularisation_loss = 0  # Reset
-        x = self._affine(x)
+        if not self._disable_affine:  # Apply affine layer if not disabled
+            x = self._affine(x)
         x = self._forward(x=x)
         return self._transform_prediction(x)
 

--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -254,16 +254,14 @@ class LearnedTask(Task):
         # Mapping from last hidden layer to required size of input
         self._loss_function = loss_function
         self._disable_affine = disable_affine
-        
+
         if self._disable_affine:
             self._affine = Linear(hidden_size, self.nb_inputs)
         else:
             self._affine = None
 
     @abstractmethod
-    def _forward(  # type: ignore
-        self, x: Union[Tensor, Data]
-    ) -> Union[Tensor, Data]:
+    def _forward(self, x: Union[Tensor, Data]) -> Union[Tensor, Data]:
         """Syntax like `.forward`, for implentation in inheriting classes."""
         raise NotImplementedError
 
@@ -280,9 +278,7 @@ class LearnedTask(Task):
         """Return number of inputs assumed by task."""
 
     @final
-    def forward(  # type: ignore
-        self, x: Union[Tensor, Data]
-    ) -> Union[Tensor, Data]:
+    def forward(self, x: Union[Tensor, Data]) -> Union[Tensor, Data]:
         """Forward call for `LearnedTask`.
 
         The learned embedding transforms last latent layer of Model to meet


### PR DESCRIPTION
For cases where the final layer of a model already reduces the dimension to the number of outputs, you may not want the affine layer in the `LearnedTask`. Added a simple bool for disabling the layer.