### PR TITLE
fix: quote pip install extras to fix zsh globbing error

### DIFF
--- a/docs/source/installation/quick-start.html
+++ b/docs/source/installation/quick-start.html
@@ -170,14 +170,14 @@
         "# Clone and Install GraphNeT",
         gitCloneCmd,
         "cd graphnet",
-        "pip3 install -e .[develop]"
+        "pip3 install -e \".[develop]\""
       ].join("\n"));
       return;
     }
 
     var torchVersion = torchWheelMap[torch];
     var extrasPrefix = torchExtrasMap[torch];
-    var installLine = "pip3 install -e .[" + extrasPrefix + "]";
+    var installLine = "pip3 install -e \".[" + extrasPrefix + "]\"";
     var wheelUrl = "https://data.pyg.org/whl/torch-" + torchVersion + "+" + (cuda === "cpu" ? "cpu" : cuda) + ".html";
     installLine += " -f " + wheelUrl;
 

--- a/docs/source/installation/quick-start.html
+++ b/docs/source/installation/quick-start.html
@@ -177,7 +177,7 @@
 
     var torchVersion = torchWheelMap[torch];
     var extrasPrefix = torchExtrasMap[torch];
-    var installLine = "pip3 install -e \".[" + extrasPrefix + "]\"";
+    var installLine = "pip3 install -e \".[develop," + extrasPrefix + "]\"";
     var wheelUrl = "https://data.pyg.org/whl/torch-" + torchVersion + "+" + (cuda === "cpu" ? "cpu" : cuda) + ".html";
     installLine += " -f " + wheelUrl;
 


### PR DESCRIPTION
## Summary

Fixes #869.

- Wrap `.[extras]` in double quotes in `quick-start.html` so the generated `pip install` commands are shell-safe on Zsh (macOS default), where unquoted square brackets are treated as glob patterns causing `zsh: no matches found: .[develop]`
- Include the `develop` extras in all installation configurations (both w/o PyTorch and with PyTorch) so dev tools (`black`, `pytest`, `mypy`, etc.) are always available