### PR TITLE
Fix Documentation Publication Workflow

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: "Version of PyTorch"
     required: true
     default: "2.6.0"
-    options: ["2.6.0", "2.5.0", "2.4.0"]
+    options: ["2.7.0", "2.6.0", "2.5.0", "2.4.0"]
 
   hardware:
     description: "The requirements file depends on the hardware, i.e., CPU, GPU, or macOS"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,17 @@ jobs:
     name: Build and publish Documentation
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - name: Install package
         uses: ./.github/actions/install
+        with:
+          editable: true
+          use_vm: false
+          torch_version: "2.6.0"
+          hardware: "cpu"
       - name: Build documentation
         run: |
           cd docs


### PR DESCRIPTION
Merging #806 revealed [a problem](https://github.com/graphnet-team/graphnet/actions/runs/15823360055/job/44597471281#logs) with the workflow that compiles and publishes documentation.

This problem is likely caused by a missing python installation action.

This PR attempts to fix the problem by adding the python installation action to the workflow prior to installing the graphnet package. 