### PR TITLE
Minor Changes to run Example Training Files on the NuBench dataset

### DIFF
--- a/examples/04_training/01_train_dynedge.py
+++ b/examples/04_training/01_train_dynedge.py
@@ -12,7 +12,7 @@ from graphnet.data.constants import FEATURES, TRUTH
 from graphnet.models import StandardModel
 from graphnet.models.detector.prometheus import Prometheus
 from graphnet.models.gnn import DynEdge
-from graphnet.models.graphs import KNNGraph
+from graphnet.models.data_representation import KNNGraph
 from graphnet.models.task.reconstruction import EnergyReconstruction
 from graphnet.training.callbacks import PiecewiseLinearLR
 from graphnet.training.loss_functions import LogCoshLoss

--- a/src/graphnet/data/curated_datamodule.py
+++ b/src/graphnet/data/curated_datamodule.py
@@ -25,7 +25,7 @@ class CuratedDataset(GraphNeTDataModule):
 
     Curated Datasets in GraphNeT are pre-converted datasets that have
     been prepared for training and evaluation of deep learning models.
-    On these Datasets, graphnet users can train and benchmark their
+    On these Datasets, GraphNeT users can train and benchmark their
     models against SOTA methods.
     """
 
@@ -325,9 +325,9 @@ class ERDAHostedDataset(CuratedDataset):
             # Download, unzip and delete zipped file
             os.makedirs(self.dataset_dir)
             file_path = os.path.join(self.dataset_dir, file_hash + ".tar.gz")
-            os.system(f"wget -O {file_path} {self._mirror}/{file_hash}")
-            os.system(f"tar -xf {file_path} -C {self.dataset_dir}")
-            os.system(f"rm {file_path}")
+            os.system(f"wget -O '{file_path}' {self._mirror}/{file_hash}")
+            os.system(f"tar -xf '{file_path}' -C {self.dataset_dir}")
+            os.system(f"rm '{file_path}'")
 
 
 class IceCubeHostedDataset(CuratedDataset):

--- a/src/graphnet/datasets/nubench_datasets.py
+++ b/src/graphnet/datasets/nubench_datasets.py
@@ -24,8 +24,8 @@ FEATURES_NUBENCH = [
     "sensor_pos_x",
     "sensor_pos_y",
     "sensor_pos_z",
-    "charge",
     "t",
+    "charge",
 ]
 
 TRUTH_NUBENCH = [


### PR DESCRIPTION
I ran one of the example training files on the low-energy Hexagon Ice Dataset and ran into 3 issues that I fixed. 
1.  I added the correct path to the module KNNGraph into `01_train_dynedge.py` as the former path was labelled as outdated.
2. I added support for file paths with spaces into `curated_datamodule.py` for people like me with messy path structures and names. 
3. I changed the order of the parameters "charge" and "t" in `nubench_datasets.py`, as this order is expected from the Hexagon detector's feature_map() in the detector model `nubench.py`.