### PR TITLE
Remove `awkward` and `timer` from dependencies

### DIFF
--- a/examples/02_data/04_ensemble_dataset.py
+++ b/examples/02_data/04_ensemble_dataset.py
@@ -1,9 +1,7 @@
 """Example of combining multiple Datasets using EnsembleDataset."""
 
 import time
-from timer import timer
-import torch.multiprocessing
-import torch.utils.data
+import torch
 from torch_geometric.data.batch import Batch
 from tqdm import tqdm
 
@@ -74,9 +72,8 @@ def main() -> None:
         prefetch_factor=2,
     )
 
-    with timer("torch dataloader"):
-        for batch in tqdm(dataloader, unit=" batches", colour="green"):
-            time.sleep(wait_time)
+    for batch in tqdm(dataloader, unit=" batches", colour="green"):
+        time.sleep(wait_time)
 
     for i in range(batch_size):
         logger.info(f"Event {i} came from {batch['dataset_path'][i]}")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ SETUP_REQUIRES = [
 ]
 
 INSTALL_REQUIRES = [
-    "awkward>=1.8,<2.0",
     "colorlog>=6.6",
     "configupdater",
     "dill>=0.3",
@@ -23,7 +22,6 @@ INSTALL_REQUIRES = [
     "scikit_learn>=1.0",
     "scipy>=1.7",
     "sqlalchemy>=1.4",
-    "timer>=0.2",
     "tqdm>=4.64",
     "wandb>=0.12",
     "polars >=0.19",


### PR DESCRIPTION
As pointed out by @nega0 in #800 , `awkward` and `timer` produce build errors in CMake. 

The two libraries are currently only used in the examples `data_02/01_read_dataset.py` and `data_02/04_ensemble_dataset.py`. In the past, we relied on these libraries more, but at this stage, I think it's unnecessary to include them as dependencies in GraphNeT.

This PR modifies the two examples to not rely on the dependencies, and removes the two libraries from the list of dependencies for GraphNeT.

The PR also close #774 



 

