### PR TITLE
add summary feature nodedefinition

### DIFF
--- a/src/graphnet/models/data_representation/graphs/__init__.py
+++ b/src/graphnet/models/data_representation/graphs/__init__.py
@@ -18,7 +18,7 @@ from .nodes import (
     NodeAsDOMTimeSeries,
     PercentileClusters,
     IceMixNodes,
-    DOMSummaryFeatures,
+    ClusterSummaryFeatures,
 )
 
 from .edges import (

--- a/src/graphnet/models/data_representation/graphs/__init__.py
+++ b/src/graphnet/models/data_representation/graphs/__init__.py
@@ -18,6 +18,7 @@ from .nodes import (
     NodeAsDOMTimeSeries,
     PercentileClusters,
     IceMixNodes,
+    DOMSummaryFeatures,
 )
 
 from .edges import (

--- a/src/graphnet/models/data_representation/graphs/__init__.py
+++ b/src/graphnet/models/data_representation/graphs/__init__.py
@@ -20,7 +20,6 @@ from .nodes import (
     IceMixNodes,
     ClusterSummaryFeatures,
 )
-
 from .edges import (
     EdgeDefinition,
     KNNEdges,

--- a/src/graphnet/models/data_representation/graphs/nodes/__init__.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/__init__.py
@@ -11,5 +11,5 @@ from .nodes import (
     PercentileClusters,
     NodeAsDOMTimeSeries,
     IceMixNodes,
-    DOMSummaryFeatures,
+    ClusterSummaryFeatures,
 )

--- a/src/graphnet/models/data_representation/graphs/nodes/__init__.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/__init__.py
@@ -11,4 +11,5 @@ from .nodes import (
     PercentileClusters,
     NodeAsDOMTimeSeries,
     IceMixNodes,
+    DOMSummaryFeatures,
 )

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -645,9 +645,6 @@ class DOMSummaryFeatures(NodeDefinition):
 
     def set_indeces(self, feature_names: List[str]) -> None:
         """Set the indices for the input features."""
-        assert set(feature_names) == set(
-            self._cluster_on + [self._charge_label, self._time_label]
-        ), f"Input feature names do not match: {feature_names}"
         self._cluster_idx = [
             feature_names.index(column) for column in self._cluster_on
         ]

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -546,11 +546,6 @@ class DOMSummaryFeatures(NodeDefinition):
         self._time_after_charge_pct = time_after_charge_pct
         self._add_counts = add_counts
 
-        # check for correct features
-        if input_feature_names is not None:
-            assert set(input_feature_names) == set(
-                cluster_on + [charge_label, time_label]
-            ), f"Input feature names do not match: {input_feature_names}"
         # Base class constructor
         super().__init__(input_feature_names=input_feature_names)
 

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -468,7 +468,7 @@ class IceMixNodes(NodeDefinition):
         for idx, feature in enumerate(non_ice_features):
             graph[:event_length, idx] = x[ids, self.feature_indexes[feature]]
 
-        return Data(x=graph)
+        return graph
 
 
 class DOMSummaryFeatures(NodeDefinition):

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -548,6 +548,10 @@ class ClusterSummaryFeatures(NodeDefinition):
                     incorrect results otherwise.
             add_counts: If True, number of log10(event counts per clusters)
                 is added as a feature.
+
+        NOTE: Make sure that either the input data is not already standardized
+        or that the `charge_standardization` and `time_standardization`
+        parameters are set to 1 to avoid a double standardization.
         """
         # Set member variables
         self._cluster_on = cluster_on

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -582,7 +582,6 @@ class DOMSummaryFeatures(NodeDefinition):
             charge_index=self._charge_idx,
             time_index=self._time_idx,
         )
-        print(ref_time)
 
         # add total charge
         if self._total_charge:
@@ -637,3 +636,14 @@ class DOMSummaryFeatures(NodeDefinition):
             ] *= self._time_standardization
 
         return Data(x=torch.tensor(cluster_class.clustered_x))
+
+    def set_indeces(self, feature_names: List[str]) -> None:
+        """Set the indices for the input features."""
+        assert set(feature_names) == set(
+            self._cluster_on + [self._charge_label, self._time_label]
+        ), f"Input feature names do not match: {feature_names}"
+        self._cluster_idx = [
+            feature_names.index(column) for column in self._cluster_on
+        ]
+        self._charge_idx = feature_names.index(self._charge_label)
+        self._time_idx = feature_names.index(self._time_label)

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -514,7 +514,7 @@ class ClusterSummaryFeatures(NodeDefinition):
         time_spread: bool = True,
         time_std: bool = True,
         time_after_charge_pct: List[int] = [1, 3, 5, 11, 15, 20, 50, 80],
-        charge_standardization: Union[float, str] = 1e-2,
+        charge_standardization: Union[float, str] = "log",
         time_standardization: float = 1e-3,
         order_in_time: bool = True,
         add_counts: bool = False,
@@ -535,8 +535,9 @@ class ClusterSummaryFeatures(NodeDefinition):
             time_std: If True, time std is added as a feature.
             time_after_charge_pct: List of percentiles to calculate time after
                 charge.
-            charge_standardization: Standardization factor for features
-                with a charge value.
+            charge_standardization: Either a float or 'log'. If a float,
+                the features are multiplied by this factor. If 'log', the
+                features are transformed to log10 scale.
             time_standardization: Standardization factor for features
                 with a time
             order_in_time: If True, clusters are ordered in time.

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -480,14 +480,15 @@ class DOMSummaryFeatures(NodeDefinition):
     NOTE: Intended to be used with features [dom_x, dom_y, dom_z, charge, time]
 
     - total charge
-    - charge after t
-    - time of first hit
-    - time spread
-    - time std
-    - time after charge percentiles
+    - charge accumulated after times `charge_after_t`
+    - time of first hit per DOM
+    - time spread per DOM
+    - time std per DOM
+    - time took to collect the charge percentiles `time_after_charge_pct`
+    - number of pulses per DOM
 
     Taken from Theo Glauchs PhD thesis:
-    https://nbn-resolving.org/urn:nbn:de:bvb:91-diss-20210208-1584755-1-7
+    https://mediatum.ub.tum.de/node?id=1584755
     """
 
     def __init__(
@@ -504,7 +505,7 @@ class DOMSummaryFeatures(NodeDefinition):
         time_after_charge_pct: List[int] = [1, 3, 5, 11, 15, 20, 50, 80],
         charge_standardization: float = 1e-2,
         time_standardization: float = 1e-3,
-        add_counts: bool = True,
+        add_counts: bool = False,
     ) -> None:
         """Construct `PercentileClusters`.
 
@@ -513,18 +514,21 @@ class DOMSummaryFeatures(NodeDefinition):
             input_feature_names: Column names for input features.
             charge_label: Name of the charge column.
             time_label: Name of the time column.
-            total_charge: If True, total charge is added to the output.
-            charge_after_t: List of times to calculate charge after.
+            total_charge: If True, calculates total charge as feature.
+            charge_after_t: List of times at which the accumulated charge
+                is calculated as a feature.
             time_of_first_hit: If True, time of first hit is added
-                to the output.
-            time_spread: If True, time spread is added to the output.
-            time_std: If True, time std is added to the output.
+                as a feature.
+            time_spread: If True, time spread is added as a feature.
+            time_std: If True, time std is added as a feature.
             time_after_charge_pct: List of percentiles to calculate time after
                 charge.
-            charge_standardization: Standardization factor for charge.
-            time_standardization: Standardization factor for time
+            charge_standardization: Standardization factor for features
+                with a charge value.
+            time_standardization: Standardization factor for features
+                with a time
             add_counts: If True, number of log10(counts per DOM) is added as
-                a nodefeature.
+                a feature.
         """
         # Set member variables
         self._cluster_on = cluster_on

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -539,12 +539,12 @@ class ClusterSummaryFeatures(NodeDefinition):
                 with a charge value.
             time_standardization: Standardization factor for features
                 with a time
-            order_in_time: If True, clusters are sorted by time.
-                    If your data is already sorted by time, you can set this
+            order_in_time: If True, clusters are ordered in time.
+                    If your data is already ordered in time, you can set this
                     to False to avoid a potential overhead.
                 NOTE: Should only be set to False if you are sure that
-                    the input data is already sorted by time. Will lead to
-                    incorrect results if the data is not sorted by time.
+                    the input data is already ordered in time. Will lead to
+                    incorrect results otherwise.
             add_counts: If True, number of log10(event counts per clusters)
                 is added as a feature.
         """
@@ -573,7 +573,7 @@ class ClusterSummaryFeatures(NodeDefinition):
         if self._order_in_time is False:
             self.info(
                 "Setting `order_by_time` to False. "
-                "Make sure that the input data is already sorted by time."
+                "Make sure that the input data is already ordered in time."
             )
 
     def _define_output_feature_names(
@@ -705,17 +705,13 @@ class ClusterSummaryFeatures(NodeDefinition):
         x: np.ndarray,
         standardization: Union[float, str],
     ) -> np.ndarray:
-        """Standardize the features in the input tensor."""
+        """Standardize the features in the input array."""
         if isinstance(standardization, float):
             return x * standardization
-        elif isinstance(standardization, str):
-            if standardization != "log":
-                raise ValueError(
-                    f"standardization must be either a float or 'log', "
-                    f"but got {standardization}"
-                )
+        elif standardization == "log":
             return np.log10(x)
         else:
+            # should never happen, but just in case
             raise ValueError(
                 f"standardization must be either a float or 'log', "
                 f"but got {standardization}"
@@ -724,7 +720,7 @@ class ClusterSummaryFeatures(NodeDefinition):
     def _verify_standardization(
         self,
     ) -> torch.Tensor:
-        """Verify the standardization of the features."""
+        """Verify settings of standardization of the features."""
         if not isinstance(self._charge_standardization, float):
             if isinstance(self._charge_standardization, str):
                 if self._charge_standardization != "log":

--- a/src/graphnet/models/data_representation/graphs/utils.py
+++ b/src/graphnet/models/data_representation/graphs/utils.py
@@ -178,7 +178,7 @@ def weighted_median(values: np.array, weights: np.array) -> float:
     """Compute the weighted median of values."""
     i = np.argsort(values)
     c = np.cumsum(weights[i])
-    return values[i[np.searchsorted(c, 0.5 * c[-1])]]
+    return values[i[np.searchsorted(c, 0.5 * np.nanmax(c))]]
 
 
 class cluster_and_pad:
@@ -214,6 +214,7 @@ class cluster_and_pad:
         x: np.ndarray,
         cluster_columns: List[int],
         input_names: Optional[List[str]] = None,
+        sort_by: List[int] = [],
     ) -> None:
         """Initialize the class with the data and cluster columns.
 
@@ -223,12 +224,22 @@ class cluster_and_pad:
                             are constructed.
             input_names: Names of the columns in the input data for automatic
                         generation of names.
+            sort_by: List of indices to sort `self._padded_x` by in
+                    addition to cluster on, if None the data will be
+                    sorted only by the cluster columns.
+                    NOTE: The priority of ordering is first by the
+                    cluster_on columns and then by the `sort_by` columns.
             Adds:
                 clustered_x: Added to the class
                 _counts: Added to the class
                 _padded_x: Added to the class
         """
-        x = lex_sort(x=x, cluster_columns=cluster_columns)
+        # for assertions later
+        self._sort_by = sort_by
+
+        sort_cols = sort_by + cluster_columns
+
+        x = lex_sort(x=x, cluster_columns=sort_cols)
 
         unique_sensors, self._counts = np.unique(
             x[:, cluster_columns], axis=0, return_counts=True
@@ -310,7 +321,9 @@ class cluster_and_pad:
             self, "_charge_sum"
         ), "Charge sum has already been calculated, \
             re-calculation is not allowed"
-        self._charge_sum = self._padded_x[:, :, charge_index].sum(axis=1)
+        self._charge_sum = np.nansum(
+            self._padded_x[:, :, charge_index], axis=1
+        )
 
     def _calculate_charge_weights(self, charge_index: int) -> np.ndarray:
         """Calculate the weights of the charge."""
@@ -362,30 +375,25 @@ class cluster_and_pad:
             _charge_sum: Added to the class
             _charge_weights: Added to the class
         Altered:
-            _padded_x: Charge is altered to be the cumulative sum
-                       of the charge divided by the total charge
             clustered_x: The summarization indices are added at the end
                          of the tensor or inserted at the specified location.
             _cluster_names: The names are added at the end of the tensor
                             or inserted at the specified location
         """
-        # convert the charge to the cumulative sum of the charge divided
-        # by the total charge
-        self._calculate_charge_sum(charge_index)
-        self._calculate_charge_weights(charge_index)
+        # calculate cumsum of charge
+        if not hasattr(self, "_charge_sum"):
+            self._calculate_charge_sum(charge_index)
 
-        self._padded_x[:, :, charge_index] = (
-            self._padded_x[:, :, charge_index]
+        charge_cumsum = (
+            self._padded_x[:, :, charge_index].cumsum(axis=1)
             / self._charge_sum[:, np.newaxis]
         )
 
         # Summarize the charge at different percentiles
         selections = np.argmax(
-            self._padded_x[:, :, charge_index][:, :, np.newaxis]
-            >= (np.array(percentiles) / 100),
+            charge_cumsum[:, :, np.newaxis] >= (np.array(percentiles) / 100),
             axis=1,
         )
-
         selections += (np.arange(len(self._counts)) * self._padded_x.shape[1])[
             :, np.newaxis
         ]
@@ -512,41 +520,20 @@ class cluster_and_pad:
         self,
         time_index: int,
         location: Optional[int] = None,
-        reference_time: bool = True,
-        charge_index: Optional[int] = None,
     ) -> np.ndarray:
         """Add the time of the first pulse.
 
         Args:
             time_index: Index of the time column in the padded tensor
             location: Location to insert the time of the first pulse in the
-                      clustered tensor defaults to adding at the end
-            reference_time: If True the time of the first pulse is calculated
-                            with respect to the charge weighted median time
-            charge_index: Index of the charge column in the padded tensor
-                          required if reference_time is True
+                    clustered tensor defaults to adding at the end
         Altered:
             clustered_x: The time of the first pulse is added at the end of
                          the tensor or inserted at the specified location
             _cluster_names: The names are added at the end of the tensor
                             or inserted at the specified location
         """
-        if reference_time:
-            if not hasattr(self, "_charge_weights"):
-                assert (
-                    charge_index is not None
-                ), "Charge index must be provided"
-                self._calculate_charge_weights(charge_index)
-            if not hasattr(self, "_reference_time"):
-                self._calculate_reference_time(time_index)
-            time_first_pulse = (
-                np.nanmin(self._padded_x[:, :, time_index], axis=1)
-                - self._reference_time
-            )
-        else:
-            time_first_pulse = np.nanmin(
-                self._padded_x[:, :, time_index], axis=1
-            )
+        time_first_pulse = np.nanmin(self._padded_x[:, :, time_index], axis=1)
         self._add_column(time_first_pulse, location)
         # update the cluster names
         if self._input_names is not None:
@@ -556,7 +543,7 @@ class cluster_and_pad:
     def add_spread(
         self, columns: List[int], location: Optional[int] = None
     ) -> np.ndarray:
-        """Add the spread of the columns."""
+        """Add the spread (max-min) of the columns."""
         self._add_column(
             np.nanmax(self._padded_x[:, :, columns], axis=1)
             - np.nanmin(self._padded_x[:, :, columns], axis=1),
@@ -566,6 +553,92 @@ class cluster_and_pad:
         if self._input_names is not None:
             new_names = [self._input_names[i] + "_spread" for i in columns]
             self._add_column_names(new_names, location)
+
+    def add_accumulated_value_after_t(
+        self,
+        time_index: int,
+        summarization_indices: List[int],
+        times: List[int],
+        location: Optional[int] = None,
+    ) -> np.ndarray:
+        """Add the cumulative sum of values after certain time.
+
+        NOTE: the time is counted from the first pulse of the sensor.
+        Make sure that the data is also sorted by time and be aware of
+        the standardization of the time column.
+
+        Args:
+            time_index: Index of the time column in the padded tensor
+            summarization_indices: List of column indices that defines
+                features that will be summarized with percentiles.
+            times: List of times after which the accumulated value
+                is calculated
+            location: Location to insert the accumulated values in the
+                      clustered tensor defaults to adding at the end
+        Altered:
+            clustered_x: The accumulated values are added at the end of
+                         the tensor or inserted at the specified location
+            _cluster_names: The names are added at the end of the tensor
+                            or inserted at the specified location
+        """
+        assert (
+            self._sort_by[-1] == time_index
+        ), """Data is not sorted by time index.
+            Make sure that the last element of
+            sort_by is set to the time index"""
+        # Summarize the values at different times
+        time_first_pulse = np.nanmin(
+            self._padded_x[:, :, time_index],
+            axis=1,
+        )[:, np.newaxis]
+        tmp_times = (
+            np.tile(
+                np.array(times),
+                (len(time_first_pulse), 1),
+            )
+            + time_first_pulse
+        )
+        # print(times)
+        mask = (
+            self._padded_x[:, :, time_index][:, np.newaxis, :]
+            >= tmp_times[:, :, np.newaxis]
+        )
+
+        selections = np.argmax(
+            mask,
+            axis=2,
+        )
+        selections += (np.arange(len(self._counts)) * self._padded_x.shape[1])[
+            :, np.newaxis
+        ]
+        selections = (
+            self._padded_x[:, :, summarization_indices]
+            .cumsum(axis=1)
+            .reshape(-1, len(summarization_indices))[selections]
+        )
+        selections = selections.transpose(0, 2, 1).reshape(
+            len(self.clustered_x), -1
+        )
+        self._add_column(selections, location)
+        # update the cluster names
+        if self._input_names is not None:
+            new_names = [
+                self._input_names[i] + "_accumulated_after_" + str(t)
+                for i in summarization_indices
+                for t in times
+            ]
+            self._add_column_names(new_names, location)
+
+    def reference_time(self, charge_index: int, time_index: int) -> float:
+        """Return and set the charge weighted median of hit times."""
+        if not hasattr(self, "_reference_time"):
+            assert charge_index is not None, "Charge index must be provided"
+            if not hasattr(self, "_charge_weights"):
+                if not hasattr(self, "_charge_sum"):
+                    self._calculate_charge_sum(charge_index)
+                self._calculate_charge_weights(charge_index)
+            self._calculate_reference_time(time_index)
+        return self._reference_time
 
 
 def ice_transparency(

--- a/src/graphnet/models/data_representation/graphs/utils.py
+++ b/src/graphnet/models/data_representation/graphs/utils.py
@@ -582,11 +582,6 @@ class cluster_and_pad:
             _cluster_names: The names are added at the end of the tensor
                             or inserted at the specified location
         """
-        assert (
-            self._sort_by[-1] == time_index
-        ), """Data is not sorted by time index.
-            Make sure that the last element of
-            sort_by is set to the time index"""
         # Summarize the values at different times
         time_first_pulse = np.nanmin(
             self._padded_x[:, :, time_index],

--- a/src/graphnet/models/data_representation/graphs/utils.py
+++ b/src/graphnet/models/data_representation/graphs/utils.py
@@ -228,7 +228,8 @@ class cluster_and_pad:
                     addition to cluster on, if None the data will be
                     sorted only by the cluster columns.
                     NOTE: The priority of ordering is first by the
-                    cluster_on columns and then by the `sort_by` columns.
+                    `cluster_columns` columns and then by the
+                    `sort_by` columns.
             Adds:
                 clustered_x: Added to the class
                 _counts: Added to the class

--- a/src/graphnet/models/graphs/nodes/__init__.py
+++ b/src/graphnet/models/graphs/nodes/__init__.py
@@ -12,6 +12,7 @@ from graphnet.models.data_representation.graphs import (
     PercentileClusters,
     NodeAsDOMTimeSeries,
     IceMixNodes,
+    DOMSummaryFeatures,
 )
 
 

--- a/src/graphnet/models/graphs/nodes/__init__.py
+++ b/src/graphnet/models/graphs/nodes/__init__.py
@@ -12,9 +12,8 @@ from graphnet.models.data_representation.graphs import (
     PercentileClusters,
     NodeAsDOMTimeSeries,
     IceMixNodes,
-    DOMSummaryFeatures,
+    ClusterSummaryFeatures,
 )
-
 
 Logger(log_folder=None).warning_once(
     (


### PR DESCRIPTION
Adding a new `NodeDefiniton` called `DOMSummaryFeatures`  which is a per DOM summary statistics NodeDefiniton used by different architectures in IceCube. This exact version is taken from Theo Glauchs thesis (https://mediatum.ub.tum.de/node?id=1584755). The reason for this PR is because I heard of other people also using/interested in these type of features. 

**Features of the DOMSummaryFeatures**

    - total charge
    - charge accumulated after times `charge_after_t`
    - time of first hit per DOM
    - time spread per DOM
    - time std per DOM
    - time took to collect the charge percentiles `time_after_charge_pct`
    - number of pulses per DOM
  

  **Here is a visual representation of the feature (more details are in Theos thesis above)**

![summary_features](https://github.com/user-attachments/assets/4c685bda-853b-49a8-a64c-21b87e3a2a03)

And the numerical ranges of these features:

![summary_features_numerical_ranges](https://github.com/user-attachments/assets/73bd9dc9-e806-4143-9678-cf15fd087744)


NOTE: I had to change the clustering utility implemented by @Aske-Rosted in #770 (Therefore the review request) .
- I added functionality for sorting the clustered table by an additional feature
- changed some of the functions (NOTE: this functions are not being used in default GN atm if I'm not mistaken)
   - `add_charge_threshold_summary` (changed it so it does not alter the `_padded_x` attribute anymore)
   - `_calculate_charge_sum` (change to deal with nans)
  - added the necessary functions for my features
  
  
  
  
**I also did timing tests:**

![node_timing](https://github.com/user-attachments/assets/e14eb1cb-6718-4b3f-bdad-2ea0472f9be5)

And some ratios:

![timing_ratios_nodes](https://github.com/user-attachments/assets/6fffc98f-f87f-4596-a8ae-4f6465d5ef72)

Here the NodeDefinitons:

```python
input_feature_names = ['dom_x', 'dom_y', 'dom_z', 'dom_time', 'charge']
nodes = {
    'nodes_as_pulses': NodesAsPulses(
        input_feature_names=input_feature_names,
    ),
    'prct_clust_5pcts' : PercentileClusters(
        input_feature_names=input_feature_names,
        cluster_on = ['dom_x', 'dom_y', 'dom_z'],
        percentiles=np.linspace(0.2, 1.0, 5),
    ),
    'prct_clust_10pcts' : PercentileClusters(
        input_feature_names=input_feature_names,
        cluster_on = ['dom_x', 'dom_y', 'dom_z'],
        percentiles=np.linspace(0.1, 1.0, 10),
    ),
    'prct_clust_20pcts' : PercentileClusters(
        input_feature_names=input_feature_names,
        cluster_on = ['dom_x', 'dom_y', 'dom_z'],
        percentiles=np.linspace(0.05, 1.0, 20),
    ),
    'ice_mix_max512': IceMixNodes(
        input_feature_names=input_feature_names,
        max_pulses=512,
        add_ice_properties=False,
        sample_pulses=True,
    ),
    'ice_mix_max1024': IceMixNodes(
        input_feature_names=input_feature_names,
        max_pulses=1024,
        add_ice_properties=False,
        sample_pulses=True,
    ),
    'ice_mix_max2048': IceMixNodes(
        input_feature_names=input_feature_names,
        max_pulses=2048,
        add_ice_properties=False,
        sample_pulses=True,
    ),
    'dom_summary': DOMSummaryFeatures(
        input_feature_names=input_feature_names,
        cluster_on = ['dom_x', 'dom_y', 'dom_z'],
        
    ),
}
```

