### PR TITLE
Add disable_affine option to LearnedTask

### DIFF
--- a/src/graphnet/models/task/task.py
+++ b/src/graphnet/models/task/task.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 import torch
 from torch import Tensor
-from torch.nn import Linear
+from torch.nn import Linear, Identity
 from torch_geometric.data import Data
 
 if TYPE_CHECKING:
@@ -235,6 +235,7 @@ class LearnedTask(Task):
         self,
         hidden_size: int,
         loss_function: "LossFunction",
+        disable_affine: bool = False,
         **task_kwargs: Any,
     ):
         """Construct `LearnedTask`.
@@ -244,13 +245,21 @@ class LearnedTask(Task):
                          the last latent layer of `Model` using this Task.
                          Available through `Model.nb_outputs`
             loss_function: Loss function appropriate to the task.
+            disable_affine: If True, replace the linear projection from
+                            `hidden_size` to `nb_inputs` with an identity.
+                            Use when the upstream model already produces
+                            an output of the right dimensionality.
         """
         # Base class constructor
         super().__init__(**task_kwargs)
 
         # Mapping from last hidden layer to required size of input
         self._loss_function = loss_function
-        self._affine = Linear(hidden_size, self.nb_inputs)
+        self._disable_affine = disable_affine
+        if self._disable_affine:
+            self._affine: torch.nn.Module = Identity()
+        else:
+            self._affine = Linear(hidden_size, self.nb_inputs)
 
     @abstractmethod
     def _forward(  # type: ignore


### PR DESCRIPTION
## Summary

Re-applies the change from #782 onto current `main`. Adds an optional `disable_affine: bool = False` argument to `LearnedTask.__init__`. When `True`, `self._affine` is `nn.Identity()` instead of `Linear(hidden_size, nb_inputs)`. Default is `False`, so existing behavior is unchanged.

Closes #883. Continuation of #782 (closed for inactivity after collaborator review approved the approach — cc @pweigel).

## Motivation

When the upstream backbone already produces an output of the right shape, the task's trailing linear projection is redundant. This is the case for the published NuBench artifacts (https://arxiv.org/abs/2511.13111), whose GRIT model config sets `disable_affine: true` because GRIT's `SANGraphHead` already produces `nb_outputs == nb_inputs`. Loading those configs into vanilla graphnet currently fails with:

```
TypeError: Task.__init__() got an unexpected keyword argument 'disable_affine'
```

## Test plan

- [x] CI passes on current `main`
- [ ] Existing models that don't pass `disable_affine` keep their `Linear` projection
- [ ] `LearnedTask(..., disable_affine=True)` instantiates with `self._affine` as `nn.Identity`
- [ ] Loading the NuBench GRIT config (with `disable_affine: true`) succeeds via `Model.from_config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)