### PR TITLE
Fix typo in installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | [![status](https://joss.theoj.org/papers/eecab02fb1ecd174a5273750c1ea0baf/status.svg)](https://joss.theoj.org/papers/eecab02fb1ecd174a5273750c1ea0baf)             | ![build](https://github.com/graphnet-team/graphnet/actions/workflows/build.yml/badge.svg) |
 | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6720188.svg)](https://doi.org/10.5281/zenodo.6720188)                                                          | ![code-quality](https://github.com/graphnet-team/graphnet/actions/workflows/code-quality.yml/badge.svg) |
 | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)                                               | [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) |
-| ![Supported python versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)                                                   | [![Maintainability](https://api.codeclimate.com/v1/badges/b273a774112e32643162/maintainability)](https://codeclimate.com/github/graphnet-team/graphnet/maintainability) |
+| ![Supported python versions](https://img.shields.io/badge/python-%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)                                                   | [![Maintainability](https://api.codeclimate.com/v1/badges/b273a774112e32643162/maintainability)](https://codeclimate.com/github/graphnet-team/graphnet/maintainability) |
 | [![Docker image](https://img.shields.io/docker/v/asogaard/graphnet?color=blue&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/asogaard/graphnet) | [![Test Coverage](https://api.codeclimate.com/v1/badges/b273a774112e32643162/test_coverage)](https://codeclimate.com/github/graphnet-team/graphnet/test_coverage) |
 
 </center>
@@ -29,7 +29,7 @@ Feel free to join the [GraphNeT Slack group](https://join.slack.com/t/graphnet-t
 
 ## :gear:  Install
 
-GraphNeT is compatible with Python 3.8 - 3.11, Linux and macOS, and we recommend installing `graphnet` in a separate virtual environment. To install GraphNeT, please follow the [installation instructions](https://graphnet-team.github.io/graphnet/installation/install.html#quick-start)
+GraphNeT is compatible with Python 3.9 - 3.11, Linux and macOS, and we recommend installing `graphnet` in a separate virtual environment. To install GraphNeT, please follow the [installation instructions](https://graphnet-team.github.io/graphnet/installation/install.html#quick-start)
 
 
 ## :ringed_planet:  Use cases

--- a/docs/source/installation/install.rst
+++ b/docs/source/installation/install.rst
@@ -47,7 +47,7 @@ To achieve this, we recommend installing |graphnet|\ GraphNeT into a CVMFS with 
    eval `/cvmfs/icecube.opensciencegrid.org/py3-v4.2.1/setup.sh`
    /cvmfs/icecube.opensciencegrid.org/py3-v4.2.1/RHEL_7_x86_64/metaprojects/icetray/v1.5.1/env-shell.sh
    # Update central utils
-   pip install --upgrade pip>=20
+   pip install --upgrade 'pip>=20'
    pip install wheel setuptools==59.5.0
    # Install graphnet into the CVMFS as a user
    pip install --user -r requirements/torch_cpu.txt -e .[torch,develop]


### PR DESCRIPTION
As pointed out by #812 by @finnmayhew, a typo in the installation text lead to unwanted behavior in the installation process. 

This PR fixes the typo, and adjusts the python range in the `README.MD` to be consistent with the installation procedure.

Closes #812 