### PR TITLE
Fix CUDA 12_6 and 12_8 installation commands

### DIFF
--- a/docs/source/installation/quick-start.html
+++ b/docs/source/installation/quick-start.html
@@ -174,6 +174,8 @@
       },
       "torch-2.7.0": {
         "cu118": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118",
+        "cu126": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126",
+        "cu128": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
         "cpu": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
       }
     };


### PR DESCRIPTION
The installation commands for torch2.7.0 still use the default "cpu" pytorch wheel for CUDA 12.6 and 12.8. I added the option to have the correct CUDA version instead.