### PR TITLE
Lmdb test fix

### DIFF
--- a/src/graphnet/data/dataset/lmdb/lmdb_dataset.py
+++ b/src/graphnet/data/dataset/lmdb/lmdb_dataset.py
@@ -169,9 +169,9 @@ class LMDBDataset(Dataset):
         if self._pre_computed_representation is None:
             # Only check for missing columns if using raw tables
             self._remove_missing_columns()
-        self._close_connection()
         if self._pre_computed_representation is not None:
             self._identify_missing_truth_labels()
+        self._close_connection()
 
     def _identify_missing_truth_labels(self) -> None:
         """Identify missing truth labels in the pre-computed representation."""

--- a/src/graphnet/data/dataset/lmdb/lmdb_dataset.py
+++ b/src/graphnet/data/dataset/lmdb/lmdb_dataset.py
@@ -430,3 +430,7 @@ class LMDBDataset(Dataset):
             data = super().__getitem__(sequential_index)
 
         return data
+
+    def close(self) -> None:
+        """Close any open LMDB connections."""
+        self._close_connection()

--- a/tests/data/test_dataconverters_and_datasets.py
+++ b/tests/data/test_dataconverters_and_datasets.py
@@ -296,7 +296,6 @@ def test_sqlite_to_lmdb_converter() -> None:
         truth=TRUTH.DEEPCORE,
         graph_definition=graph_definition,
     )
-
     dataset_from_lmdb_raw = LMDBDataset(path, **opt_raw)  # type: ignore
     dataset_sqlite = SQLiteDataset(
         get_file_path("sqlite"), **opt_raw  # type: ignore[arg-type]
@@ -310,6 +309,7 @@ def test_sqlite_to_lmdb_converter() -> None:
             dataset_from_lmdb_raw[ix].x, dataset_sqlite[ix].x
         )
 
+    dataset_from_lmdb_raw.close()  # Close connection
     # Test 2: Check that pre-computed representation matches real-time computed
     # The pre-computed representation field name is the class name
     pre_computed_field_name = graph_definition.__class__.__name__
@@ -361,3 +361,4 @@ def test_sqlite_to_lmdb_converter() -> None:
                     )
                 else:
                     assert precomputed_truth == realtime_truth
+    dataset_from_lmdb_precomputed.close()  # Close connection


### PR DESCRIPTION
The current checks are running into an error, the inital merge of #852 did not seem to have the test fail but all subsequent PR's have the test failing. (I also reran the test for #852 and the test seems to fail, it is beyond me how it passed initially...) 

The error comes from opening multiple connections of the same LMDB database which does not seem to be allowed. This runs into an error at https://github.com/graphnet-team/graphnet/blob/847775711f93b8e9b6f7a40db72886b970462102/src/graphnet/data/utilities/lmdb_utilities.py#L62 which is caught and `None` is returned for https://github.com/graphnet-team/graphnet/blob/847775711f93b8e9b6f7a40db72886b970462102/src/graphnet/data/utilities/lmdb_utilities.py#L50 . My impression is that https://github.com/graphnet-team/graphnet/blob/847775711f93b8e9b6f7a40db72886b970462102/src/graphnet/data/dataset/lmdb/lmdb_dataset.py#L340 is properly handled by the dataloaders and why this has not shown up as an issue in real use. 

The fix I propose is to add a public close() (which just calls the private _close_connection(), this is more convention than anything else) and then call the close() in the test before testing the precomputed dataset version. 

Another minor adjustment i made is move the close_connection() call to the end of the post_init() call, this is just a small refactoring.