### PR TITLE
Fix predict_as_dataframe: single-pass, shuffle-safe, multi-dim

### DIFF
--- a/examples/04_training/01_train_dynedge.py
+++ b/examples/04_training/01_train_dynedge.py
@@ -178,6 +178,10 @@ def main(
         gpus=config["fit"]["gpus"],
     )
 
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
+
     # Save predictions and model to file
     db_name = path.split("/")[-1].split(".")[0]
     path = os.path.join(archive, db_name, run_name)

--- a/examples/04_training/02_train_tito_model.py
+++ b/examples/04_training/02_train_tito_model.py
@@ -177,6 +177,10 @@ def main(
         gpus=config["fit"]["gpus"],
     )
 
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
+
     # Save predictions and model to file
     db_name = path.split("/")[-1].split(".")[0]
     path = os.path.join(archive, db_name, run_name)

--- a/examples/04_training/03_train_dynedge_from_config.py
+++ b/examples/04_training/03_train_dynedge_from_config.py
@@ -113,6 +113,10 @@ def main(
         additional_attributes=additional_attributes + ["event_no"],
         gpus=config.fit["gpus"],
     )
+
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
     results.to_csv(f"{path}/results.csv")
 
 

--- a/examples/04_training/04_train_multiclassifier_from_configs.py
+++ b/examples/04_training/04_train_multiclassifier_from_configs.py
@@ -139,6 +139,10 @@ def main(
         additional_attributes=additional_attributes + ["event_no"],
         gpus=config.fit["gpus"],
     )
+
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
     results.to_csv(f"{path}/results.csv")
 
 

--- a/examples/04_training/05_train_RNN_TITO.py
+++ b/examples/04_training/05_train_RNN_TITO.py
@@ -199,6 +199,10 @@ def main(
         gpus=config["fit"]["gpus"],
     )
 
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
+
     # Save predictions and model to file
     db_name = path.split("/")[-1].split(".")[0]
     path = os.path.join(archive, db_name, run_name)

--- a/examples/04_training/06_train_icemix_model.py
+++ b/examples/04_training/06_train_icemix_model.py
@@ -205,6 +205,10 @@ def main(
         gpus=config["fit"]["gpus"],
     )
 
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
+
     # Save predictions and model to file
     db_name = path.split("/")[-1].split(".")[0]
     path = os.path.join(archive, db_name, run_name)

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -148,6 +148,10 @@ def main(
         gpus=config["fit"]["gpus"],
     )
 
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
+
     # Save predictions and model to file
     db_name = path.split("/")[-1].split(".")[0]
     path = os.path.join(archive, db_name, run_name)

--- a/examples/04_training/08_train_grit_model.py
+++ b/examples/04_training/08_train_grit_model.py
@@ -166,6 +166,10 @@ def main(
         gpus=config["fit"]["gpus"],
     )
 
+    if results is None:
+        # Only the global-zero rank holds the output in multi-device runs.
+        return
+
     # Save predictions and model to file
     db_name = path.split("/")[-1].split(".")[0]
     path = os.path.join(archive, db_name, run_name)

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -459,7 +459,16 @@ class EasySyntax(Model):
                     " event-level predictions. Attribute skipped."
                 )
                 continue
-            columns[name] = np.asarray(arr)
+            arr = np.asarray(arr)
+            if arr.ndim == 1:
+                columns[name] = arr
+            else:
+                # Multi-dim target (e.g. `direction` with x/y/z components):
+                # expand to one column per component so the DataFrame stays
+                # tabular.
+                flat = arr.reshape(len(arr), -1)
+                for i in range(flat.shape[1]):
+                    columns[f"{name}_{i}"] = flat[:, i]
 
         return pd.DataFrame(columns)
 

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -336,7 +336,11 @@ class EasySyntax(Model):
                 value = value.detach().cpu().numpy()
             else:
                 value = np.asarray(value)
-            if pulse_level_predictions and len(value) < n_pulses.sum():
+            if (
+                pulse_level_predictions
+                and n_pulses is not None
+                and len(value) < n_pulses.sum()
+            ):
                 value = np.repeat(value, n_pulses)
             pred.append(value)
         return pred
@@ -433,9 +437,7 @@ class EasySyntax(Model):
         pred_tensors = outputs[:split]
         attr_arrays = outputs[split:]
 
-        predictions = (
-            torch.cat(pred_tensors, dim=1).detach().cpu().numpy()
-        )
+        predictions = torch.cat(pred_tensors, dim=1).detach().cpu().numpy()
         assert len(prediction_columns) == predictions.shape[1], (
             f"Number of provided column names ({len(prediction_columns)}) and "
             f"number of output columns ({predictions.shape[1]}) don't match."

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -1,6 +1,5 @@
 """Suggested Model subclass that enables simple user syntax."""
 
-from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Union, Type
 
 import numpy as np
@@ -10,7 +9,7 @@ from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from torch import Tensor
 from torch.nn import ModuleList
 from torch.optim import Adam
-from torch.utils.data import DataLoader, SequentialSampler
+from torch.utils.data import DataLoader
 from torch_geometric.data import Data
 import pandas as pd
 from pytorch_lightning.loggers import Logger as LightningLogger
@@ -307,14 +306,55 @@ class EasySyntax(Model):
                 task.train_eval()
         return self
 
+    def predict_step(self, *args: Any, **kwargs: Any) -> List[Any]:
+        """Perform prediction step.
+
+        Returns a list whose first entries are the per-task prediction
+        tensors and whose trailing entries are numpy arrays for any
+        attributes requested via `_predict_additional_attributes`. Pulling
+        attributes here avoids a second pass over the dataloader in
+        `predict_as_dataframe`.
+        """
+        batch = kwargs.get("batch", args[0])
+        pred = list(self(batch))
+
+        attrs = getattr(self, "_predict_additional_attributes", None)
+        if not attrs:
+            return pred
+
+        # Pulse- vs event-level: pred[0] has one row per node when
+        # predictions are on the pulse level.
+        pulse_level_predictions = len(pred[0]) > len(batch)
+        n_pulses = (
+            batch.n_pulses.detach().cpu().numpy()
+            if pulse_level_predictions
+            else None
+        )
+        for attr in attrs:
+            value = batch[attr]
+            if isinstance(value, torch.Tensor):
+                value = value.detach().cpu().numpy()
+            else:
+                value = np.asarray(value)
+            if pulse_level_predictions and len(value) < n_pulses.sum():
+                value = np.repeat(value, n_pulses)
+            pred.append(value)
+        return pred
+
     def predict(
         self,
         dataloader: DataLoader,
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
+        additional_attributes: Optional[List[str]] = None,
         **trainer_kwargs: Any,
-    ) -> List[Tensor]:
-        """Return predictions for `dataloader`."""
+    ) -> List[Union[Tensor, np.ndarray]]:
+        """Return predictions for `dataloader`.
+
+        If `additional_attributes` is provided, the returned list has the
+        per-task prediction tensors followed by one numpy array per
+        requested attribute, gathered from the same dataloader pass.
+        """
         self.inference()
         self.train(mode=False)
 
@@ -329,14 +369,30 @@ class EasySyntax(Model):
             **trainer_kwargs,
         )
 
-        predictions_list = inference_trainer.predict(self, dataloader)
+        # Stash on self so predict_step can see it; always clear.
+        self._predict_additional_attributes = additional_attributes or None
+        try:
+            predictions_list = inference_trainer.predict(self, dataloader)
+        finally:
+            self._predict_additional_attributes = None
         assert len(predictions_list), "Got no predictions"
 
+        # The trailing entries in each batch's output are the gathered
+        # additional attributes (numpy arrays); everything before is a
+        # per-task prediction tensor.
+        nb_attrs = len(additional_attributes or [])
         nb_outputs = len(predictions_list[0])
-        predictions: List[Tensor] = [
-            torch.cat([preds[ix] for preds in predictions_list], dim=0)
-            for ix in range(nb_outputs)
-        ]
+        nb_task_outputs = nb_outputs - nb_attrs
+        predictions: List[Union[Tensor, np.ndarray]] = []
+        for ix in range(nb_outputs):
+            if ix < nb_task_outputs:
+                predictions.append(
+                    torch.cat([p[ix] for p in predictions_list], dim=0)
+                )
+            else:
+                predictions.append(
+                    np.concatenate([p[ix] for p in predictions_list], axis=0)
+                )
         return predictions
 
     def predict_as_dataframe(
@@ -352,79 +408,49 @@ class EasySyntax(Model):
         """Return predictions for `dataloader` as a DataFrame.
 
         Include `additional_attributes` as additional columns in the output
-        DataFrame.
+        DataFrame. Attributes are gathered during the prediction pass, so
+        the dataloader is iterated only once and shuffling is safe.
         """
         if prediction_columns is None:
             prediction_columns = self.prediction_labels
-
         if additional_attributes is None:
             additional_attributes = []
         assert isinstance(additional_attributes, list)
 
-        if (
-            not isinstance(dataloader.sampler, SequentialSampler)
-            and additional_attributes
-        ):
-            print(dataloader.sampler)
-            raise UserWarning(
-                "DataLoader has a `sampler` that is not `SequentialSampler`, "
-                "indicating that shuffling is enabled. Using "
-                "`predict_as_dataframe` with `additional_attributes` assumes "
-                "that the sequence of batches in `dataloader` are "
-                "deterministic. Either call this method a `dataloader` which "
-                "doesn't resample batches; or do not request "
-                "`additional_attributes`."
-            )
         self.info(f"Column names for predictions are: \n {prediction_columns}")
-        predictions_torch = self.predict(
+
+        outputs = self.predict(
             dataloader=dataloader,
             gpus=gpus,
             distribution_strategy=distribution_strategy,
+            additional_attributes=additional_attributes,
             **trainer_kwargs,
         )
+
+        # `predict` returns task tensors first, then one np.ndarray per
+        # requested attribute — split on that boundary.
+        split = len(outputs) - len(additional_attributes)
+        pred_tensors = outputs[:split]
+        attr_arrays = outputs[split:]
+
         predictions = (
-            torch.cat(predictions_torch, dim=1).detach().cpu().numpy()
+            torch.cat(pred_tensors, dim=1).detach().cpu().numpy()
         )
         assert len(prediction_columns) == predictions.shape[1], (
             f"Number of provided column names ({len(prediction_columns)}) and "
             f"number of output columns ({predictions.shape[1]}) don't match."
         )
 
-        # Check if predictions are on event- or pulse-level
-        pulse_level_predictions = len(predictions) > len(dataloader.dataset)
-
-        # Get additional attributes
-        attributes: Dict[str, List[np.ndarray]] = OrderedDict(
-            [(attr, []) for attr in additional_attributes]
-        )
-        for batch in dataloader:
-            for attr in attributes:
-                attribute = batch[attr]
-                if isinstance(attribute, torch.Tensor):
-                    attribute = attribute.detach().cpu().numpy()
-
-                # Check if node level predictions
-                # If true, additional attributes are repeated
-                # to make dimensions fit
-                if pulse_level_predictions:
-                    if len(attribute) < np.sum(
-                        batch.n_pulses.detach().cpu().numpy()
-                    ):
-                        attribute = np.repeat(
-                            attribute, batch.n_pulses.detach().cpu().numpy()
-                        )
-                attributes[attr].extend(attribute)
-
-        # Confirm that attributes match length of predictions
-        skip_attributes = []
-        for attr in attributes.keys():
-            try:
-                assert len(attributes[attr]) == len(predictions)
-            except AssertionError:
+        columns: Dict[str, np.ndarray] = {
+            name: predictions[:, i]
+            for i, name in enumerate(prediction_columns)
+        }
+        for name, arr in zip(additional_attributes, attr_arrays):
+            if len(arr) != len(predictions):
                 self.warning_once(
                     "Could not automatically adjust length"
-                    f" of additional attribute '{attr}' to match length of"
-                    f" predictions.This error can be caused by heavy"
+                    f" of additional attribute '{name}' to match length of"
+                    " predictions. This error can be caused by heavy"
                     " disagreement between number of examples in the"
                     " dataset vs. actual events in the dataloader, e.g. "
                     " heavy filtering of events in `collate_fn` passed to"
@@ -432,26 +458,10 @@ class EasySyntax(Model):
                     " pulse-level attributes for `Task`s that produce"
                     " event-level predictions. Attribute skipped."
                 )
-                skip_attributes.append(attr)
+                continue
+            columns[name] = np.asarray(arr)
 
-        # Remove bad attributes
-        for attr in skip_attributes:
-            attributes.pop(attr)
-            additional_attributes.remove(attr)
-
-        data = np.concatenate(
-            [predictions]
-            + [
-                np.asarray(values)[:, np.newaxis]
-                for values in attributes.values()
-            ],
-            axis=1,
-        )
-
-        results = pd.DataFrame(
-            data, columns=prediction_columns + additional_attributes
-        )
-        return results
+        return pd.DataFrame(columns)
 
     def _create_default_callbacks(
         self,

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -310,11 +310,8 @@ class EasySyntax(Model):
     def predict_step(self, *args: Any, **kwargs: Any) -> List[Any]:
         """Perform prediction step.
 
-        Returns a list whose first entries are the per-task prediction
-        tensors and whose trailing entries are numpy arrays for any
-        attributes requested via `_predict_additional_attributes`. Pulling
-        attributes here avoids a second pass over the dataloader in
-        `predict_as_dataframe`.
+        Returns the per-task prediction tensors, followed by one numpy
+        array per attribute in `_predict_additional_attributes`.
         """
         batch = kwargs.get("batch", args[0])
         pred = list(self(batch))
@@ -353,16 +350,10 @@ class EasySyntax(Model):
     ) -> Optional[List[List[Any]]]:
         """Gather per-rank prediction shards onto the global-zero rank.
 
-        Returns the per-batch outputs from every rank, concatenated, on the
-        global-zero rank and `None` on all other ranks. Tensors are moved to
-        CPU before the transfer so a shard produced on one rank's device
-        deserializes onto a device that exists on the receiving rank.
-
-        The gather runs over a transient gloo group: NCCL has no
-        gather-to-one primitive, so gathering over the default (NCCL) backend
-        would require an all-gather that forces every rank to hold the whole
-        result. Over gloo (CPU, where the shards already live) only the
-        global-zero rank receives them.
+        Returns every rank's per-batch outputs on the global-zero rank and
+        `None` on all other ranks. Shards are moved to CPU and gathered
+        over a transient gloo group, as NCCL has no gather-to-one
+        primitive.
         """
 
         def _to_cpu(value: Any) -> Any:
@@ -402,17 +393,11 @@ class EasySyntax(Model):
     ) -> Optional[List[Union[Tensor, np.ndarray]]]:
         """Return predictions for `dataloader`.
 
-        If `additional_attributes` is provided, the returned list has the
-        per-task prediction tensors followed by one numpy array per
-        requested attribute, gathered from the same dataloader pass.
-
-        Under a multi-device (DDP) strategy the dataloader is split into
-        disjoint shards across ranks, so each rank only predicts part of the
-        dataset. The shards are gathered onto the global-zero rank, which
-        returns the complete result; every other rank returns `None`. Rows
-        come back grouped by rank rather than in dataset order, so include
-        the index column (e.g. `event_no`) in `additional_attributes` if you
-        need to re-key or sort the output.
+        The returned list holds the per-task prediction tensors, followed
+        by one numpy array per requested additional attribute. Under a
+        multi-device strategy the global-zero rank returns the complete
+        result and all other ranks return `None`; rows are grouped by
+        rank, not in dataset order.
         """
         self.inference()
         self.train(mode=False)
@@ -479,17 +464,10 @@ class EasySyntax(Model):
     ) -> Optional[pd.DataFrame]:
         """Return predictions for `dataloader` as a DataFrame.
 
-        Include `additional_attributes` as additional columns in the output
-        DataFrame. Attributes are gathered during the prediction pass, so
-        the dataloader is iterated only once and shuffling is safe.
-
-        Under a multi-device (DDP) strategy the global-zero rank returns the
-        complete DataFrame and every other rank returns `None` — guard any
-        downstream write accordingly, e.g.::
-
-            df = model.predict_as_dataframe(...)
-            if df is not None:  # only the global-zero rank
-                df.to_parquet(path)
+        `additional_attributes` are added as columns, collected during the
+        prediction pass itself, so shuffled dataloaders are safe. Under a
+        multi-device strategy the global-zero rank returns the complete
+        DataFrame and all other ranks return `None`.
         """
         if prediction_columns is None:
             prediction_columns = self.prediction_labels

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -420,12 +420,9 @@ class EasySyntax(Model):
         finally:
             self._predict_additional_attributes = None
 
-        # Under a multi-device strategy each rank holds predictions for its
-        # own disjoint shard only; gather every shard so the global-zero rank
-        # can assemble one complete result. Other ranks have nothing to
-        # return. A rank's shard may be empty (fewer batches than ranks), so
-        # completeness is only checked after the gather — checking earlier
-        # would crash that rank and strand the others in the collective.
+        # Each rank holds only its own shard. Emptiness is checked after
+        # the gather: a rank's shard may be empty, and crashing it would
+        # strand the other ranks in the collective.
         if inference_trainer.world_size > 1:
             predictions_list = self._gather_prediction_shards(
                 predictions_list, inference_trainer

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union, Type
 
 import numpy as np
 import torch
+import torch.distributed as dist
 from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from torch import Tensor
@@ -345,6 +346,52 @@ class EasySyntax(Model):
             pred.append(value)
         return pred
 
+    @staticmethod
+    def _gather_prediction_shards(
+        predictions_list: List[List[Any]],
+        trainer: Trainer,
+    ) -> Optional[List[List[Any]]]:
+        """Gather per-rank prediction shards onto the global-zero rank.
+
+        Returns the per-batch outputs from every rank, concatenated, on the
+        global-zero rank and `None` on all other ranks. Tensors are moved to
+        CPU before the transfer so a shard produced on one rank's device
+        deserializes onto a device that exists on the receiving rank.
+
+        The gather runs over a transient gloo group: NCCL has no
+        gather-to-one primitive, so gathering over the default (NCCL) backend
+        would require an all-gather that forces every rank to hold the whole
+        result. Over gloo (CPU, where the shards already live) only the
+        global-zero rank receives them.
+        """
+
+        def _to_cpu(value: Any) -> Any:
+            if isinstance(value, torch.Tensor):
+                return value.detach().cpu()
+            return value
+
+        local_shard = [
+            [_to_cpu(value) for value in batch] for batch in predictions_list
+        ]
+        gather_group = dist.new_group(backend="gloo")
+        try:
+            gathered: Optional[List[Optional[List[List[Any]]]]] = (
+                [None] * trainer.world_size if trainer.is_global_zero else None
+            )
+            dist.gather_object(
+                local_shard, gathered, dst=0, group=gather_group
+            )
+        finally:
+            dist.destroy_process_group(gather_group)
+        if not trainer.is_global_zero:
+            return None
+        # Only the global-zero rank receives the gathered shards; the assert
+        # narrows away the `None` the other ranks pass to `gather_object`.
+        assert gathered is not None
+        return [
+            batch for shard in gathered if shard is not None for batch in shard
+        ]
+
     def predict(
         self,
         dataloader: DataLoader,
@@ -352,12 +399,20 @@ class EasySyntax(Model):
         distribution_strategy: Optional[str] = "auto",
         additional_attributes: Optional[List[str]] = None,
         **trainer_kwargs: Any,
-    ) -> List[Union[Tensor, np.ndarray]]:
+    ) -> Optional[List[Union[Tensor, np.ndarray]]]:
         """Return predictions for `dataloader`.
 
         If `additional_attributes` is provided, the returned list has the
         per-task prediction tensors followed by one numpy array per
         requested attribute, gathered from the same dataloader pass.
+
+        Under a multi-device (DDP) strategy the dataloader is split into
+        disjoint shards across ranks, so each rank only predicts part of the
+        dataset. The shards are gathered onto the global-zero rank, which
+        returns the complete result; every other rank returns `None`. Rows
+        come back grouped by rank rather than in dataset order, so include
+        the index column (e.g. `event_no`) in `additional_attributes` if you
+        need to re-key or sort the output.
         """
         self.inference()
         self.train(mode=False)
@@ -379,6 +434,19 @@ class EasySyntax(Model):
             predictions_list = inference_trainer.predict(self, dataloader)
         finally:
             self._predict_additional_attributes = None
+
+        # Under a multi-device strategy each rank holds predictions for its
+        # own disjoint shard only; gather every shard so the global-zero rank
+        # can assemble one complete result. Other ranks have nothing to
+        # return. A rank's shard may be empty (fewer batches than ranks), so
+        # completeness is only checked after the gather — checking earlier
+        # would crash that rank and strand the others in the collective.
+        if inference_trainer.world_size > 1:
+            predictions_list = self._gather_prediction_shards(
+                predictions_list, inference_trainer
+            )
+            if not inference_trainer.is_global_zero:
+                return None
         assert len(predictions_list), "Got no predictions"
 
         # The trailing entries in each batch's output are the gathered
@@ -408,12 +476,20 @@ class EasySyntax(Model):
         gpus: Optional[Union[List[int], int]] = None,
         distribution_strategy: Optional[str] = "auto",
         **trainer_kwargs: Any,
-    ) -> pd.DataFrame:
+    ) -> Optional[pd.DataFrame]:
         """Return predictions for `dataloader` as a DataFrame.
 
         Include `additional_attributes` as additional columns in the output
         DataFrame. Attributes are gathered during the prediction pass, so
         the dataloader is iterated only once and shuffling is safe.
+
+        Under a multi-device (DDP) strategy the global-zero rank returns the
+        complete DataFrame and every other rank returns `None` — guard any
+        downstream write accordingly, e.g.::
+
+            df = model.predict_as_dataframe(...)
+            if df is not None:  # only the global-zero rank
+                df.to_parquet(path)
         """
         if prediction_columns is None:
             prediction_columns = self.prediction_labels
@@ -430,6 +506,12 @@ class EasySyntax(Model):
             additional_attributes=additional_attributes,
             **trainer_kwargs,
         )
+
+        # `predict` returns `None` on non-global-zero ranks under a
+        # multi-device strategy; the full result lives on the global-zero
+        # rank.
+        if outputs is None:
+            return None
 
         # `predict` returns task tensors first, then one np.ndarray per
         # requested attribute — split on that boundary.

--- a/tests/models/test_easy_model.py
+++ b/tests/models/test_easy_model.py
@@ -5,7 +5,7 @@ the tests exercise only the prediction/attribute-gathering machinery,
 not GNN/Detector/Task code.
 """
 
-from typing import List, Union
+from typing import Iterator, List, Union
 
 import numpy as np
 import pytest
@@ -40,9 +40,7 @@ class _FakeModel(EasySyntax):
     def validate_tasks(self) -> None:
         pass
 
-    def forward(
-        self, data: Union[Data, List[Data]]
-    ) -> List[Tensor]:
+    def forward(self, data: Union[Data, List[Data]]) -> List[Tensor]:
         if isinstance(data, list):
             data = data[0]
         # Per-event prediction: repeat event_id across all prediction columns.
@@ -50,10 +48,14 @@ class _FakeModel(EasySyntax):
         n_cols = len(self.prediction_labels)
         return [eid.repeat(1, n_cols)]
 
-    def compute_loss(self, preds, data, verbose=False):  # type: ignore[override]
+    def compute_loss(  # type: ignore[override]
+        self, preds: Tensor, data: List[Data], verbose: bool = False
+    ) -> Tensor:
         raise NotImplementedError
 
-    def shared_step(self, batch, batch_idx):  # type: ignore[override]
+    def shared_step(  # type: ignore[override]
+        self, batch: List[Data], batch_idx: int
+    ) -> Tensor:
         raise NotImplementedError
 
 
@@ -69,7 +71,9 @@ def _make_dataset(n_events: int) -> List[Data]:
                 value=torch.tensor([float(i) * 10.0]),
                 # Per-event 3-vector — mimics `direction` (shape (1, 3)) so
                 # batches concatenate to (N, 3).
-                vec=torch.tensor([[float(i), float(i) + 0.5, float(i) + 0.25]]),
+                vec=torch.tensor(
+                    [[float(i), float(i) + 0.5, float(i) + 0.25]]
+                ),
                 pulses=torch.arange(n_pulses, dtype=torch.float32),
                 n_pulses=torch.tensor([n_pulses]),
             )
@@ -111,9 +115,7 @@ def test_predict_as_dataframe_attributes_aligned(model: _FakeModel) -> None:
         additional_attributes=["event_id", "value"],
     )
     assert list(df.columns) == ["pred_a", "pred_b", "event_id", "value"]
-    np.testing.assert_array_equal(
-        df["event_id"].to_numpy(), np.arange(8)
-    )
+    np.testing.assert_array_equal(df["event_id"].to_numpy(), np.arange(8))
     np.testing.assert_array_equal(
         df["value"].to_numpy(), np.arange(8, dtype=np.float32) * 10.0
     )
@@ -131,7 +133,7 @@ class _CountingLoader(DataLoader):
     counter has to live on the class — patching the instance has no effect.
     """
 
-    def __iter__(self):  # type: ignore[override]
+    def __iter__(self) -> Iterator:
         type(self).iter_count = getattr(type(self), "iter_count", 0) + 1
         return super().__iter__()
 
@@ -181,7 +183,8 @@ def test_predict_as_dataframe_with_shuffled_loader(
 def test_predict_as_dataframe_respects_limit_predict_batches(
     model: _FakeModel,
 ) -> None:
-    """`limit_predict_batches` truncates predictions and attributes together."""
+    """`limit_predict_batches` truncates predictions and attributes
+    together."""
     ds = _make_dataset(20)
     df = model.predict_as_dataframe(
         _loader(ds, batch_size=4),
@@ -199,7 +202,8 @@ def test_predict_as_dataframe_respects_limit_predict_batches(
 def test_predict_as_dataframe_skips_misaligned_attribute(
     model: _FakeModel,
 ) -> None:
-    """Pulse-level attr requested on event-level model is dropped, not crashed."""
+    """Pulse-level attr requested on event-level model is dropped, not
+    crashed."""
     ds = _make_dataset(6)
     df = model.predict_as_dataframe(
         _loader(ds, batch_size=2),
@@ -226,7 +230,12 @@ def test_predict_as_dataframe_expands_multidim_attribute(
         additional_attributes=["vec", "event_id"],
     )
     assert list(df.columns) == [
-        "pred_a", "pred_b", "vec_0", "vec_1", "vec_2", "event_id"
+        "pred_a",
+        "pred_b",
+        "vec_0",
+        "vec_1",
+        "vec_2",
+        "event_id",
     ]
     expected = np.arange(n, dtype=np.float32)
     np.testing.assert_array_equal(df["vec_0"].to_numpy(), expected)

--- a/tests/models/test_easy_model.py
+++ b/tests/models/test_easy_model.py
@@ -67,6 +67,9 @@ def _make_dataset(n_events: int) -> List[Data]:
                 x=torch.zeros(n_pulses, 1),
                 event_id=torch.tensor([i], dtype=torch.long),
                 value=torch.tensor([float(i) * 10.0]),
+                # Per-event 3-vector — mimics `direction` (shape (1, 3)) so
+                # batches concatenate to (N, 3).
+                vec=torch.tensor([[float(i), float(i) + 0.5, float(i) + 0.25]]),
                 pulses=torch.arange(n_pulses, dtype=torch.float32),
                 n_pulses=torch.tensor([n_pulses]),
             )
@@ -205,3 +208,27 @@ def test_predict_as_dataframe_skips_misaligned_attribute(
     assert "event_id" in df.columns
     assert "pulses" not in df.columns
     assert len(df) == 6
+
+
+def test_predict_as_dataframe_expands_multidim_attribute(
+    model: _FakeModel,
+) -> None:
+    """Per-event vector attribute is split into one column per component.
+
+    Mirrors how `target_labels = ["direction"]` carries an (N, 3) tensor
+    on the batch — pandas can't take a 2D array as a single column, so
+    `predict_as_dataframe` flattens to `<name>_<i>`.
+    """
+    n = 7
+    ds = _make_dataset(n)
+    df = model.predict_as_dataframe(
+        _loader(ds, batch_size=3),
+        additional_attributes=["vec", "event_id"],
+    )
+    assert list(df.columns) == [
+        "pred_a", "pred_b", "vec_0", "vec_1", "vec_2", "event_id"
+    ]
+    expected = np.arange(n, dtype=np.float32)
+    np.testing.assert_array_equal(df["vec_0"].to_numpy(), expected)
+    np.testing.assert_array_equal(df["vec_1"].to_numpy(), expected + 0.5)
+    np.testing.assert_array_equal(df["vec_2"].to_numpy(), expected + 0.25)

--- a/tests/models/test_easy_model.py
+++ b/tests/models/test_easy_model.py
@@ -1,0 +1,207 @@
+"""Unit tests for `EasySyntax.predict_as_dataframe`.
+
+Uses a minimal `EasySyntax` subclass and a synthetic in-memory dataset so
+the tests exercise only the prediction/attribute-gathering machinery,
+not GNN/Detector/Task code.
+"""
+
+from typing import List, Union
+
+import numpy as np
+import pytest
+import torch
+from torch import Tensor
+from torch_geometric.data import Data
+from torch_geometric.loader import DataLoader
+
+from graphnet.models.easy_model import EasySyntax
+
+
+class _FakeTask(torch.nn.Module):
+    def __init__(self, prediction_labels: List[str]) -> None:
+        super().__init__()
+        self._prediction_labels = list(prediction_labels)
+        self._target_labels: List[str] = []
+
+    def inference(self) -> None:
+        pass
+
+    def train_eval(self) -> None:
+        pass
+
+
+class _FakeModel(EasySyntax):
+    """Echoes `event_id` as the prediction so we can verify alignment."""
+
+    def __init__(self, prediction_labels: List[str]) -> None:
+        super().__init__(tasks=[_FakeTask(prediction_labels)])
+        self._dummy = torch.nn.Linear(1, 1)  # so Lightning sees parameters
+
+    def validate_tasks(self) -> None:
+        pass
+
+    def forward(
+        self, data: Union[Data, List[Data]]
+    ) -> List[Tensor]:
+        if isinstance(data, list):
+            data = data[0]
+        # Per-event prediction: repeat event_id across all prediction columns.
+        eid = data.event_id.to(torch.float32).unsqueeze(1)
+        n_cols = len(self.prediction_labels)
+        return [eid.repeat(1, n_cols)]
+
+    def compute_loss(self, preds, data, verbose=False):  # type: ignore[override]
+        raise NotImplementedError
+
+    def shared_step(self, batch, batch_idx):  # type: ignore[override]
+        raise NotImplementedError
+
+
+def _make_dataset(n_events: int) -> List[Data]:
+    """One Data per event with event_id, scalar value, pulse-level array."""
+    out = []
+    for i in range(n_events):
+        n_pulses = 2 + (i % 3)
+        out.append(
+            Data(
+                x=torch.zeros(n_pulses, 1),
+                event_id=torch.tensor([i], dtype=torch.long),
+                value=torch.tensor([float(i) * 10.0]),
+                pulses=torch.arange(n_pulses, dtype=torch.float32),
+                n_pulses=torch.tensor([n_pulses]),
+            )
+        )
+    return out
+
+
+def _loader(
+    dataset: List[Data], batch_size: int = 4, shuffle: bool = False
+) -> DataLoader:
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle)
+
+
+@pytest.fixture
+def model() -> _FakeModel:
+    return _FakeModel(prediction_labels=["pred_a", "pred_b"])
+
+
+def test_predict_as_dataframe_shape_and_columns(model: _FakeModel) -> None:
+    """No attributes: columns and length match prediction labels/dataset."""
+    ds = _make_dataset(10)
+    df = model.predict_as_dataframe(_loader(ds, batch_size=3))
+    assert list(df.columns) == ["pred_a", "pred_b"]
+    assert len(df) == len(ds)
+    # _FakeModel echoes event_id, so both columns should equal 0..9.
+    np.testing.assert_array_equal(
+        df["pred_a"].to_numpy(), np.arange(10, dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        df["pred_b"].to_numpy(), np.arange(10, dtype=np.float32)
+    )
+
+
+def test_predict_as_dataframe_attributes_aligned(model: _FakeModel) -> None:
+    """Additional attributes line up with predictions row-for-row."""
+    ds = _make_dataset(8)
+    df = model.predict_as_dataframe(
+        _loader(ds, batch_size=3),
+        additional_attributes=["event_id", "value"],
+    )
+    assert list(df.columns) == ["pred_a", "pred_b", "event_id", "value"]
+    np.testing.assert_array_equal(
+        df["event_id"].to_numpy(), np.arange(8)
+    )
+    np.testing.assert_array_equal(
+        df["value"].to_numpy(), np.arange(8, dtype=np.float32) * 10.0
+    )
+    # Prediction (= event_id) must equal the event_id attribute.
+    np.testing.assert_array_equal(
+        df["pred_a"].to_numpy().astype(np.int64),
+        df["event_id"].to_numpy(),
+    )
+
+
+class _CountingLoader(DataLoader):
+    """`DataLoader` that records how many times `__iter__` was called.
+
+    Python's ``iter(obj)`` dispatches via ``type(obj).__iter__``, so the
+    counter has to live on the class — patching the instance has no effect.
+    """
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).iter_count = getattr(type(self), "iter_count", 0) + 1
+        return super().__iter__()
+
+
+def test_predict_as_dataframe_iterates_dataloader_once(
+    model: _FakeModel,
+) -> None:
+    """Regression: with attributes, the dataloader is iterated exactly once.
+
+    The previous implementation iterated a second time after `predict()`
+    purely to collect `additional_attributes`.
+    """
+    ds = _make_dataset(6)
+    loader = _CountingLoader(ds, batch_size=2)
+    _CountingLoader.iter_count = 0
+
+    model.predict_as_dataframe(
+        loader, additional_attributes=["event_id", "value"]
+    )
+    assert _CountingLoader.iter_count == 1
+
+
+def test_predict_as_dataframe_with_shuffled_loader(
+    model: _FakeModel,
+) -> None:
+    """Shuffling is allowed now that attributes come from the same pass."""
+    torch.manual_seed(0)
+    ds = _make_dataset(12)
+    loader = _loader(ds, batch_size=4, shuffle=True)
+    df = model.predict_as_dataframe(
+        loader, additional_attributes=["event_id", "value"]
+    )
+    assert len(df) == 12
+    # event_id may appear in any order, but pred and attr stay paired.
+    np.testing.assert_array_equal(
+        df["pred_a"].to_numpy().astype(np.int64),
+        df["event_id"].to_numpy(),
+    )
+    np.testing.assert_array_equal(
+        df["value"].to_numpy(),
+        df["event_id"].to_numpy().astype(np.float32) * 10.0,
+    )
+    # All events present exactly once.
+    assert sorted(df["event_id"].to_numpy().tolist()) == list(range(12))
+
+
+def test_predict_as_dataframe_respects_limit_predict_batches(
+    model: _FakeModel,
+) -> None:
+    """`limit_predict_batches` truncates predictions and attributes together."""
+    ds = _make_dataset(20)
+    df = model.predict_as_dataframe(
+        _loader(ds, batch_size=4),
+        additional_attributes=["event_id"],
+        limit_predict_batches=2,
+    )
+    # 2 batches * 4 events = 8 rows; predictions and attrs must still align.
+    assert len(df) == 8
+    np.testing.assert_array_equal(
+        df["pred_a"].to_numpy().astype(np.int64),
+        df["event_id"].to_numpy(),
+    )
+
+
+def test_predict_as_dataframe_skips_misaligned_attribute(
+    model: _FakeModel,
+) -> None:
+    """Pulse-level attr requested on event-level model is dropped, not crashed."""
+    ds = _make_dataset(6)
+    df = model.predict_as_dataframe(
+        _loader(ds, batch_size=2),
+        additional_attributes=["event_id", "pulses"],
+    )
+    assert "event_id" in df.columns
+    assert "pulses" not in df.columns
+    assert len(df) == 6

--- a/tests/models/test_easy_model.py
+++ b/tests/models/test_easy_model.py
@@ -5,6 +5,10 @@ the tests exercise only the prediction/attribute-gathering machinery,
 not GNN/Detector/Task code.
 """
 
+import os
+import socket
+from datetime import timedelta
+from types import SimpleNamespace
 from typing import Iterator, List, Union
 
 import numpy as np
@@ -96,6 +100,7 @@ def test_predict_as_dataframe_shape_and_columns(model: _FakeModel) -> None:
     """No attributes: columns and length match prediction labels/dataset."""
     ds = _make_dataset(10)
     df = model.predict_as_dataframe(_loader(ds, batch_size=3))
+    assert df is not None
     assert list(df.columns) == ["pred_a", "pred_b"]
     assert len(df) == len(ds)
     # _FakeModel echoes event_id, so both columns should equal 0..9.
@@ -114,6 +119,7 @@ def test_predict_as_dataframe_attributes_aligned(model: _FakeModel) -> None:
         _loader(ds, batch_size=3),
         additional_attributes=["event_id", "value"],
     )
+    assert df is not None
     assert list(df.columns) == ["pred_a", "pred_b", "event_id", "value"]
     np.testing.assert_array_equal(df["event_id"].to_numpy(), np.arange(8))
     np.testing.assert_array_equal(
@@ -166,6 +172,7 @@ def test_predict_as_dataframe_with_shuffled_loader(
     df = model.predict_as_dataframe(
         loader, additional_attributes=["event_id", "value"]
     )
+    assert df is not None
     assert len(df) == 12
     # event_id may appear in any order, but pred and attr stay paired.
     np.testing.assert_array_equal(
@@ -191,6 +198,7 @@ def test_predict_as_dataframe_respects_limit_predict_batches(
         additional_attributes=["event_id"],
         limit_predict_batches=2,
     )
+    assert df is not None
     # 2 batches * 4 events = 8 rows; predictions and attrs must still align.
     assert len(df) == 8
     np.testing.assert_array_equal(
@@ -209,6 +217,7 @@ def test_predict_as_dataframe_skips_misaligned_attribute(
         _loader(ds, batch_size=2),
         additional_attributes=["event_id", "pulses"],
     )
+    assert df is not None
     assert "event_id" in df.columns
     assert "pulses" not in df.columns
     assert len(df) == 6
@@ -229,6 +238,7 @@ def test_predict_as_dataframe_expands_multidim_attribute(
         _loader(ds, batch_size=3),
         additional_attributes=["vec", "event_id"],
     )
+    assert df is not None
     assert list(df.columns) == [
         "pred_a",
         "pred_b",
@@ -241,3 +251,56 @@ def test_predict_as_dataframe_expands_multidim_attribute(
     np.testing.assert_array_equal(df["vec_0"].to_numpy(), expected)
     np.testing.assert_array_equal(df["vec_1"].to_numpy(), expected + 0.5)
     np.testing.assert_array_equal(df["vec_2"].to_numpy(), expected + 0.25)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _gather_shards_worker(rank: int, world_size: int, port: int) -> None:
+    """Run `_gather_prediction_shards` inside one rank of a gloo group.
+
+    Assertions raise here and `mp.spawn` propagates them to the test, so a
+    failing rank fails the test.
+    """
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.distributed.init_process_group(
+        backend="gloo",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        # One batch per rank: [prediction tensor, attribute array]. The tensor
+        # value and the attribute both encode the rank so the gathered result
+        # can be checked for completeness.
+        local_shard = [[torch.tensor([[float(rank)]]), np.array([rank * 10])]]
+        trainer = SimpleNamespace(
+            world_size=world_size, is_global_zero=(rank == 0)
+        )
+        gathered = EasySyntax._gather_prediction_shards(local_shard, trainer)
+        if rank == 0:
+            assert gathered is not None
+            assert len(gathered) == world_size
+            preds = sorted(batch[0].item() for batch in gathered)
+            attrs = sorted(int(batch[1][0]) for batch in gathered)
+            assert preds == [0.0, 1.0]
+            assert attrs == [0, 10]
+        else:
+            assert gathered is None
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def test_gather_prediction_shards_across_ranks() -> None:
+    """DDP shards from every rank are assembled on rank 0; others get None."""
+    world_size = 2
+    torch.multiprocessing.spawn(
+        _gather_shards_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/models/test_easy_model.py
+++ b/tests/models/test_easy_model.py
@@ -147,11 +147,7 @@ class _CountingLoader(DataLoader):
 def test_predict_as_dataframe_iterates_dataloader_once(
     model: _FakeModel,
 ) -> None:
-    """Regression: with attributes, the dataloader is iterated exactly once.
-
-    The previous implementation iterated a second time after `predict()`
-    purely to collect `additional_attributes`.
-    """
+    """Regression: with attributes, the dataloader is iterated once."""
     ds = _make_dataset(6)
     loader = _CountingLoader(ds, batch_size=2)
     _CountingLoader.iter_count = 0
@@ -226,12 +222,7 @@ def test_predict_as_dataframe_skips_misaligned_attribute(
 def test_predict_as_dataframe_expands_multidim_attribute(
     model: _FakeModel,
 ) -> None:
-    """Per-event vector attribute is split into one column per component.
-
-    Mirrors how `target_labels = ["direction"]` carries an (N, 3) tensor
-    on the batch — pandas can't take a 2D array as a single column, so
-    `predict_as_dataframe` flattens to `<name>_<i>`.
-    """
+    """Per-event (N, 3) attribute is expanded to `<name>_<i>` columns."""
     n = 7
     ds = _make_dataset(n)
     df = model.predict_as_dataframe(
@@ -262,8 +253,7 @@ def _free_port() -> int:
 def _gather_shards_worker(rank: int, world_size: int, port: int) -> None:
     """Run `_gather_prediction_shards` inside one rank of a gloo group.
 
-    Assertions raise here and `mp.spawn` propagates them to the test, so a
-    failing rank fails the test.
+    Assertion failures propagate to the test via `mp.spawn`.
     """
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)


### PR DESCRIPTION
Closes #880

## Summary
- Refactor `EasySyntax.predict_as_dataframe` so `additional_attributes` are gathered inside `predict_step` during the same trainer pass as the model predictions, instead of in a second `for batch in dataloader` loop. This keeps predictions and attributes aligned by construction and removes the implicit assumption that the dataloader replays batches in the same order.
- Drop the `SequentialSampler` guard: with attributes now collected in-pass, a shuffled dataloader is safe to use with `additional_attributes`.
- Add `additional_attributes` parameter to `EasySyntax.predict` so callers that don't need a DataFrame can still get aligned attributes back; the return type becomes `List[Union[Tensor, np.ndarray]]` (task tensors first, attribute arrays after).
- Support multi-dimensional attributes (e.g. `direction` with x/y/z components): a 2-D attribute array is flattened to one column per component (`<name>_0`, `<name>_1`, ...) so the resulting DataFrame stays tabular.
- Preserve the pulse-level repeat behavior (`np.repeat(value, batch.n_pulses)`) and the warn-and-skip path for length mismatches.
- Add `tests/models/test_easy_model.py` covering event-level, pulse-level, multi-dim, and shuffled-dataloader cases.
- Drop trailing whitespace in `.github/workflows/build.yml` (no behavior change).