### PR TITLE
Fixing the get_primaries function of I3Extractor

### DIFF
--- a/src/graphnet/data/extractors/icecube/i3extractor.py
+++ b/src/graphnet/data/extractors/icecube/i3extractor.py
@@ -229,17 +229,14 @@ class I3Extractor(Extractor):
                         self.mctree,
                     )
 
-                    # This is not expected to happen
-                    if len(primaries) == 0:
-                        self.warning_once(
-                            "No in-ice neutrino found for NuGen event, "
-                            "returning no primaries."
-                        )
-                        return dataclasses.ListI3Particle([])
+                # This is not expected to happen
+                if len(primaries) == 0:
+                    self.warning_once(
+                        "No in-ice daughter of primary " "neutrino found"
+                    )
+                    return dataclasses.ListI3Particle([])
 
-            if len(primaries) == 0:
-                self.warning_once("No in-ice neutrino found for NuGen event")
-                return dataclasses.ListI3Particle([])
+            assert len(primaries) >= 0, "No primary found"
 
             if highest_energy_primary:
                 # Select only the highest energy primary

--- a/src/graphnet/data/extractors/icecube/i3extractor.py
+++ b/src/graphnet/data/extractors/icecube/i3extractor.py
@@ -164,7 +164,10 @@ class I3Extractor(Extractor):
         return primary
 
     def get_primaries(
-        self, frame: "icetray.I3Frame", daughters: bool = False
+        self,
+        frame: "icetray.I3Frame",
+        daughters: bool = False,
+        highest_energy_primary: bool = True,
     ) -> "dataclasses.ListI3Particle":
         """Get the primary particles in the event.
 
@@ -174,6 +177,10 @@ class I3Extractor(Extractor):
         frame: I3Frame object
         daughters: If True, then ensure that for nugen the primaries are
             only the in-ice neutrinos, otherwise all primaries are returned.
+        highest_energy_primary: If True, return the primary with the highest
+            energy. If False, return all primaries.
+            NOTE: only used for non corsika events and only makes a difference
+            if daughters is False.
         """
         assert hasattr(
             self, "mctree"
@@ -211,10 +218,12 @@ class I3Extractor(Extractor):
                 self.warning_once("No in-ice neutrino found for NuGen event")
                 return dataclasses.ListI3Particle()
 
-            energies = np.array([p.energy for p in primaries])
+            if highest_energy_primary:
+                energies = np.array([p.energy for p in primaries])
 
-            primaries = np.array(primaries)[np.argmax(energies)]
-            primaries = dataclasses.ListI3Particle([primaries])
+                primaries = [np.array(primaries)[np.argmax(energies)]]
+
+            primaries = dataclasses.ListI3Particle(primaries)
         if self._is_corsika:
             primaries = frame[self.mctree].get_primaries()
         return primaries

--- a/src/graphnet/data/extractors/icecube/i3filtermapextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3filtermapextractor.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
 class I3FilterMapExtractor(I3Extractor):
     """Class for extracting I3FilterMap properties.
 
-    This class extracts the boolean condition of the I3FilterMask from the
-    I3FilterMap in the frame.
+    This class extracts the boolean condition of the I3FilterMask from
+    the I3FilterMap in the frame.
     """
 
     def __init__(


### PR DESCRIPTION
This PR addresses the problem in #817.

As a fix to Problem 1 explained in #817, I introduce a function `find_in_ice_daughters` that recursively looks for in-ice particles in the subtree of the primary neutrino.

This solution makes sure that ...
- one finds the in-ice particle, no matter how many interactions the primary neutrino undergoes outside of ice. 
-  only the first in-ice particle is returned, mitigating the issue of returning a `primaries` list of particles where one of the particles might be a daughter of another (as explained in #817)
- no particle that is a daughter of a background particle is returned

As a fix to Problem 2 explained in #817, I introduce the argument `highest_energy_primary` that allows to return all primaries found instead of only the highest-energy one in the case of a NuGen file