### PR TITLE
Add log_train_loss_on_step toggle to EasySyntax

### DIFF
--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -262,11 +262,10 @@ class EasySyntax(Model):
         if isinstance(train_batch, Data):
             train_batch = [train_batch]
         loss = self.shared_step(train_batch, batch_idx)
-        batch_size = self._get_batch_size(train_batch)
         self.log(
             "train_loss",
             loss,
-            batch_size=batch_size,
+            batch_size=self._get_batch_size(train_batch),
             prog_bar=True,
             on_epoch=self._log_on_epoch,
             on_step=self._log_on_step,

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -36,6 +36,7 @@ class EasySyntax(Model):
         scheduler_class: Optional[type] = None,
         scheduler_kwargs: Optional[Dict] = None,
         scheduler_config: Optional[Dict] = None,
+        log_train_loss_on_step: bool = False,
     ) -> None:
         """Construct `StandardModel`."""
         # Base class constructor
@@ -52,6 +53,7 @@ class EasySyntax(Model):
         self._scheduler_class = scheduler_class
         self._scheduler_kwargs = scheduler_kwargs or dict()
         self._scheduler_config = scheduler_config or dict()
+        self._log_train_loss_on_step = log_train_loss_on_step
 
         self.validate_tasks()
 
@@ -243,15 +245,26 @@ class EasySyntax(Model):
         if isinstance(train_batch, Data):
             train_batch = [train_batch]
         loss = self.shared_step(train_batch, batch_idx)
+        batch_size = self._get_batch_size(train_batch)
         self.log(
             "train_loss",
             loss,
-            batch_size=self._get_batch_size(train_batch),
+            batch_size=batch_size,
             prog_bar=True,
             on_epoch=True,
             on_step=False,
             sync_dist=True,
         )
+        if self._log_train_loss_on_step:
+            self.log(
+                "train_loss_step",
+                loss,
+                batch_size=batch_size,
+                prog_bar=False,
+                on_epoch=False,
+                on_step=True,
+                sync_dist=True,
+            )
 
         current_lr = self.trainer.optimizers[0].param_groups[0]["lr"]
         self.log("lr", current_lr, prog_bar=True, on_step=True)

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -69,7 +69,8 @@ class EasySyntax(Model):
         self._scheduler_class = scheduler_class
         self._scheduler_kwargs = scheduler_kwargs or dict()
         self._scheduler_config = scheduler_config or dict()
-        self._also_log_train_loss_per_step = also_log_train_loss_per_step
+        self._log_on_step = log_on_step
+        self._log_on_epoch = log_on_epoch
 
         self.validate_tasks()
 
@@ -288,8 +289,8 @@ class EasySyntax(Model):
             loss,
             batch_size=self._get_batch_size(val_batch),
             prog_bar=True,
-            on_epoch=True,
-            on_step=False,
+            on_epoch=self._log_on_epoch,
+            on_step=self._log_on_step,
             sync_dist=True,
         )
         return loss

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -36,7 +36,8 @@ class EasySyntax(Model):
         scheduler_class: Optional[type] = None,
         scheduler_kwargs: Optional[Dict] = None,
         scheduler_config: Optional[Dict] = None,
-        also_log_train_loss_per_step: bool = False,
+        log_on_epoch: bool = True,
+        log_on_step: bool = False,
     ) -> None:
         """Construct `StandardModel`.
 
@@ -50,7 +51,8 @@ class EasySyntax(Model):
             scheduler_kwargs: Keyword arguments passed to `scheduler_class`.
             scheduler_config: Additional configuration for how the scheduler
                 is invoked by PyTorch Lightning (e.g. `interval`, `frequency`).
-            also_log_train_loss_per_step: If `True`, additionally logs the
+            log_on_epoch: If `True`, logs the training loss on epoch end.
+            log_on_step: If `True`, logs the training loss on step end.
                 per-batch training loss under `train_loss_step`.
         """
         # Base class constructor
@@ -265,20 +267,10 @@ class EasySyntax(Model):
             loss,
             batch_size=batch_size,
             prog_bar=True,
-            on_epoch=True,
-            on_step=False,
+            on_epoch=self._log_on_epoch,
+            on_step=self._log_on_step,
             sync_dist=True,
         )
-        if self._also_log_train_loss_per_step:
-            self.log(
-                "train_loss_step",
-                loss,
-                batch_size=batch_size,
-                prog_bar=False,
-                on_epoch=False,
-                on_step=True,
-                sync_dist=False,
-            )
 
         current_lr = self.trainer.optimizers[0].param_groups[0]["lr"]
         self.log("lr", current_lr, prog_bar=True, on_step=True)

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -36,9 +36,23 @@ class EasySyntax(Model):
         scheduler_class: Optional[type] = None,
         scheduler_kwargs: Optional[Dict] = None,
         scheduler_config: Optional[Dict] = None,
-    also_log_train_loss_per_step: bool = False,
+        also_log_train_loss_per_step: bool = False,
     ) -> None:
-        """Construct `StandardModel`."""
+        """Construct `StandardModel`.
+
+        Args:
+            tasks: Task(s) appended as the head(s) of the model, defining
+                the prediction target(s) and loss(es).
+            optimizer_class: Optimizer class used during training.
+            optimizer_kwargs: Keyword arguments passed to `optimizer_class`.
+            scheduler_class: Learning-rate scheduler class. If `None`, no
+                scheduler is used.
+            scheduler_kwargs: Keyword arguments passed to `scheduler_class`.
+            scheduler_config: Additional configuration for how the scheduler
+                is invoked by PyTorch Lightning (e.g. `interval`, `frequency`).
+            also_log_train_loss_per_step: If `True`, additionally logs the
+                per-batch training loss under `train_loss_step`.
+        """
         # Base class constructor
         super().__init__(name=__name__, class_name=self.__class__.__name__)
 
@@ -53,7 +67,7 @@ class EasySyntax(Model):
         self._scheduler_class = scheduler_class
         self._scheduler_kwargs = scheduler_kwargs or dict()
         self._scheduler_config = scheduler_config or dict()
-    self._also_log_train_loss_per_step = also_log_train_loss_per_step
+        self._also_log_train_loss_per_step = also_log_train_loss_per_step
 
         self.validate_tasks()
 
@@ -255,7 +269,7 @@ class EasySyntax(Model):
             on_step=False,
             sync_dist=True,
         )
-if self._also_log_train_loss_on_step:
+        if self._also_log_train_loss_per_step:
             self.log(
                 "train_loss_step",
                 loss,

--- a/src/graphnet/models/easy_model.py
+++ b/src/graphnet/models/easy_model.py
@@ -36,7 +36,7 @@ class EasySyntax(Model):
         scheduler_class: Optional[type] = None,
         scheduler_kwargs: Optional[Dict] = None,
         scheduler_config: Optional[Dict] = None,
-        log_train_loss_on_step: bool = False,
+    also_log_train_loss_per_step: bool = False,
     ) -> None:
         """Construct `StandardModel`."""
         # Base class constructor
@@ -53,7 +53,7 @@ class EasySyntax(Model):
         self._scheduler_class = scheduler_class
         self._scheduler_kwargs = scheduler_kwargs or dict()
         self._scheduler_config = scheduler_config or dict()
-        self._log_train_loss_on_step = log_train_loss_on_step
+    self._also_log_train_loss_per_step = also_log_train_loss_per_step
 
         self.validate_tasks()
 
@@ -255,7 +255,7 @@ class EasySyntax(Model):
             on_step=False,
             sync_dist=True,
         )
-        if self._log_train_loss_on_step:
+if self._also_log_train_loss_on_step:
             self.log(
                 "train_loss_step",
                 loss,
@@ -263,7 +263,7 @@ class EasySyntax(Model):
                 prog_bar=False,
                 on_epoch=False,
                 on_step=True,
-                sync_dist=True,
+                sync_dist=False,
             )
 
         current_lr = self.trainer.optimizers[0].param_groups[0]["lr"]


### PR DESCRIPTION
## Summary
- Adds an opt-in `log_train_loss_on_step` flag to `EasySyntax` that logs a per-step `train_loss_step` metric in addition to the existing epoch-aggregated `train_loss`.
- Default is `False`, so existing logging behavior is unchanged.

addresses #882 