### PR TITLE
Fix IceTray CI: keep numpy<2 in the jammy_flows install resolve

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -70,4 +70,5 @@ runs:
         echo "pip install ${{ steps.flags.outputs.user_flag }} ${{ steps.flags.outputs.editable_flag }} .[torch-${{ steps.flags.outputs.torch_flag }},${{ inputs.extras }}] -f https://data.pyg.org/whl/torch-${{ inputs.torch_version }}+${{ inputs.hardware }}.html"
         pip install --no-cache-dir${{ steps.flags.outputs.user_flag }} ${{ steps.flags.outputs.editable_flag }} .[torch-${{ steps.flags.outputs.torch_flag }},${{ inputs.extras }}] -f https://data.pyg.org/whl/torch-${{ inputs.torch_version }}+${{ inputs.hardware }}.html
         rm -rf ~/.cache/pip
-        pip install --no-cache-dir git+https://github.com/thoglu/jammy_flows.git
+        # without this pin, healpy (via jammy_flows) upgrades numpy to 2.x, breaking icetray
+        pip install --no-cache-dir "numpy>=1.22,<2.0" git+https://github.com/thoglu/jammy_flows.git


### PR DESCRIPTION
## Summary

Closes #912.

The `Unit tests - IceTray (v1.13.0 - 3.10)` job fails on every run since ~2026-07-18 with

```
SystemError: initialization of _MuonGun raised unreported exception
AttributeError: _ARRAY_API not found
```

Root cause (full analysis in #912): the final install step `pip install git+https://github.com/thoglu/jammy_flows.git` is a separate pip resolve that does not include graphnet's `numpy>=1.22,<2.0` pin. healpy 1.20.0 (pulled transitively via mhealpy) requires numpy>=2, so pip silently upgrades numpy to 2.2.6 — and the icetray container's C extensions are compiled against numpy 1.x, so they fail to load.

## Fix

Add graphnet's numpy constraint to the jammy_flows install line in `.github/actions/install/action.yml`, making it part of the same resolve. pip then selects a numpy-1-compatible healpy instead of upgrading numpy.

## Why not a newer icetray image

Verified at runtime: even the newest published image (`icetray-devel-v1.19.1-ubuntu22.04-2026-08-05`, identical digest to `icetray-devel-current-ubuntu22.04`) ships apt numpy 1.21.5, and importing `MuonGun` under numpy 2.2.6 there fails with exactly the CI error above. All published icetray images are built against numpy 1.x, so this constraint is needed regardless of image; a version bump can happen separately.

Once merged, open PRs go green on their next CI run, since PR workflows run against the merge with the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H5hSfPGXaV5aabm1g45oH