### PR TITLE
restrict pytorch versions - due to supply chain attack on pytorch lightning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ INSTALL_REQUIRES = [
     "lmdb>=1.4.1",
 ]
 
+# Security: pytorch-lightning versions 2.6.2 and 2.6.3 were compromised in a
+# PyPI supply-chain incident. We restrict extras to <=2.6.1 to avoid those
+# releases. See: https://socket.dev/blog/lightning-pypi-package-compromised
 EXTRAS_REQUIRE = {
     "develop": [
         "black",
@@ -58,7 +61,7 @@ EXTRAS_REQUIRE = {
         "torch_sparse",
         "torch_cluster",
         "torch_spline_conv",
-        "pytorch-lightning>=2.0",
+        "pytorch-lightning>=2.0,<=2.6.1",
     ],
     # --- PyTorch 2.6.0 ---
     "torch-26": [
@@ -69,7 +72,7 @@ EXTRAS_REQUIRE = {
         "torch_sparse",
         "torch_cluster",
         "torch_spline_conv",
-        "pytorch-lightning>=2.0",
+        "pytorch-lightning>=2.0,<=2.6.1",
     ],
     # --- PyTorch 2.7.0 ---
     "torch-27": [
@@ -80,7 +83,7 @@ EXTRAS_REQUIRE = {
         "torch_sparse",
         "torch_cluster",
         "torch_spline_conv",
-        "pytorch-lightning>=2.0",
+        "pytorch-lightning>=2.0,<=2.6.1",
     ],
 }
 


### PR DESCRIPTION
See the following for a more detailed description of the issue. 

https://socket.dev/blog/lightning-pypi-package-compromised
This pull request updates the `setup.py` file to address a security concern with the `pytorch-lightning` dependency. Specifically, it restricts the allowed versions to exclude compromised releases and adds documentation about the issue.

Dependency security updates:

* Restricted the `pytorch-lightning` version requirement to `>=2.0,<=2.6.1` in all relevant extras to avoid the compromised 2.6.2 and 2.6.3 releases. 

Documentation:

* Added a comment explaining the version restriction and referencing the PyPI supply-chain incident for `pytorch-lightning`.

Hopefully this prevents our users from installing compromised software. 