### PR TITLE
chore: bump pre-commit hook versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt update --fix-missing --yes
           sudo apt upgrade --yes
           sudo apt-get install --yes git
-          sudo apt-get clean 
+          sudo apt-get clean
 
       - uses: actions/checkout@v4
 
@@ -88,9 +88,9 @@ jobs:
           python --version
           pip show setuptools
           rm -rf ~/.cache/pip
-      
+
       - name: Print available disk space before graphnet install
-        run: | 
+        run: |
           df -h
       - name: Upgrade packages in virtual environment
         shell: bash
@@ -128,7 +128,7 @@ jobs:
           pip show torch-scatter
           pip show jammy_flows
       - name: Print available disk space after graphnet install
-        run: | 
+        run: |
           df -h
       - name: Run unit tests and generate coverage report
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 exclude: '^(versioneer.py|src/graphnet/_version.py|docs/)'
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.3.1
     hooks:
     - id: black
       language_version: python3
       args: [--config=black.toml]
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: ["--config=.flake8", "--show-source", "--statistics"]
@@ -22,13 +22,13 @@ repos:
     - id: pydocstyle
       language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.20.2
     hooks:
     - id: mypy
       args: [--follow-imports=silent, --disallow-untyped-defs, --disallow-incomplete-defs, --disallow-untyped-calls]
       language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/docker/gnn-benchmarking/apply.py
+++ b/docker/gnn-benchmarking/apply.py
@@ -15,7 +15,6 @@ from graphnet.data.extractors.i3featureextractor import (
 from graphnet.data.constants import FEATURES
 from graphnet.constants import PRETRAINED_MODEL_DIR
 
-
 # Constants
 MODEL_NAME = "total_neutrino_energy"
 BASE_PATH = f"{PRETRAINED_MODEL_DIR}/icecube/upgrade/QUESO"

--- a/examples/01_icetray/01_convert_i3_files.py
+++ b/examples/01_icetray/01_convert_i3_files.py
@@ -160,11 +160,9 @@ if __name__ == "__main__":
     if not has_icecube_package():
         Logger(log_folder=None).error(ERROR_MESSAGE_MISSING_ICETRAY)
     else:
-        parser = ArgumentParser(
-            description="""
+        parser = ArgumentParser(description="""
 Convert I3 files to an intermediate format.
-"""
-        )
+""")
 
         parser.add_argument(
             "backend",

--- a/examples/01_icetray/02_compare_sqlite_and_parquet.py
+++ b/examples/01_icetray/02_compare_sqlite_and_parquet.py
@@ -88,12 +88,10 @@ if __name__ == "__main__":
 
     else:
         # Parse command-line arguments
-        parser = ArgumentParser(
-            description="""
+        parser = ArgumentParser(description="""
 Convert I3 files to both SQLite and Parquet formats, and see that the results
 agree.
-"""
-        )
+""")
 
         args, unknown = parser.parse_known_args()
 

--- a/examples/01_icetray/03_i3_deployer_example.py
+++ b/examples/01_icetray/03_i3_deployer_example.py
@@ -87,11 +87,9 @@ if __name__ == "__main__":
 
     else:
         # Parse command-line arguments
-        parser = ArgumentParser(
-            description="""
+        parser = ArgumentParser(description="""
 Use GraphNeTI3Modules to deploy trained model with GraphNeTI3Deployer.
-"""
-        )
+""")
 
         args, unknown = parser.parse_known_args()
 

--- a/examples/01_icetray/04_i3_module_in_native_icetray_example.py
+++ b/examples/01_icetray/04_i3_module_in_native_icetray_example.py
@@ -119,11 +119,9 @@ if __name__ == "__main__":
 
     else:
         # Parse command-line arguments
-        parser = ArgumentParser(
-            description="""
+        parser = ArgumentParser(description="""
 Use GraphNeTI3Modules to deploy trained model in native IceTray.
-"""
-        )
+""")
 
         args, unknown = parser.parse_known_args()
 

--- a/examples/01_icetray/05_convert_i3_files_advanced.py
+++ b/examples/01_icetray/05_convert_i3_files_advanced.py
@@ -187,11 +187,9 @@ if __name__ == "__main__":
         Logger(log_folder=None).error(ERROR_MESSAGE_MISSING_ICETRAY)
     else:
         # Parse command-line arguments
-        parser = ArgumentParser(
-            description="""
+        parser = ArgumentParser(description="""
 Convert I3 files to an intermediate format.
-"""
-        )
+""")
 
         parser.add_argument("--merge", type=bool, default=True)
         parser.add_argument("--remove", type=bool, default=True)

--- a/examples/02_data/01_read_dataset.py
+++ b/examples/02_data/01_read_dataset.py
@@ -107,11 +107,9 @@ def main(backend: str) -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Read a few events from data in an intermediate format.
-"""
-    )
+""")
 
     parser.add_argument(
         "backend",

--- a/examples/02_data/02_plot_feature_distributions.py
+++ b/examples/02_data/02_plot_feature_distributions.py
@@ -60,11 +60,9 @@ def main() -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Plot feature distributions in dataset.
-"""
-    )
+""")
 
     args, unknown = parser.parse_known_args()
 

--- a/examples/02_data/03_convert_parquet_to_sqlite.py
+++ b/examples/02_data/03_convert_parquet_to_sqlite.py
@@ -37,11 +37,9 @@ def main(parquet_path: str, tables: List[str]) -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Convert Parquet files to SQLite database.
-"""
-    )
+""")
 
     parser.add_argument(
         "--parquet-path",

--- a/examples/02_data/04_ensemble_dataset.py
+++ b/examples/02_data/04_ensemble_dataset.py
@@ -80,10 +80,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Combine multiple Datasets using EnsembleDataset.
-"""
-    )
+""")
     args, unknown = parser.parse_known_args()
     main()

--- a/examples/03_weights/01_fit_uniform_weights.py
+++ b/examples/03_weights/01_fit_uniform_weights.py
@@ -31,11 +31,9 @@ def main() -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Fit per-event weights to make the truth-level zenith distribution uniform.
-"""
-    )
+""")
 
     args, unknown = parser.parse_known_args()
 

--- a/examples/03_weights/02_fit_bjoern_low_weights.py
+++ b/examples/03_weights/02_fit_bjoern_low_weights.py
@@ -39,11 +39,9 @@ def main() -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Fit per-event weights according to the `BjoernLow` weight fitter.
-"""
-    )
+""")
 
     args, unknown = parser.parse_known_args()
 

--- a/examples/04_training/01_train_dynedge.py
+++ b/examples/04_training/01_train_dynedge.py
@@ -196,11 +196,9 @@ def main(
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train GNN model without the use of config files.
-"""
-    )
+""")
 
     parser.add_argument(
         "--path",

--- a/examples/04_training/02_train_tito_model.py
+++ b/examples/04_training/02_train_tito_model.py
@@ -194,11 +194,9 @@ def main(
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train GNN model without the use of config files.
-"""
-    )
+""")
 
     parser.add_argument(
         "--path",

--- a/examples/04_training/03_train_dynedge_from_config.py
+++ b/examples/04_training/03_train_dynedge_from_config.py
@@ -118,11 +118,9 @@ def main(
 
 if __name__ == "__main__":
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train GNN model.
-"""
-    )
+""")
 
     parser.with_standard_arguments(
         "dataset-config",

--- a/examples/04_training/04_train_multiclassifier_from_configs.py
+++ b/examples/04_training/04_train_multiclassifier_from_configs.py
@@ -144,11 +144,9 @@ def main(
 
 if __name__ == "__main__":
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
             Train GNN classification model.
-            """
-    )
+            """)
 
     parser.with_standard_arguments(
         (

--- a/examples/04_training/05_train_RNN_TITO.py
+++ b/examples/04_training/05_train_RNN_TITO.py
@@ -216,11 +216,9 @@ def main(
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train GNN model without the use of config files.
-"""
-    )
+""")
 
     parser.add_argument(
         "--path",

--- a/examples/04_training/06_train_icemix_model.py
+++ b/examples/04_training/06_train_icemix_model.py
@@ -222,11 +222,9 @@ def main(
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train GNN model without the use of config files.
-"""
-    )
+""")
 
     parser.add_argument(
         "--path",

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -166,11 +166,9 @@ def main(
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train conditional NormalizingFlow without the use of config files.
-"""
-    )
+""")
 
     parser.add_argument(
         "--path",

--- a/examples/04_training/08_train_grit_model.py
+++ b/examples/04_training/08_train_grit_model.py
@@ -181,11 +181,9 @@ def main(
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
 Train GNN model without the use of config files.
-"""
-    )
+""")
 
     parser.add_argument(
         "--path",

--- a/examples/05_liquido/01_convert_h5.py
+++ b/examples/05_liquido/01_convert_h5.py
@@ -39,11 +39,9 @@ def main(backend: str) -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
             Convert h5 files from LiquidO to an intermediate format.
-            """
-    )
+            """)
 
     parser.add_argument("backend", choices=["sqlite", "parquet"])
 

--- a/examples/06_prometheus/01_convert_prometheus.py
+++ b/examples/06_prometheus/01_convert_prometheus.py
@@ -42,11 +42,9 @@ def main(backend: str) -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
             Convert parquet files from Prometheus to an intermediate format.
-            """
-    )
+            """)
 
     parser.add_argument("backend", choices=["sqlite", "parquet"])
 

--- a/examples/07_km3net/01_convert_km3net.py
+++ b/examples/07_km3net/01_convert_km3net.py
@@ -71,11 +71,9 @@ def main(backend: str, triggered: str, HNL: str, OUTPUT_DIR: str) -> None:
 if __name__ == "__main__":
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="""
+    parser = ArgumentParser(description="""
             Convert root files from KM3NeT to an sqlite or parquet.
-            """
-    )
+            """)
 
     parser.add_argument(
         "backend",

--- a/src/graphnet/data/datamodule.py
+++ b/src/graphnet/data/datamodule.py
@@ -575,7 +575,7 @@ class GraphNeTDataModule(pl.LightningDataModule, Logger):
             # Construct single dataset
             dataset = self._create_single_dataset(
                 selection=selection,
-                path=self._dataset_args["path"],  # type:ignore
+                path=self._dataset_args["path"],  # type: ignore
             )
         return dataset
 

--- a/src/graphnet/data/dataset/parquet/parquet_dataset.py
+++ b/src/graphnet/data/dataset/parquet/parquet_dataset.py
@@ -258,14 +258,20 @@ class ParquetDataset(Dataset):
         else:
             file_idx = [bisect_right(self._chunk_cumsum, sequential_index)]
 
-        file_indices = [self._indices[idx] for idx in file_idx]
+        raw_file_indices = [self._indices[idx] for idx in file_idx]
+        file_indices: List[int] = []
+        for entry in raw_file_indices:
+            if isinstance(entry, list):
+                file_indices.extend(entry)
+            else:
+                file_indices.append(int(entry))
 
         arrays = []
-        for file_idx in file_indices:
+        for fidx in file_indices:
             array = self._query_table(
                 table=table,
                 columns=columns,
-                file_idx=file_idx,
+                file_idx=fidx,
                 sequential_index=sequential_index,
                 selection=selection,
             )

--- a/src/graphnet/data/extractors/icecube/i3genericextractor.py
+++ b/src/graphnet/data/extractors/icecube/i3genericextractor.py
@@ -15,7 +15,6 @@ from graphnet.data.extractors.icecube.utilities.collections import (
 
 from graphnet.utilities.imports import has_icecube_package
 
-
 if has_icecube_package() or TYPE_CHECKING:
     from icecube import (
         dataclasses,

--- a/src/graphnet/data/extractors/icecube/utilities/collections.py
+++ b/src/graphnet/data/extractors/icecube/utilities/collections.py
@@ -66,7 +66,7 @@ def serialise(obj: Union[Dict, Any]) -> Union[Dict, Any]:
 
 
 def transpose_list_of_dicts(
-    array: List[Dict[str, Any]]
+    array: List[Dict[str, Any]],
 ) -> Dict[str, List[Any]]:
     """Transpose a list of dicts to a dict of lists."""
     if len(array) == 0:

--- a/src/graphnet/data/extractors/icecube/utilities/types.py
+++ b/src/graphnet/data/extractors/icecube/utilities/types.py
@@ -14,7 +14,6 @@ from graphnet.data.extractors.icecube.utilities.frames import (
 from graphnet.utilities.imports import has_icecube_package
 from graphnet.utilities.logging import Logger
 
-
 if has_icecube_package():
     from icecube import (
         icetray,
@@ -58,7 +57,6 @@ def break_cyclic_recursion(fn: Callable) -> Callable:
 
     @wraps(fn)
     def wrapper(obj: Any) -> Any:
-        global BEING_EVALUATED
         try:
             hash_ = (hash(fn), hash(obj))
             if hash_ in BEING_EVALUATED:

--- a/src/graphnet/data/readers/i3reader.py
+++ b/src/graphnet/data/readers/i3reader.py
@@ -12,7 +12,6 @@ from graphnet.data.dataclasses import I3FileSet
 from graphnet.utilities.filesys import find_i3_files
 from .graphnet_file_reader import GraphNeTFileReader
 
-
 if has_icecube_package():
     from icecube import icetray, dataio  # pyright: reportMissingImports=false
 

--- a/src/graphnet/data/readers/km3netreader.py
+++ b/src/graphnet/data/readers/km3netreader.py
@@ -14,7 +14,6 @@ from graphnet.data.extractors.km3net import (
     KM3NeTHNLRecoExtractor,
 )
 
-
 # km3net specific imports
 if has_km3net_package() or TYPE_CHECKING:
     import km3io as ki  # pyright: reportMissingImports=false

--- a/src/graphnet/deployment/deployer.py
+++ b/src/graphnet/deployment/deployer.py
@@ -121,12 +121,8 @@ class Deployer(ABC, Logger):
 
         assert len(settings) == self._n_workers
 
-        self.info(
-            f"""processing {len(input_files)} files \n
-                using {self._n_workers} workers"""
-        )
+        self.info(f"""processing {len(input_files)} files \n
+                using {self._n_workers} workers""")
         self._launch_jobs(settings)
-        self.info(
-            f"""Processing {len(input_files)} files was completed in \n
-         {time.time() - start_time} seconds using {self._n_workers} cores."""
-        )
+        self.info(f"""Processing {len(input_files)} files was completed in \n
+         {time.time() - start_time} seconds using {self._n_workers} cores.""")

--- a/src/graphnet/models/data_representation/data_representation.py
+++ b/src/graphnet/models/data_representation/data_representation.py
@@ -300,11 +300,9 @@ class DataRepresentation(Model):
 
     def _perturb_input(self, input_features: np.ndarray) -> np.ndarray:
         if isinstance(self._perturbation_dict, dict):
-            self.warning_once(
-                f"""Will randomly perturb
+            self.warning_once(f"""Will randomly perturb
                 {list(self._perturbation_dict.keys())}
-                using stds {self._perturbation_dict.values()}"""  # noqa
-            )
+                using stds {self._perturbation_dict.values()}""")  # noqa
             perturbed_features = self.rng.normal(
                 loc=input_features[:, self._perturbation_cols],
                 scale=np.array(

--- a/src/graphnet/models/data_representation/graphs/nodes/nodes.py
+++ b/src/graphnet/models/data_representation/graphs/nodes/nodes.py
@@ -55,13 +55,11 @@ class NodeDefinition(Model):  # pylint: disable=too-few-public-methods
         try:
             self._hidden_output_feature_names
         except AttributeError as e:
-            self.error(
-                f"""{self.__class__.__name__} was instantiated without
+            self.error(f"""{self.__class__.__name__} was instantiated without
                        `input_feature_names` and it was not set prior to this
                        forward call. If you are using this class outside a
                        `GraphDefinition`, please instatiate
-                       with `input_feature_names`."""
-            )  # noqa
+                       with `input_feature_names`.""")  # noqa
             raise e
         return self._hidden_output_feature_names
 
@@ -212,12 +210,10 @@ class PercentileClusters(NodeDefinition):
                 cluster_class.add_counts()
             array = cluster_class.clustered_x
         else:
-            self.error(
-                f"""{self.__class__.__name__} was not instatiated with
+            self.error(f"""{self.__class__.__name__} was not instatiated with
                 `input_feature_names` and has not been set later.
                 Please instantiate this class with `input_feature_names`
-                if you're using it outside `GraphDefinition`."""
-            )  # noqa
+                if you're using it outside `GraphDefinition`.""")  # noqa
             raise AttributeError
 
         return torch.tensor(array)

--- a/src/graphnet/models/detector/detector.py
+++ b/src/graphnet/models/detector/detector.py
@@ -46,10 +46,8 @@ class Detector(Model):
             try:
                 assert hasattr(self, "geometry_table_path")
             except AssertionError as e:
-                self.error(
-                    f"""{self.__class__.__name__} does not have class
-                           variable `geometry_table_path` set."""
-                )
+                self.error(f"""{self.__class__.__name__} does not have class
+                           variable `geometry_table_path` set.""")
                 raise e
             self._geometry_table = pd.read_parquet(self.geometry_table_path)
         return self._geometry_table

--- a/src/graphnet/utilities/argparse.py
+++ b/src/graphnet/utilities/argparse.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional, Union, Tuple
 
 from graphnet.constants import CONFIG_DIR
 
-
 ASCII_LOGO = r"""
   _____              __   _  __  ______
  / ___/______ ____  / /  / |/ /_/_  __/

--- a/src/graphnet/utilities/config/base_config.py
+++ b/src/graphnet/utilities/config/base_config.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, Optional
 from pydantic import BaseModel
 import ruamel.yaml as yaml
 
-
 CONFIG_FILES_SUFFIXES = (".yml", ".yaml")
 
 

--- a/src/graphnet/utilities/config/dataset_config.py
+++ b/src/graphnet/utilities/config/dataset_config.py
@@ -195,7 +195,7 @@ def save_dataset_config(init_fn: Callable) -> Callable:
     )
 
     def _replace_model_instance_with_config(
-        obj: Union["Model", Any]
+        obj: Union["Model", Any],
     ) -> Union[ModelConfig, Any]:
         """Replace `Model` instances in `obj` with their `ModelConfig`."""
         from graphnet.models import Model
@@ -236,7 +236,7 @@ class DatasetConfigSaverMeta(type):
         """Catch object after construction and save config."""
 
         def _replace_model_instance_with_config(
-            obj: Union["Model", Any]
+            obj: Union["Model", Any],
         ) -> Union[ModelConfig, Any]:
             """Replace `Model` instances in `obj` with their `ModelConfig`."""
             from graphnet.models import Model

--- a/src/graphnet/utilities/config/model_config.py
+++ b/src/graphnet/utilities/config/model_config.py
@@ -282,7 +282,7 @@ def save_model_config(init_fn: Callable) -> Callable:
     )
 
     def _replace_model_instance_with_config(
-        obj: Union["Model", Any]
+        obj: Union["Model", Any],
     ) -> Union[ModelConfig, Any]:
         """Replace `Model` instances in `obj` with their `ModelConfig`."""
         from graphnet.models import Model
@@ -322,7 +322,7 @@ class ModelConfigSaverMeta(type):
         """Catch object construction and save config after `__init__`."""
 
         def _replace_model_instance_with_config(
-            obj: Union["Model", Any]
+            obj: Union["Model", Any],
         ) -> Union[ModelConfig, Any]:
             """Replace `Model` instances in `obj` with their `ModelConfig`."""
             from graphnet.models import Model

--- a/src/graphnet/utilities/filesys.py
+++ b/src/graphnet/utilities/filesys.py
@@ -105,9 +105,7 @@ def find_i3_files(
         return i3_files, gcd_files
     else:
         if any([os.path.isdir(input) for input in inputs]):
-            raise ValueError(
-                "Inputs contains a mix of files and directories \
-                which is not supported."
-            )
+            raise ValueError("Inputs contains a mix of files and directories \
+                which is not supported.")
         else:
             raise ValueError("Some inputs are not valid directories or files.")

--- a/src/graphnet/utilities/logging.py
+++ b/src/graphnet/utilities/logging.py
@@ -226,7 +226,6 @@ class Logger:
 
     def warning_once(self, msg: str) -> None:
         """Print `msg` as warning exactly once."""
-        global WARNINGS
         if msg in WARNINGS:
             return
 

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -123,7 +123,7 @@ def test_save_selection(selection: List[int], file_path: str) -> None:
     "dataset_ref", [SQLiteDataset, ParquetDataset], indirect=True
 )
 def test_single_dataset_without_selections(
-    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]]
+    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]],
 ) -> None:
     """Verify GraphNeTDataModule behavior when no test selection is provided.
 
@@ -163,7 +163,7 @@ def test_single_dataset_without_selections(
     "dataset_ref", [SQLiteDataset, ParquetDataset], indirect=True
 )
 def test_single_dataset_with_selections(
-    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]]
+    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]],
 ) -> None:
     """Test that selection functionality of DataModule behaves as expected.
 
@@ -226,7 +226,7 @@ def test_single_dataset_with_selections(
     "dataset_ref", [SQLiteDataset, ParquetDataset], indirect=True
 )
 def test_dataloader_args(
-    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]]
+    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]],
 ) -> None:
     """Test that arguments to dataloaders are propagated correctly.
 
@@ -267,7 +267,7 @@ def test_dataloader_args(
     "dataset_ref", [SQLiteDataset, ParquetDataset], indirect=True
 )
 def test_ensemble_dataset_without_selections(
-    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]]
+    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]],
 ) -> None:
     """Test ensemble dataset functionality without selections.
 
@@ -306,7 +306,7 @@ def test_ensemble_dataset_without_selections(
 
 @pytest.mark.parametrize("dataset_ref", [SQLiteDataset, ParquetDataset])
 def test_ensemble_dataset_with_selections(
-    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]]
+    dataset_setup: Tuple[Any, Dict[str, Any], Dict[str, int]],
 ) -> None:
     """Test ensemble dataset functionality with selections.
 

--- a/tests/training/test_dataloader_utilities.py
+++ b/tests/training/test_dataloader_utilities.py
@@ -55,7 +55,7 @@ def test_none_selection() -> None:
 )
 def test_array_selection(selection: Tuple[int]) -> None:
     """Test agreement of the two ways to calculate this loss."""
-    (train_dataloader, test_dataloader) = make_train_validation_dataloader(
+    train_dataloader, test_dataloader = make_train_validation_dataloader(
         db=TEST_SQLITE_DATA,
         graph_definition=graph_definition,
         selection=list(selection),

--- a/tests/utilities/test_dataset_config.py
+++ b/tests/utilities/test_dataset_config.py
@@ -20,7 +20,6 @@ from graphnet.models.graphs import KNNGraph
 from graphnet.models.detector.icecube import IceCubeDeepCore
 from graphnet.models.graphs.nodes import NodesAsPulses
 
-
 CONFIG_PATHS = {
     "parquet": "/tmp/test_dataset_parquet.yml",
     "sqlite": "/tmp/test_dataset_sqlite.yml",


### PR DESCRIPTION
## NOTE:
The large amount of changed files is only a relic from running the new linting on the whole repo the only real change is in [.pre-commit-config.yaml](https://github.com/graphnet-team/graphnet/pull/881/changes#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9)

## Summary

Updates pinned versions in `.pre-commit-config.yaml` to current upstream tags. The previous pins were ~1 year old and the older `flake8 7.1.1` / `black 24.10.0` releases trigger a deprecated `bdist_wheel.universal` codepath that fails to install cleanly on certain pip + setuptools combinations (we saw `[Errno 17] File exists: 'build/bdist.linux-x86_64/wheel/<pkg>.dist-info'` during fresh hook env installs). Newer releases ship prebuilt wheels and avoid the legacy install path.

Changes:
- black 24.10.0 → 26.3.1
- flake8 7.1.1 → 7.3.0
- mypy v1.13.0 → v1.20.2
- pre-commit-hooks v4.6.0 → v6.0.0
- docformatter intentionally **not** bumped — v1.7.8 has a `NameError: tomllib is not defined` regression on Python 3.10 (uses 3.11+ stdlib unconditionally), so v1.7.7 is kept.

## Test plan

- [x] `pre-commit run --all-files` (or on changed files) passes locally with the new pins
- [x] CI lint job passes
- [x] No new lint findings introduced by the bumped versions on existing code