### PR TITLE
Fix silent data loss in the Prometheus pipeline: raise on missing tables, sync TRUTH.PROMETHEUS

### DIFF
--- a/examples/04_training/01_train_dynedge.py
+++ b/examples/04_training/01_train_dynedge.py
@@ -24,7 +24,7 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/02_train_tito_model.py
+++ b/examples/04_training/02_train_tito_model.py
@@ -26,7 +26,7 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/05_train_RNN_TITO.py
+++ b/examples/04_training/05_train_RNN_TITO.py
@@ -30,7 +30,7 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/06_train_icemix_model.py
+++ b/examples/04_training/06_train_icemix_model.py
@@ -32,7 +32,7 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/07_train_normalizing_flow.py
+++ b/examples/04_training/07_train_normalizing_flow.py
@@ -30,7 +30,7 @@ except AssertionError:
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/examples/04_training/08_train_grit_model.py
+++ b/examples/04_training/08_train_grit_model.py
@@ -24,7 +24,7 @@ from graphnet.data.dataset import ParquetDataset
 
 # Constants
 features = FEATURES.PROMETHEUS
-truth = TRUTH.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
 
 
 def main(

--- a/src/graphnet/data/constants.py
+++ b/src/graphnet/data/constants.py
@@ -87,7 +87,21 @@ class TRUTH:
     ]
     DEEPCORE = ICECUBE86
     UPGRADE = DEEPCORE
+    # Truth schema written by current Prometheus versions; the default
+    # column list of `PrometheusTruthExtractor`.
     PROMETHEUS = [
+        "interaction",
+        "initial_state_energy",
+        "initial_state_type",
+        "initial_state_zenith",
+        "initial_state_azimuth",
+        "initial_state_x",
+        "initial_state_y",
+        "initial_state_z",
+    ]
+    # Truth schema written by older Prometheus versions, e.g. the bundled
+    # example database `prometheus-events.db`.
+    PROMETHEUS_LEGACY = [
         "injection_energy",
         "injection_type",
         "injection_interaction_type",

--- a/src/graphnet/data/extractors/prometheus/prometheus_extractor.py
+++ b/src/graphnet/data/extractors/prometheus/prometheus_extractor.py
@@ -1,6 +1,6 @@
 """Parquet Extractor for conversion of simulation files from PROMETHEUS."""
 
-from typing import List
+from typing import List, Optional
 import pandas as pd
 import numpy as np
 
@@ -53,16 +53,25 @@ class PrometheusTruthExtractor(PrometheusExtractor):
     This Extractor will "initial_state" i.e. neutrino truth.
     """
 
-    def __init__(self, table_name: str = "mc_truth") -> None:
+    def __init__(
+        self,
+        table_name: str = "mc_truth",
+        columns: Optional[List[str]] = None,
+    ) -> None:
         """Construct PrometheusTruthExtractor.
 
         Args:
             table_name: Name of the table in the parquet files that contain
                 event-level truth. Defaults to "mc_truth".
+            columns: Columns to extract from the table. Defaults to
+                `TRUTH.PROMETHEUS`, the truth fields written by every
+                Prometheus injection type. Override to include truth-level
+                data not present per default, e.g. LeptonInjector's
+                "bjorken_x", "bjorken_y" and "column_depth".
         """
-        super().__init__(
-            extractor_name=table_name, columns=list(TRUTH.PROMETHEUS)
-        )
+        if columns is None:
+            columns = list(TRUTH.PROMETHEUS)
+        super().__init__(extractor_name=table_name, columns=columns)
 
 
 class PrometheusFeatureExtractor(PrometheusExtractor):

--- a/src/graphnet/data/extractors/prometheus/prometheus_extractor.py
+++ b/src/graphnet/data/extractors/prometheus/prometheus_extractor.py
@@ -4,6 +4,7 @@ from typing import List
 import pandas as pd
 import numpy as np
 
+from graphnet.data.constants import TRUTH
 from graphnet.data.extractors import Extractor
 
 
@@ -59,17 +60,9 @@ class PrometheusTruthExtractor(PrometheusExtractor):
             table_name: Name of the table in the parquet files that contain
                 event-level truth. Defaults to "mc_truth".
         """
-        columns = [
-            "interaction",
-            "initial_state_energy",
-            "initial_state_type",
-            "initial_state_zenith",
-            "initial_state_azimuth",
-            "initial_state_x",
-            "initial_state_y",
-            "initial_state_z",
-        ]
-        super().__init__(extractor_name=table_name, columns=columns)
+        super().__init__(
+            extractor_name=table_name, columns=list(TRUTH.PROMETHEUS)
+        )
 
 
 class PrometheusFeatureExtractor(PrometheusExtractor):

--- a/src/graphnet/data/readers/prometheus_reader.py
+++ b/src/graphnet/data/readers/prometheus_reader.py
@@ -22,17 +22,31 @@ class PrometheusReader(GraphNeTFileReader):
 
         Returns:
             Extracted data.
+
+        Raises:
+            ValueError: If a table required by one of the configured
+                extractors does not exist in the file.
         """
         # Open file
         outputs = []
         file = pd.read_parquet(file_path)
+        extractors: List[PrometheusExtractor] = []
+        missing_tables = []
+        for extractor in self._extractors:
+            assert isinstance(extractor, PrometheusExtractor)
+            extractors.append(extractor)
+            if extractor._table not in file.columns:
+                missing_tables.append(extractor._table)
+        if missing_tables:
+            raise ValueError(
+                f"Table(s) {missing_tables} not found in {file_path}. "
+                f"Available tables: {list(file.columns)}."
+            )
         for k in range(len(file)):  # Loop over events in file
             extracted_event = OrderedDict()
-            for extractor in self._extractors:
-                assert isinstance(extractor, PrometheusExtractor)
-                if extractor._table in file.columns:
-                    output = extractor(file[extractor._table][k])
-                    extracted_event[extractor._extractor_name] = output
+            for extractor in extractors:
+                output = extractor(file[extractor._table][k])
+                extracted_event[extractor._extractor_name] = output
             outputs.append(extracted_event)
         return outputs
 

--- a/src/graphnet/datasets/prometheus_datasets.py
+++ b/src/graphnet/datasets/prometheus_datasets.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from graphnet.training.labels import Direction, Track
 from graphnet.data import ERDAHostedDataset
-from graphnet.data.constants import FEATURES
+from graphnet.data.constants import FEATURES, TRUTH
 from graphnet.data.utilities import query_database
 
 
@@ -18,16 +18,7 @@ class PublicPrometheusDataset(ERDAHostedDataset):
     # Static Member Variables:
     _pulsemaps = ["photons"]
     _truth_table = "mc_truth"
-    _event_truth = [
-        "interaction",
-        "initial_state_energy",
-        "initial_state_type",
-        "initial_state_zenith",
-        "initial_state_azimuth",
-        "initial_state_x",
-        "initial_state_y",
-        "initial_state_z",
-    ]
+    _event_truth = TRUTH.PROMETHEUS
     _pulse_truth = None
     _features = FEATURES.PROMETHEUS
 

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -85,7 +85,7 @@ def dataset_setup(dataset_ref: pytest.FixtureRequest) -> tuple:
     dataset_kwargs = {
         "truth_table": "mc_truth",
         "pulsemaps": "total",
-        "truth": TRUTH.PROMETHEUS,
+        "truth": TRUTH.PROMETHEUS_LEGACY,
         "features": FEATURES.PROMETHEUS,
         "path": data_path,
         "graph_definition": graph_definition,

--- a/tests/data/test_prometheus_reader.py
+++ b/tests/data/test_prometheus_reader.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from graphnet.constants import TEST_DATA_DIR
+from graphnet.data.constants import TRUTH
 from graphnet.data.extractors.prometheus import (
     PrometheusFeatureExtractor,
     PrometheusTruthExtractor,
@@ -25,6 +26,7 @@ def test_prometheus_reader_extracts_configured_tables() -> None:
     events = reader(FILE_PATH)
     assert len(events) > 0
     assert set(events[0].keys()) == {"mc_truth", "photons"}
+    assert set(TRUTH.PROMETHEUS) <= set(events[0]["mc_truth"].keys())
 
 
 def test_prometheus_reader_raises_on_missing_table() -> None:

--- a/tests/data/test_prometheus_reader.py
+++ b/tests/data/test_prometheus_reader.py
@@ -1,12 +1,14 @@
 """Tests for the PrometheusReader."""
 
 import os
+from typing import List
 
 import pytest
 
 from graphnet.constants import TEST_DATA_DIR
 from graphnet.data.constants import TRUTH
 from graphnet.data.extractors.prometheus import (
+    PrometheusExtractor,
     PrometheusFeatureExtractor,
     PrometheusTruthExtractor,
 )
@@ -27,6 +29,17 @@ def test_prometheus_reader_extracts_configured_tables() -> None:
     assert len(events) > 0
     assert set(events[0].keys()) == {"mc_truth", "photons"}
     assert set(TRUTH.PROMETHEUS) <= set(events[0]["mc_truth"].keys())
+
+
+def test_prometheus_truth_extractor_columns_override() -> None:
+    """Truth extractor extracts only the overridden columns."""
+    reader = PrometheusReader()
+    extractors: List[PrometheusExtractor] = [
+        PrometheusTruthExtractor(columns=["initial_state_energy"])
+    ]
+    reader.set_extractors(extractors)
+    events = reader(FILE_PATH)
+    assert list(events[0]["mc_truth"].keys()) == ["initial_state_energy"]
 
 
 def test_prometheus_reader_raises_on_missing_table() -> None:

--- a/tests/data/test_prometheus_reader.py
+++ b/tests/data/test_prometheus_reader.py
@@ -1,0 +1,40 @@
+"""Tests for the PrometheusReader."""
+
+import os
+
+import pytest
+
+from graphnet.constants import TEST_DATA_DIR
+from graphnet.data.extractors.prometheus import (
+    PrometheusFeatureExtractor,
+    PrometheusTruthExtractor,
+)
+from graphnet.data.readers import PrometheusReader
+
+FILE_PATH = os.path.join(
+    TEST_DATA_DIR, "prometheus", "22980001_photons.parquet"
+)
+
+
+def test_prometheus_reader_extracts_configured_tables() -> None:
+    """Reader extracts every configured table when all are present."""
+    reader = PrometheusReader()
+    reader.set_extractors(
+        [PrometheusTruthExtractor(), PrometheusFeatureExtractor()]
+    )
+    events = reader(FILE_PATH)
+    assert len(events) > 0
+    assert set(events[0].keys()) == {"mc_truth", "photons"}
+
+
+def test_prometheus_reader_raises_on_missing_table() -> None:
+    """Reader raises if an extractor's table is not in the file."""
+    reader = PrometheusReader()
+    reader.set_extractors(
+        [
+            PrometheusTruthExtractor(),
+            PrometheusFeatureExtractor(table_name="not_a_table"),
+        ]
+    )
+    with pytest.raises(ValueError, match="not_a_table"):
+        reader(FILE_PATH)


### PR DESCRIPTION
Closes #909.

Both failure modes in the Prometheus conversion/training path were silent — truth-less or photon-less datasets with no error. This PR makes the first one loud and fixes the second at its root.

## Changes

**`PrometheusReader`: raise on missing tables.** The reader dispatched extractors by exact table-name match and silently skipped any extractor whose table wasn't in the file (e.g. a non-default `photon_field_name` in the Prometheus config, or a typo'd `table_name`). It now validates all configured tables once per file and raises a `ValueError` listing the missing and the available tables.

**`TRUTH.PROMETHEUS` synced with current Prometheus output.** The constant still described a truth schema (`injection_*`, `primary_lepton_1_*`, ...) that Prometheus stopped writing long ago; against a freshly converted file, `Dataset._remove_missing_columns` silently stripped every truth column. Now:
- `TRUTH.PROMETHEUS` = the event-level truth written by every current Prometheus injection type (`interaction` + `initial_state_*`), matching `Injection.to_dict()`.
- The old list is preserved as `TRUTH.PROMETHEUS_LEGACY` for older files such as the bundled example database (`prometheus-events.db`).
- `PrometheusTruthExtractor` derives its default columns from `TRUTH.PROMETHEUS`, so the constant and the extractor can no longer drift apart.
- `PrometheusTruthExtractor` gained an optional `columns` override for truth fields that only some injection types write (e.g. LeptonInjector's `bjorken_x`, `bjorken_y`, `column_depth` — deliberately not in the default, since GENIE-based files don't have them).
- All in-repo consumers point at the schema matching their data: the six `examples/04_training` scripts and the datamodule tests (which run on the bundled legacy database) use `PROMETHEUS_LEGACY`; `PublicPrometheusDataset._event_truth` now derives from `TRUTH.PROMETHEUS` instead of duplicating it.

## Breaking changes

- `TRUTH.PROMETHEUS` changes meaning: code using it against **old** databases must switch to `TRUTH.PROMETHEUS_LEGACY`. This is intentional — the default-looking name should describe what current Prometheus writes.
- Prometheus files containing no photon table now raise in `PrometheusReader` instead of quietly converting to truth-only databases. Note this includes files from runs where **zero events produced hits** (Prometheus writes `mc_truth`-only files in that case) — previously these converted silently; failing loudly surfaces e.g. vertices injected outside the detector volume.

## Testing

- New `tests/data/test_prometheus_reader.py`: extraction of both tables from the shipped Prometheus test parquet, verification that every `TRUTH.PROMETHEUS` field exists in that (current-schema) file, the `columns` override, and the missing-table raise.
- `tests/data/test_datamodule.py` + the new tests: 14 passed locally; pre-commit (black, flake8, docformatter, pydocstyle, mypy) green on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
