### PR TITLE
Fix coverage upload to CodeClimate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,12 +132,11 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/graphnet/graphnet
       - name: Publish code coverage
-        uses: paambaati/codeclimate-action@v3.0.0
+        uses: paambaati/codeclimate-action@v9.0.0
         if: needs.check-codeclimate-credentials.outputs.has_credentials == 'true'
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
-        with:
-          coverageCommand: coverage report
+        with: 
           coverageLocations: coverage.xml:coverage.py
           
 


### PR DESCRIPTION
Merging #806 revealed[ a problem](https://github.com/graphnet-team/graphnet/actions/runs/15822307101/job/44594158831) with the upload of the coverage report.  

The problem is caused by the codeclimate action not activating the virtual environment that contains the `coverage` command.

This attempts to fix it by uploading the pre-compiled .XML file from the workflow instead of relying on the `coverage` command to generate it from scratch.