### PR TITLE
move examples dependencies into their own "extras" section.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ SETUP_REQUIRES = [
 ]
 
 INSTALL_REQUIRES = [
-    "awkward>=1.8,<2.0",
     "colorlog>=6.6",
     "configupdater",
     "dill>=0.3",
@@ -23,7 +22,6 @@ INSTALL_REQUIRES = [
     "scikit_learn>=1.0",
     "scipy>=1.7",
     "sqlalchemy>=1.4",
-    "timer>=0.2",
     "tqdm>=4.64",
     "wandb>=0.12",
     "polars >=0.19",
@@ -58,6 +56,11 @@ EXTRAS_REQUIRE = {
         "pytorch-lightning>=2.0",
     ],
 }
+
+EXTRAS_REQUIRE["examples"] = EXTRAS_REQUIRE["torch"] + [
+        "awkward>=1.8,<2.0",
+        "timer>=0.2",
+    ]
 
 # https://pypi.org/classifiers/
 CLASSIFIERS = [


### PR DESCRIPTION
AwkwardArray doesn't build with CMake v4 and prevents building graphnet.
This moves it and `timers` into an examples "extra" since that's the
only place they're used.
