### PR TITLE
chore: cap torch-geometric below 2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ EXTRAS_REQUIRE = {
     # --- PyTorch 2.5.1 ---
     "torch-25": [
         "torch==2.5.1",
-        "torch-geometric",
+        "torch-geometric<2.8",
         "pyg_lib",
         "torch_scatter",
         "torch_sparse",
@@ -66,7 +66,7 @@ EXTRAS_REQUIRE = {
     # --- PyTorch 2.6.0 ---
     "torch-26": [
         "torch==2.6.0",
-        "torch-geometric",
+        "torch-geometric<2.8",
         "pyg_lib",
         "torch_scatter",
         "torch_sparse",
@@ -77,7 +77,7 @@ EXTRAS_REQUIRE = {
     # --- PyTorch 2.7.0 ---
     "torch-27": [
         "torch==2.7.0",
-        "torch-geometric",
+        "torch-geometric<2.8",
         "pyg_lib",
         "torch_scatter",
         "torch_sparse",


### PR DESCRIPTION
## Summary

Caps `torch-geometric<2.8` in all three torch extras (`torch-25`, `torch-26`, `torch-27`) in `setup.py`.

torch-geometric 2.8.0 (released 2026-06-05) rewrote `knn_graph` to hard-require `pyg-lib>=0.6.0` and removed the `torch-cluster` fallback. The PyG wheel index only ships `pyg-lib>=0.6.0` for torch 2.8.0, so installs on our pinned torch versions (2.5/2.6/2.7) resolve to an older `pyg-lib` and fail at import:

```
ImportError: 'knn_graph' requires 'pyg-lib>=0.6.0'
```

Because `torch-geometric` was unpinned, CI went red with no code change on our side — purely an upstream release picked up by dependency resolution.

## Fix

Pin `torch-geometric<2.8` until `pyg-lib>=0.6.0` wheels exist for the pinned torch versions.

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
