### PR TITLE
Fix silent data loss in the Prometheus pipeline

### DIFF
--- a/examples/04_training/01_train_dynedge.py
+++ b/examples/04_training/01_train_dynedge.py
@@ -24,7 +24,9 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+# The bundled example database was produced by an old version of Prometheus.
+# Use `TRUTH.PROMETHEUS` when training on freshly converted Prometheus files.
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/02_train_tito_model.py
+++ b/examples/04_training/02_train_tito_model.py
@@ -26,7 +26,9 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+# The bundled example database was produced by an old version of Prometheus.
+# Use `TRUTH.PROMETHEUS` when training on freshly converted Prometheus files.
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/05_train_RNN_TITO.py
+++ b/examples/04_training/05_train_RNN_TITO.py
@@ -30,7 +30,9 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+# The bundled example database was produced by an old version of Prometheus.
+# Use `TRUTH.PROMETHEUS` when training on freshly converted Prometheus files.
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/06_train_icemix_model.py
+++ b/examples/04_training/06_train_icemix_model.py
@@ -32,7 +32,9 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+# The bundled example database was produced by an old version of Prometheus.
+# Use `TRUTH.PROMETHEUS` when training on freshly converted Prometheus files.
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -30,7 +30,9 @@ except AssertionError:
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+# The bundled example database was produced by an old version of Prometheus.
+# Use `TRUTH.PROMETHEUS` when training on freshly converted Prometheus files.
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/08_train_grit_model.py
+++ b/examples/04_training/08_train_grit_model.py
@@ -24,7 +24,9 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+# The bundled example database was produced by an old version of Prometheus.
+# Use `TRUTH.PROMETHEUS` when training on freshly converted Prometheus files.
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/src/graphnet/data/constants.py
+++ b/src/graphnet/data/constants.py
@@ -87,7 +87,21 @@ class TRUTH:
     ]
     DEEPCORE = ICECUBE86
     UPGRADE = DEEPCORE
+    # Matches the schema produced by `PrometheusTruthExtractor` from current
+    # Prometheus (`Injection.to_dict()`) files.
     PROMETHEUS = [
+        "interaction",
+        "initial_state_energy",
+        "initial_state_type",
+        "initial_state_zenith",
+        "initial_state_azimuth",
+        "initial_state_x",
+        "initial_state_y",
+        "initial_state_z",
+    ]
+    # Schema written by old Prometheus versions, e.g. the bundled example
+    # database (`data/examples/sqlite/prometheus/prometheus-events.db`).
+    PROMETHEUS_LEGACY = [
         "injection_energy",
         "injection_type",
         "injection_interaction_type",

--- a/src/graphnet/data/dataset/dataset.py
+++ b/src/graphnet/data/dataset/dataset.py
@@ -586,6 +586,23 @@ class Dataset(
 
         # Remove missing truth variables
         if missing_truth_variables:
+            requested_truth = [
+                truth_variable
+                for truth_variable in self._truth
+                if truth_variable != self._index_column
+            ]
+            if requested_truth and set(missing_truth_variables) >= set(
+                requested_truth
+            ):
+                raise ColumnMissingException(
+                    "None of the requested truth variables "
+                    f"({', '.join(requested_truth)}) are present in truth "
+                    f"table '{self._truth_table}'. This likely means the "
+                    "requested truth schema does not match the input "
+                    "file, e.g. `TRUTH.PROMETHEUS` used with a file "
+                    "produced by an old Prometheus version (use "
+                    "`TRUTH.PROMETHEUS_LEGACY` for those)."
+                )
             self.warning(
                 (
                     "Removing the following (missing) truth variables: "

--- a/src/graphnet/data/readers/prometheus_reader.py
+++ b/src/graphnet/data/readers/prometheus_reader.py
@@ -26,6 +26,16 @@ class PrometheusReader(GraphNeTFileReader):
         # Open file
         outputs = []
         file = pd.read_parquet(file_path)
+        for extractor in self._extractors:
+            assert isinstance(extractor, PrometheusExtractor)
+            if extractor._table not in file.columns:
+                self.warning_once(
+                    f"Table '{extractor._table}' was not found in "
+                    f"{file_path} (available: {file.columns.tolist()}). "
+                    "Output from this extractor will be empty. If the file "
+                    "was produced with a non-default `photon_field_name`, "
+                    "instantiate the extractor with that table name."
+                )
         for k in range(len(file)):  # Loop over events in file
             extracted_event = OrderedDict()
             for extractor in self._extractors:

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -85,7 +85,8 @@ def dataset_setup(dataset_ref: pytest.FixtureRequest) -> tuple:
     dataset_kwargs = {
         "truth_table": "mc_truth",
         "pulsemaps": "total",
-        "truth": TRUTH.PROMETHEUS,
+        # The example data was produced by an old Prometheus version
+        "truth": TRUTH.PROMETHEUS_LEGACY,
         "features": FEATURES.PROMETHEUS,
         "path": data_path,
         "graph_definition": graph_definition,

--- a/tests/data/test_prometheus.py
+++ b/tests/data/test_prometheus.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Prometheus truth schema and reader dispatch."""
+
+import os
+
+import pandas as pd
+import pytest
+
+from graphnet.constants import EXAMPLE_DATA_DIR
+from graphnet.data.constants import FEATURES, TRUTH
+from graphnet.data.dataset import SQLiteDataset
+from graphnet.data.extractors.prometheus import (
+    PrometheusFeatureExtractor,
+    PrometheusTruthExtractor,
+)
+from graphnet.data.readers import PrometheusReader
+from graphnet.exceptions.exceptions import ColumnMissingException
+from graphnet.models.detector.prometheus import Prometheus
+from graphnet.models.data_representation import KNNGraph
+from graphnet.models.data_representation.graphs.nodes import NodesAsPulses
+
+DB_PATH = f"{EXAMPLE_DATA_DIR}/sqlite/prometheus/prometheus-events.db"
+
+
+def _graph_definition() -> KNNGraph:
+    """Return a minimal graph definition for the Prometheus detector."""
+    return KNNGraph(
+        detector=Prometheus(),
+        node_definition=NodesAsPulses(),
+        nb_nearest_neighbours=8,
+        input_feature_names=FEATURES.PROMETHEUS,
+    )
+
+
+def test_truth_prometheus_matches_truth_extractor() -> None:
+    """`TRUTH.PROMETHEUS` must stay in lockstep with the truth extractor."""
+    assert TRUTH.PROMETHEUS == PrometheusTruthExtractor()._columns
+
+
+def test_dataset_raises_when_all_truth_variables_missing() -> None:
+    """Requesting a truth schema absent from the file should not be silent.
+
+    The bundled example database was produced by an old Prometheus
+    version, so it contains none of the `TRUTH.PROMETHEUS` columns.
+    """
+    with pytest.raises(ColumnMissingException):
+        SQLiteDataset(
+            path=DB_PATH,
+            pulsemaps="total",
+            features=FEATURES.PROMETHEUS,
+            truth=TRUTH.PROMETHEUS,
+            truth_table="mc_truth",
+            graph_definition=_graph_definition(),
+        )
+
+
+def test_dataset_accepts_legacy_truth_schema() -> None:
+    """`TRUTH.PROMETHEUS_LEGACY` matches the bundled example database."""
+    dataset = SQLiteDataset(
+        path=DB_PATH,
+        pulsemaps="total",
+        features=FEATURES.PROMETHEUS,
+        truth=TRUTH.PROMETHEUS_LEGACY,
+        truth_table="mc_truth",
+        graph_definition=_graph_definition(),
+    )
+    assert len(dataset) > 0
+    # No truth variables should have been silently removed
+    # (the index column is prepended by the Dataset itself)
+    assert dataset._truth == ["event_no"] + TRUTH.PROMETHEUS_LEGACY
+
+
+def test_reader_warns_when_extractor_table_not_in_file(
+    tmp_path: "os.PathLike", caplog: pytest.LogCaptureFixture
+) -> None:
+    """A configured extractor matching no table should emit a warning."""
+    # File written with a non-default `photon_field_name`
+    file_path = os.path.join(tmp_path, "events.parquet")
+    pd.DataFrame(
+        {
+            "photons_custom": [{"sensor_pos_x": [0.0], "sensor_pos_y": [0.0]}],
+            "mc_truth": [{"interaction": 1}],
+        }
+    ).to_parquet(file_path)
+
+    reader = PrometheusReader()
+    reader.set_extractors(
+        [PrometheusTruthExtractor(), PrometheusFeatureExtractor()]
+    )
+    with caplog.at_level("WARNING"):
+        outputs = reader(file_path)
+
+    assert "photons" in caplog.text
+    assert file_path in caplog.text
+    # Truth is still extracted; the missing table is simply absent
+    assert all("photons" not in event for event in outputs)
+    assert all("mc_truth" in event for event in outputs)


### PR DESCRIPTION
Fixes #909.

`TRUTH.PROMETHEUS` still listed the truth schema written by old Prometheus versions (`injection_*`, `primary_lepton_1_*`, ...), while `PrometheusTruthExtractor` extracts the schema current Prometheus actually writes (`interaction`, `initial_state_*`). Converting current Prometheus files and training with `truth = TRUTH.PROMETHEUS` therefore produced datasets with an empty truth dict — `Dataset._remove_missing_columns` only warns before dropping every requested column.

Changes:

* `TRUTH.PROMETHEUS` now matches `PrometheusTruthExtractor` (a test keeps the two in lockstep). The old list is kept as `TRUTH.PROMETHEUS_LEGACY`, since the bundled example database (`prometheus-events.db`) was produced by an old Prometheus version; the example scripts and `test_datamodule.py` use it now.
* `Dataset._remove_missing_columns` raises `ColumnMissingException` when **all** requested truth variables are missing from the truth table (a schema mismatch), instead of silently returning truth-less events. Partial removal still only warns, as before.
* `PrometheusReader` warns when a configured extractor matches no table in the input file, which happens e.g. when a production was run with a non-default `photon_field_name` — this used to silently produce photon-less databases.

Tests: `tests/data/test_prometheus.py` (4 new tests, all fail on `main`), plus updated `tests/data/test_datamodule.py`. `tests/data`, `tests/models` and `tests/utilities` pass locally (except the icetray-dependent converter test, which is unavailable in my environment).
