### PR TITLE
Fix I3HighestEparticleExtractor

### DIFF
--- a/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
@@ -429,9 +429,9 @@ class I3HighestEparticleExtractor(I3Extractor):
                 visible_length,
                 -1,
             )
-        else:
-            energies = e_p[0]
-            particles = e_p[1]
+
+        energies = e_p[0]
+        particles = e_p[1]
 
         pos, direc, lengths = self.get_pos_dir_length(particles)
         pos = pos + direc * lengths

--- a/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
@@ -224,7 +224,9 @@ class I3HighestEparticleExtractor(I3Extractor):
         lengths[np.isnan(lengths)] = 0
         return pos, direc, lengths
 
-    def get_bundle_HEP(self, particles: np.array) -> "dataclasses.I3Particle":
+    def get_bundle_HEP(
+        self, particles: np.array
+    ) -> Tuple["dataclasses.I3Particle", np.ndarray, bool]:
         """Get the energy averaged particle of a list of particles.
 
         Args:

--- a/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
@@ -340,10 +340,16 @@ class I3HighestEparticleExtractor(I3Extractor):
 
                         # a skimming track can be outside the hull
                         # therefore it can have 0 visible length
-                        visible_length = max(
-                            0,
-                            intersections.second - max(intersections.first, 0),
+                        visible_length = intersections.second - max(
+                            intersections.first, 0
                         )
+
+                        # It can happen that both intersections are negative
+                        # in this case the particle never reaches the detector
+                        # and therefore should not be considered for the HEP
+                        if visible_length < 0:
+                            continue
+
                         e_mask = energies > EonEntrance
                         energies = energies[e_mask]
                         MMCTrackList = MMCTrackList[e_mask]
@@ -727,6 +733,10 @@ class I3HighestEparticleExtractor(I3Extractor):
                     containment = (
                         GN_containment_types.throughgoing_bundle.value
                     )
+
+        assert (
+            visible_length >= 0
+        ), f"Visible length is negative for particle {frame['I3EventHeader']}"
 
         closest_pos = np.sum(closest_pos, axis=0) / EonEntrance
 

--- a/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
@@ -490,10 +490,17 @@ class I3HighestEparticleExtractor(I3Extractor):
                 intersections = self.hull.surface.intersection(
                     track.pos, track.dir
                 )
-                visible_length = max(
-                    visible_length,
-                    intersections.second - max(intersections.first, 0),
+
+                visible_length = intersections.second - max(
+                    intersections.first, 0
                 )
+
+                # It can happen that both intersections are negative
+                # in this case the particle never reaches the detector
+                # and therefore should not be considered for the HEP
+                if visible_length < 0:
+                    continue
+
                 # Check if we have a single topologically "real" track
                 if not real_track:
                     if not dataclasses.I3MCTree.parent(

--- a/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
@@ -707,6 +707,11 @@ class I3HighestEparticleExtractor(I3Extractor):
                 MGtrack.pos, MGtrack.dir
             )
 
+            # Particles that passed the sphere check but
+            # do not actually intersect the hull
+            if intersections.second < 0:
+                continue
+
             track_energy = MGtrack.get_energy(intersections.first)
             EonEntrance += track_energy
 
@@ -733,6 +738,19 @@ class I3HighestEparticleExtractor(I3Extractor):
                     containment = (
                         GN_containment_types.throughgoing_bundle.value
                     )
+
+        # If no intersection.second is every positive
+        # the visible_length can still be negative here
+        # this means that all particles that passed the
+        # sphere check do not actually make it to the real hull
+        if visible_length < 0:
+            return (
+                dataclasses.I3Particle(),
+                0.0,
+                -1.0,
+                -1,
+                GN_containment_types.no_intersect.value,
+            )
 
         assert (
             visible_length >= 0

--- a/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py
@@ -335,8 +335,12 @@ class I3HighestEparticleExtractor(I3Extractor):
                         EonEntrance = MGtrack.get_energy(
                             max(intersections.first, 0)
                         )
-                        visible_length = intersections.second - max(
-                            intersections.first, 0
+
+                        # a skimming track can be outside the hull
+                        # therefore it can have 0 visible length
+                        visible_length = max(
+                            0,
+                            intersections.second - max(intersections.first, 0),
                         )
                         e_mask = energies > EonEntrance
                         energies = energies[e_mask]


### PR DESCRIPTION
This PR addresses the bugs explained in #821.

# Solving Issues

## 1. Negative visible length
set visible length to 0 if it would be negative

## 2. Track filtering only for top-level primaries
Look, if a track particle is in the subtree of any primary, not if the head-level primary is in the `primaries` list

## 3. Wrong return in `get_bundle_HEP`
return the right tuple

Additionally, I introduced the `get_descendants` function, which accelerates this code snippet:

https://github.com/graphnet-team/graphnet/blob/f3faff18f6caeddb7159b9d02910e17e33b8e9ad/src/graphnet/data/extractors/icecube/i3highesteparticleextractor.py#L399-L414

by not iterating through all particles, but only the descendants of the primaries