### PR TITLE
fix typo: "EventProprties" -> "EventProperties"

### DIFF
--- a/src/graphnet/data/extractors/icecube/i3truthextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3truthextractor.py
@@ -515,7 +515,7 @@ class I3TruthExtractor(I3Extractor):
             sim_type = "genie"
         elif "noise" in input_file:
             sim_type = "noise"
-        elif frame.Has("EventProprties") or frame.Has(
+        elif frame.Has("EventProperties") or frame.Has(
             "LeptonInjectorProperties"
         ):
             sim_type = "LeptonInjector"


### PR DESCRIPTION
Fixes a typo in src/graphnet/data/extractors/icecube/i3truthextractor.py (line 518): "EventProprties" -> "EventProperties".