### PR TITLE
Add IceTop support to I3TruthExtractor

### DIFF
--- a/src/graphnet/data/extractors/icecube/i3truthextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3truthextractor.py
@@ -175,6 +175,7 @@ class I3TruthExtractor(I3Extractor):
         if frame["I3EventHeader"].sub_event_stream not in [
             "InIceSplit",
             "Final",
+            "ice_top",
         ]:
             return output
 
@@ -289,6 +290,9 @@ class I3TruthExtractor(I3Extractor):
     def _extract_dbang_decay_length(
         self, frame: "icetray.I3Frame", padding_value: float = -1
     ) -> float:
+        if self._mctree not in frame:
+            return padding_value
+            
         mctree = frame[self._mctree]
         try:
             p_true = mctree.primaries[0]
@@ -418,7 +422,10 @@ class I3TruthExtractor(I3Extractor):
             try:
                 MCInIcePrimary = frame["MCInIcePrimary"]
             except KeyError:
-                MCInIcePrimary = frame[self._mctree][0]
+                try:
+                    MCInIcePrimary = frame[self._mctree][0]
+                except KeyError:
+                    MCInIcePrimary = frame["MCPrimary"]  # IceTop CORSIKA primary
             if (
                 MCInIcePrimary.energy != MCInIcePrimary.energy
             ):  # This is a nan check. Only happens for some muons
@@ -472,6 +479,9 @@ class I3TruthExtractor(I3Extractor):
             Tuple containing the energy of tracks from primary, and the
                 corresponding inelasticity.
         """
+        if self._mctree not in frame:
+            return float("nan"), float("nan"), float("nan")
+            
         mc_tree = frame[self._mctree]
         primary = mc_tree.primaries[0]
         daughters = mc_tree.get_daughters(primary)
@@ -509,7 +519,7 @@ class I3TruthExtractor(I3Extractor):
             sim_type = "data"
         elif "muon" in input_file:
             sim_type = "muongun"
-        elif "corsika" in input_file:
+        elif "corsika" in input_file or frame.Has("MCPrimary"):
             sim_type = "corsika"
         elif "genie" in input_file or "nu" in input_file.lower():
             sim_type = "genie"

--- a/src/graphnet/data/extractors/icecube/i3truthextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3truthextractor.py
@@ -32,6 +32,7 @@ class I3TruthExtractor(I3Extractor):
         mctree: Optional[str] = "I3MCTree",
         extend_boundary: Optional[float] = 0.0,
         exclude: list = [None],
+        ice_top: bool = False,
     ):
         """Construct I3TruthExtractor.
 
@@ -45,6 +46,7 @@ class I3TruthExtractor(I3Extractor):
             extend_boundary: Distance to extend the convex hull of the detector
                 for defining starting events.
             exclude: List of keys to exclude from the extracted data.
+            ice_top: Whether the data being extracted is IceTop data. Defaults to False.
         """
         # Base class constructor
         super().__init__(name, exclude=exclude)
@@ -89,6 +91,7 @@ class I3TruthExtractor(I3Extractor):
 
         self._extend_boundary = extend_boundary
         self._mctree = mctree
+        self._ice_top = ice_top
 
     def set_gcd(self, i3_file: str, gcd_file: Optional[str] = None) -> None:
         """Extract GFrame and CFrame from i3/gcd-file pair.
@@ -130,8 +133,8 @@ class I3TruthExtractor(I3Extractor):
         self, frame: "icetray.I3Frame", padding_value: Any = -1
     ) -> Dict[str, Any]:
         """Extract truth-level information."""
-        is_mc = frame_is_montecarlo(frame, self._mctree)
-        is_noise = frame_is_noise(frame, self._mctree)
+        is_mc = frame_is_montecarlo(frame, self._mctree, self._ice_top)
+        is_noise = frame_is_noise(frame, self._mctree, self._ice_top)
         sim_type = self._find_data_type(is_mc, self._i3_file, frame)
 
         output = {
@@ -172,11 +175,11 @@ class I3TruthExtractor(I3Extractor):
         # for example I3RecoPulseSeriesMap,  etc.
         # At low levels i3 files contain several other P frame splits
         # (e.g NullSplit). We remove those here.
-        if frame["I3EventHeader"].sub_event_stream not in [
-            "InIceSplit",
-            "Final",
-            "ice_top",
-        ]:
+        allowed_streams = ["InIceSplit", "Final"]
+        if self._ice_top:
+            allowed_streams.append("ice_top")
+
+        if frame["I3EventHeader"].sub_event_stream not in allowed_streams:
             return output
 
         if "FilterMask" in frame:
@@ -251,8 +254,12 @@ class I3TruthExtractor(I3Extractor):
                     "pid": MCInIcePrimary.pdg_encoding,
                     "interaction_type": interaction_type,
                     "elasticity": elasticity,
-                    "dbang_decay_length": self._extract_dbang_decay_length(
-                        frame, padding_value
+                    "dbang_decay_length": (
+                        padding_value
+                        if self._ice_top
+                        else self._extract_dbang_decay_length(
+                            frame, padding_value
+                        )
                     ),
                     "energy_track": energy_track,
                     "energy_cascade": energy_cascade,
@@ -290,9 +297,6 @@ class I3TruthExtractor(I3Extractor):
     def _extract_dbang_decay_length(
         self, frame: "icetray.I3Frame", padding_value: float = -1
     ) -> float:
-        if self._mctree not in frame:
-            return padding_value
-            
         mctree = frame[self._mctree]
         try:
             p_true = mctree.primaries[0]
@@ -419,20 +423,20 @@ class I3TruthExtractor(I3Extractor):
                 or 0 (neither); and the elasticity in the range ]0,1[.
         """
         if sim_type != "noise":
-            try:
-                MCInIcePrimary = frame["MCInIcePrimary"]
-            except KeyError:
+            if self._ice_top:
+                MCInIcePrimary = frame["MCPrimary"]  # IceTop CORSIKA primary
+            else:
                 try:
-                    MCInIcePrimary = frame[self._mctree][0]
+                    MCInIcePrimary = frame["MCInIcePrimary"]
                 except KeyError:
-                    MCInIcePrimary = frame["MCPrimary"]  # IceTop CORSIKA primary
-            if (
-                MCInIcePrimary.energy != MCInIcePrimary.energy
-            ):  # This is a nan check. Only happens for some muons
-                # where second item in MCTree is primary. Weird!
-                MCInIcePrimary = frame[self._mctree][1]
-                # For some strange reason the second entry is identical in
-                # all variables and has no nans (always muon)
+                    MCInIcePrimary = frame[self._mctree][0]
+                if (
+                    MCInIcePrimary.energy != MCInIcePrimary.energy
+                ):  # This is a nan check. Only happens for some muons
+                    # where second item in MCTree is primary. Weird!
+                    MCInIcePrimary = frame[self._mctree][1]
+                    # For some strange reason the second entry is identical in
+                    # all variables and has no nans (always muon)
         else:
             MCInIcePrimary = None
 
@@ -479,9 +483,11 @@ class I3TruthExtractor(I3Extractor):
             Tuple containing the energy of tracks from primary, and the
                 corresponding inelasticity.
         """
-        if self._mctree not in frame:
-            return float("nan"), float("nan"), float("nan")
-            
+        if self._ice_top and self._mctree not in frame:
+            raise RuntimeError(
+                f"Expected MCTree key '{self._mctree}' not found in frame for IceTop data."
+            )
+
         mc_tree = frame[self._mctree]
         primary = mc_tree.primaries[0]
         daughters = mc_tree.get_daughters(primary)
@@ -519,7 +525,7 @@ class I3TruthExtractor(I3Extractor):
             sim_type = "data"
         elif "muon" in input_file:
             sim_type = "muongun"
-        elif "corsika" in input_file or frame.Has("MCPrimary"):
+        elif "corsika" in input_file or self._ice_top:
             sim_type = "corsika"
         elif "genie" in input_file or "nu" in input_file.lower():
             sim_type = "genie"

--- a/src/graphnet/data/extractors/icecube/i3truthextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3truthextractor.py
@@ -177,7 +177,7 @@ class I3TruthExtractor(I3Extractor):
         # (e.g NullSplit). We remove those here.
         allowed_streams = ["InIceSplit", "Final"]
         if self._ice_top:
-            allowed_streams.append("ice_top")
+            allowed_streams = ["ice_top"]
 
         if frame["I3EventHeader"].sub_event_stream not in allowed_streams:
             return output

--- a/src/graphnet/data/extractors/icecube/utilities/frames.py
+++ b/src/graphnet/data/extractors/icecube/utilities/frames.py
@@ -15,7 +15,7 @@ def frame_is_montecarlo(
     frame: "icetray.I3Frame", mctree: Optional[str] = "I3MCTree"
 ) -> bool:
     """Check whether `frame` is from Monte Carlo simulation."""
-    return ("MCInIcePrimary" in frame) or (mctree in frame)
+    return ("MCInIcePrimary" in frame) or ("MCPrimary" in frame) or (mctree in frame)
 
 
 def frame_is_noise(
@@ -30,8 +30,11 @@ def frame_is_noise(
             frame["MCInIcePrimary"].energy
             return False
         except:  # noqa: E722
-            return True
-
+            try:
+                frame["MCPrimary"].energy  # IceTop CORSIKA primary
+                return False
+            except:  # noqa: E722
+                return True
 
 def get_om_keys_and_pulseseries(
     frame: "icetray.I3Frame",

--- a/src/graphnet/data/extractors/icecube/utilities/frames.py
+++ b/src/graphnet/data/extractors/icecube/utilities/frames.py
@@ -12,16 +12,29 @@ if has_icecube_package():
 
 
 def frame_is_montecarlo(
-    frame: "icetray.I3Frame", mctree: Optional[str] = "I3MCTree"
+    frame: "icetray.I3Frame",
+    mctree: Optional[str] = "I3MCTree",
+    ice_top: bool = False,
 ) -> bool:
     """Check whether `frame` is from Monte Carlo simulation."""
-    return ("MCInIcePrimary" in frame) or ("MCPrimary" in frame) or (mctree in frame)
+    if ice_top:
+        return "MCPrimary" in frame
+    return ("MCInIcePrimary" in frame) or (mctree in frame)
 
 
 def frame_is_noise(
-    frame: "icetray.I3Frame", mctree: Optional[str] = "I3MCTree"
+    frame: "icetray.I3Frame",
+    mctree: Optional[str] = "I3MCTree",
+    ice_top: bool = False,
 ) -> bool:
     """Check whether `frame` is from noise."""
+    if ice_top:
+        try:
+            frame["MCPrimary"].energy
+            return False
+        except:  # noqa: E722
+            return True
+
     try:
         frame[mctree][0].energy
         return False
@@ -30,11 +43,8 @@ def frame_is_noise(
             frame["MCInIcePrimary"].energy
             return False
         except:  # noqa: E722
-            try:
-                frame["MCPrimary"].energy  # IceTop CORSIKA primary
-                return False
-            except:  # noqa: E722
-                return True
+            return True
+
 
 def get_om_keys_and_pulseseries(
     frame: "icetray.I3Frame",


### PR DESCRIPTION
Adds an ice_top boolean toggle to I3TruthExtractor that enables correct extraction of truth-level information from IceTop frames. Closes #874 .

**Changes**
Added ice_top parameter to I3TruthExtractor.__init__
Updated allowed sub-event streams to include ice_top when ice_top=True
Skips _extract_dbang_decay_length and _get_primary_track_energy_and_inelasticity for IceTop frames
Updated _get_primary_particle_interaction_type_and_elasticity to explicitly use "MCPrimary" for IceTop frames
Updated _find_data_type to correctly identify IceTop MC as "corsika"
Updated frame_is_montecarlo and frame_is_noise to use IceTop-specific frame keys when ice_top=True

**Testing**
Verified that existing in-ice behavior is fully preserved when ice_top=False (default)
Verified that IceTop frames are correctly identified as "corsika" MC and return non-padding truth values when ice_top=True as shown in the screenshot:
<img width="1691" height="211" alt="image" src="https://github.com/user-attachments/assets/d4fa3bd4-edc4-4fe3-87d3-e929b1bb1e6b" />