### PR TITLE
Save event_no as a non-index column in ParquetWriter

### DIFF
--- a/src/graphnet/data/writers/parquet_writer.py
+++ b/src/graphnet/data/writers/parquet_writer.py
@@ -55,7 +55,7 @@ class ParquetWriter(GraphNeTWriter):
 
                 table_dir = os.path.join(save_path, f"{table}")
                 os.makedirs(table_dir, exist_ok=True)
-                df = data[table].set_index(self._index_column)
+                df = data[table]
                 df.to_parquet(
                     os.path.join(table_dir, file_name + f"_{table}.parquet")
                 )
@@ -199,8 +199,8 @@ class ParquetWriter(GraphNeTWriter):
                     id = split[index_column][split["file_name"] == unique_file]
 
                     # Filter out indices that point to empty events
-                    idx = [i for i in id if i in df.index]
-                    table_shards.append(df.loc[idx, :])
+                    idx = [i for i in id if i in set(df[index_column])]
+                    table_shards.append(df[df[index_column].isin(idx)])
 
                 os.makedirs(os.path.join(outdir, table), exist_ok=True)
                 if len(table_shards) > 0:


### PR DESCRIPTION
The main change here is that instead of setting the `self._index_column` to the index, we just let it stay as a normal column in the dataframe/parquet file.

This way later we don't get 'column not found' errors when merging files in these places:
- `_process_shard()` when calling `id = split[index_column]`
- `_identify_events()` when doing `df.select([index_column])` 

This fixes the bug I was having but would need a maintainer/expert to let me know if this might mess things up downstream, i.e. if somewhere else `event_no` is expected as an index column. In this case we could just set the index again at the very end of the merging process.

Fixes #871