### PR TITLE
Make VonMisesFisher3DLoss exact and GPU-only

### DIFF
--- a/src/graphnet/training/loss_functions.py
+++ b/src/graphnet/training/loss_functions.py
@@ -494,8 +494,61 @@ class EuclideanDistanceLoss(LossFunction):
         )
 
 
-class VonMisesFisher3DLoss(VonMisesFisherLoss):
-    """Von Mises-Fisher loss function vectors in the 3D plane."""
+class VonMisesFisher3DLoss(LossFunction):
+    """Negative log-likelihood of the 3D von Mises-Fisher distribution.
+
+    The density on the unit sphere is `f(t | mu, kappa) = C_3(kappa) *
+    exp(kappa * mu . t)` with normalization `C_3(kappa) = kappa /
+    (4*pi*sinh(kappa))`. Substituting `sinh(kappa) = exp(kappa) *
+    (1 - exp(-2*kappa)) / 2` and, exactly for unit vectors,
+    `kappa * (1 - mu . t) = kappa * ||t - mu||**2 / 2`, the negative
+    log-likelihood becomes
+
+    `kappa * ||t - mu||**2 / 2 - log(kappa / (2*pi*(1 - exp(-2*kappa))))`
+
+    where no term grows like `kappa` — the `exp(kappa)` of the normalizer
+    cancels analytically against the alignment term. Every operation is
+    elementary and on-device (no Bessel functions), the derivative is
+    continuous in `kappa` (no approximation boundary for gradient descent
+    on the concentration to stall at), and the squared-chord angular term
+    stays accurate in float32 at high concentration, where `1 - cos(theta)`
+    is comparable to the floating-point epsilon.
+
+    All arithmetic runs in the dtype of the inputs; resolving sub-degree
+    angular information requires the direction vectors in float32 or better.
+    """
+
+    def __init__(self, eps: float = 1e-8, **kwargs: Any) -> None:
+        """Construct `VonMisesFisher3DLoss`.
+
+        Args:
+            eps: Regularization of the normalizer, evaluated as
+                `(kappa + eps) / (1 - exp(-2*kappa) + 2*eps)` so that value
+                and gradient stay finite at `kappa = 0` while the ratio
+                keeps its exact limit of 1/2 (the uniform value
+                `-log(4*pi)`). Gradients lose accuracy below
+                `kappa ~ sqrt(eps)`, where the distribution is effectively
+                uniform.
+        """
+        super().__init__(**kwargs)
+        self._eps = eps
+
+    @staticmethod
+    def _log_cmk_scaled(kappa: Tensor, eps: float) -> Tensor:
+        """Calculate `log(exp(kappa) * C_3(kappa))`.
+
+        Args:
+            kappa: Concentration parameters, of shape [batch_size,].
+            eps: Regularization, see the constructor.
+
+        Returns:
+            Elementwise `log(exp(kappa) * C_3(kappa))`, shape [batch_size,].
+        """
+        return (
+            torch.log(kappa + eps)
+            - torch.log1p(2 * eps - torch.exp(-2 * kappa))
+            - np.log(2 * np.pi)
+        )
 
     def _forward(self, prediction: Tensor, target: Tensor) -> Tensor:
         """Calculate von Mises-Fisher loss for a direction in the 3D.
@@ -504,7 +557,7 @@ class VonMisesFisher3DLoss(VonMisesFisherLoss):
             prediction: Output of the model. Must have shape [N, 4] where
                 columns 0, 1, 2 are predictions of `direction` and last column
                 is an estimate of `kappa`.
-            target: Target tensor, extracted from graph object.
+            target: Target unit vector, extracted from graph object.
 
         Returns:
             Elementwise von Mises-Fisher loss terms. Shape [N,]
@@ -515,9 +568,25 @@ class VonMisesFisher3DLoss(VonMisesFisherLoss):
         assert target.dim() == 2
         assert prediction.size()[0] == target.size()[0]
 
-        kappa = prediction[:, 3]
-        p = kappa.unsqueeze(1) * prediction[:, [0, 1, 2]]
-        return self._evaluate(p, target)
+        # The likelihood depends only on the natural parameter
+        # eta = prediction[:, 3] * direction; re-factoring it as
+        # concentration * unit vector makes the squared-chord identity below
+        # applicable. For a unit direction the concentration equals
+        # prediction[:, 3].
+        direction = prediction[:, :3]
+        direction_norm = torch.norm(direction, dim=1)
+        concentration = prediction[:, 3] * direction_norm
+        unit_direction = direction / direction_norm.unsqueeze(1)
+
+        # For unit vectors, concentration * (1 - mu . t) equals
+        # concentration * ||t - mu||**2 / 2 exactly. The squared-chord form
+        # measures the small angular deficit directly, whereas subtracting
+        # cos(theta) from 1 loses all significant digits once theta**2
+        # approaches the floating-point epsilon.
+        sq_chord = torch.sum((target - unit_direction) ** 2, dim=1)
+        return concentration * sq_chord / 2 - self._log_cmk_scaled(
+            concentration, self._eps
+        )
 
 
 class EnsembleLoss(LossFunction):

--- a/src/graphnet/training/loss_functions.py
+++ b/src/graphnet/training/loss_functions.py
@@ -568,10 +568,11 @@ class VonMisesFisher3DLoss(LossFunction):
         assert target.dim() == 2
         assert prediction.size()[0] == target.size()[0]
 
-        direction = prediction[:, :3] # vector  mu / (norm(mu) + eps)
-        direction_norm = torch.norm(direction, dim=1) # norm(mu) / (norm(mu) + eps)
-        concentration = prediction[:, 3] * direction_norm # norm(mu)
-        unit_direction = direction / direction_norm.unsqueeze(1) # mu \ norm(mu)
+        # With x the raw model output the task head normalized:
+        direction = prediction[:, :3]  # x / (|x| + eps)
+        direction_norm = torch.norm(direction, dim=1)  # |x| / (|x| + eps)
+        concentration = prediction[:, 3] * direction_norm  # |x|
+        unit_direction = direction / direction_norm.unsqueeze(1)  # x / |x|
 
         # For unit vectors, concentration * (1 - mu . t) equals
         # concentration * ||t - mu||**2 / 2 exactly. The squared-chord form

--- a/src/graphnet/training/loss_functions.py
+++ b/src/graphnet/training/loss_functions.py
@@ -568,15 +568,10 @@ class VonMisesFisher3DLoss(LossFunction):
         assert target.dim() == 2
         assert prediction.size()[0] == target.size()[0]
 
-        # The likelihood depends only on the natural parameter
-        # eta = prediction[:, 3] * direction; re-factoring it as
-        # concentration * unit vector makes the squared-chord identity below
-        # applicable. For a unit direction the concentration equals
-        # prediction[:, 3].
-        direction = prediction[:, :3]
-        direction_norm = torch.norm(direction, dim=1)
-        concentration = prediction[:, 3] * direction_norm
-        unit_direction = direction / direction_norm.unsqueeze(1)
+        direction = prediction[:, :3] # vector  mu / (norm(mu) + eps)
+        direction_norm = torch.norm(direction, dim=1) # norm(mu) / (norm(mu) + eps)
+        concentration = prediction[:, 3] * direction_norm # norm(mu)
+        unit_direction = direction / direction_norm.unsqueeze(1) # mu \ norm(mu)
 
         # For unit vectors, concentration * (1 - mu . t) equals
         # concentration * ||t - mu||**2 / 2 exactly. The squared-chord form

--- a/tests/training/test_loss_functions.py
+++ b/tests/training/test_loss_functions.py
@@ -7,7 +7,11 @@ import warnings
 from torch import Tensor
 from torch.autograd import grad
 
-from graphnet.training.loss_functions import LogCoshLoss, VonMisesFisherLoss
+from graphnet.training.loss_functions import (
+    LogCoshLoss,
+    VonMisesFisherLoss,
+    VonMisesFisher3DLoss,
+)
 from graphnet.utilities.maths import eps_like
 
 
@@ -297,3 +301,184 @@ def test_logcmk_backward_zero_handling(
     assert torch.all(
         grads_multi[zero_mask] == 0.0
     ), "Zero kappa values should have zero gradients"
+
+
+def test_vmf3d_log_cmk_closed_form(dtype: torch.dtype = torch.float64) -> None:
+    """Test the vMF-3D normalizer against the m=3 closed form.
+
+    `log C_3(k) = _log_cmk_scaled(k, eps) - k` is checked in value against
+    the reference log(k) - k - log(2 pi (1 - exp(-2k))) and in gradient
+    against d/dk log C_3(k) = 1/k - coth(k).
+    """
+    k = torch.tensor(
+        data=[0.1, 0.5, 1.0, 3.0, 10.0, 100.0, 1000.0, 10000.0],
+        requires_grad=True,
+        dtype=dtype,
+    )
+
+    res = VonMisesFisher3DLoss._log_cmk_scaled(k, eps=1e-8) - k
+    res_reference = (
+        torch.log(k) - k - torch.log(2 * np.pi * (1 - torch.exp(-2 * k)))
+    )
+    assert torch.allclose(res, res_reference, atol=1e-6)
+
+    grads = _compute_elementwise_gradient(res, k)
+    grads_reference = 1 / k - 1 / torch.tanh(k)
+    assert torch.allclose(grads, grads_reference, atol=1e-6)
+
+
+def test_vmf3d_log_cmk_small_kappa(dtype: torch.dtype = torch.float64) -> None:
+    """Test the vMF-3D normalizer at and near kappa = 0.
+
+    The uniform-distribution limit is log(C_3(0)) = -log(4 pi); values
+    must hit it and both values and gradients must stay finite all the
+    way to 0.
+    """
+    k = torch.tensor(
+        data=[0.0, 1e-8, 1e-4, 1e-2],
+        requires_grad=True,
+        dtype=dtype,
+    )
+
+    res = VonMisesFisher3DLoss._log_cmk_scaled(k, eps=1e-8)
+    assert torch.all(torch.isfinite(res))
+    assert torch.isclose(
+        res[0], torch.tensor(-np.log(4 * np.pi), dtype=dtype), atol=1e-9
+    )
+    assert torch.allclose(
+        res, torch.full_like(res, -np.log(4 * np.pi)), atol=2e-2
+    )
+
+    grads = _compute_elementwise_gradient(res, k)
+    assert torch.all(torch.isfinite(grads))
+    # d/dk log(exp(k) C_3(k)) = 1 - A_3(k) -> 1 - k/3 for small k; only
+    # checked where the eps-regularization error eps/k**2 is subdominant.
+    assert torch.isclose(
+        grads[3], torch.tensor(1 - 1e-2 / 3, dtype=dtype), atol=1e-3
+    )
+
+
+def test_vmf3d_log_cmk_matches_bessel_path(
+    dtype: torch.dtype = torch.float64,
+) -> None:
+    """Test the closed-form normalizer against the Bessel-based path.
+
+    `_log_cmk_scaled(k, eps) - k` and `log_cmk_exact(3, k)` are independent
+    implementations of log C_3(k) (elementary closed form vs.
+    `scipy.special.iv`), so agreement validates both.
+    """
+    k = torch.tensor(
+        data=[0.1, 1.0, 10.0, 100.0, 500.0],
+        requires_grad=True,
+        dtype=dtype,
+    )
+
+    res = VonMisesFisher3DLoss._log_cmk_scaled(k, eps=1e-8) - k
+    res_bessel = VonMisesFisherLoss.log_cmk_exact(3, k)
+    assert torch.allclose(res, res_bessel, atol=1e-6)
+
+    grads = _compute_elementwise_gradient(res, k)
+    grads_bessel = _compute_elementwise_gradient(res_bessel, k)
+    assert torch.allclose(grads, grads_bessel, atol=1e-6)
+
+
+def test_vmf3d_loss_elements(dtype: torch.dtype = torch.float64) -> None:
+    """Test `VonMisesFisher3DLoss` elements against the plain NLL formula."""
+    torch.manual_seed(0)
+    n = 64
+    direction = torch.randn(n, 3, dtype=dtype)
+    direction = direction / direction.norm(dim=1, keepdim=True)
+    target = torch.randn(n, 3, dtype=dtype)
+    target = target / target.norm(dim=1, keepdim=True)
+    kappa = 10 ** (torch.rand(n, dtype=dtype) * 4 - 1)  # 0.1 ... 1000
+
+    prediction = torch.cat([direction, kappa.unsqueeze(1)], dim=1)
+    elements = VonMisesFisher3DLoss()._forward(prediction, target)
+
+    log_cmk_reference = (
+        torch.log(kappa)
+        - kappa
+        - torch.log(2 * np.pi * (1 - torch.exp(-2 * kappa)))
+    )
+    dotprod = (kappa.unsqueeze(1) * direction * target).sum(dim=1)
+    elements_reference = -log_cmk_reference - dotprod
+    assert torch.allclose(elements, elements_reference, atol=1e-6)
+
+
+def test_vmf3d_loss_no_gradient_dead_zone(
+    dtype: torch.dtype = torch.float64,
+) -> None:
+    """Test that the kappa-gradient has a stationary point for any alignment.
+
+    The optimum concentration satisfies A_3(kappa) = coth(kappa) - 1/kappa =
+    cos(theta). A derivative that is discontinuous somewhere in kappa leaves
+    a band of cos(theta) values with no stationary point, so gradient descent
+    pins kappa at the discontinuity for those events. Alignments in
+    (0.9900, 0.9998) probe kappa ~ 100...5000.
+    """
+    loss = VonMisesFisher3DLoss()
+    for cos_theta in [0.9905, 0.995, 0.999]:
+        sin_theta = float(np.sqrt(1 - cos_theta**2))
+        kappa = torch.logspace(1, 4, 400, dtype=dtype, requires_grad=True)
+        n = kappa.size(0)
+        direction = torch.tensor([[0.0, 0.0, 1.0]], dtype=dtype).repeat(n, 1)
+        target = torch.tensor(
+            [[sin_theta, 0.0, cos_theta]], dtype=dtype
+        ).repeat(n, 1)
+
+        prediction = torch.cat([direction, kappa.unsqueeze(1)], dim=1)
+        elements = loss._forward(prediction, target)
+        elements.sum().backward()
+        grads = kappa.grad
+
+        # A_3 is monotone, so d(loss)/d(kappa) = A_3(kappa) - cos(theta)
+        # must cross zero exactly once on a grid spanning the optimum.
+        signs = torch.sign(grads)
+        flips = (signs[1:] != signs[:-1]).nonzero().flatten()
+        assert len(flips) == 1, (cos_theta, len(flips))
+
+        kappa_star = kappa[flips[0]].detach()
+        a3 = 1 / torch.tanh(kappa_star) - 1 / kappa_star
+        assert torch.isclose(
+            a3, torch.tensor(cos_theta, dtype=dtype), atol=1e-3
+        )
+
+
+def test_vmf3d_loss_fp32_high_kappa_small_angle() -> None:
+    """Test float32 precision of the loss at high kappa and small angles.
+
+    The angular part of the loss is kappa * (1 - cos(theta)); computing it
+    via the squared chord ||t - mu||**2 keeps it accurate in float32 even
+    when 1 - cos(theta) is comparable to the float32 epsilon.
+    """
+    theta = 1e-3
+    kappa_value = 1e4
+    direction = torch.tensor([[0.0, 0.0, 1.0]], dtype=torch.float32)
+    kappa = torch.tensor([[kappa_value]], dtype=torch.float32)
+    prediction = torch.cat([direction, kappa], dim=1)
+    target_aligned = direction.clone()
+    target_off = torch.tensor(
+        [[np.sin(theta), 0.0, np.cos(theta)]], dtype=torch.float32
+    )
+
+    loss = VonMisesFisher3DLoss()
+    angular_part = (
+        loss._forward(prediction, target_off)
+        - loss._forward(prediction, target_aligned)
+    ).double()
+
+    expected = kappa_value * (1 - np.cos(theta))
+    assert torch.isclose(
+        angular_part,
+        torch.tensor([expected], dtype=torch.float64),
+        rtol=1e-3,
+    )
+
+    # Extreme concentrations must not overflow values or gradients.
+    prediction_extreme = torch.tensor(
+        [[0.0, 0.0, 1.0, 1e7]], dtype=torch.float32, requires_grad=True
+    )
+    elements = loss._forward(prediction_extreme, target_off)
+    assert torch.all(torch.isfinite(elements))
+    elements.sum().backward()
+    assert torch.all(torch.isfinite(prediction_extreme.grad))

--- a/tests/training/test_loss_functions.py
+++ b/tests/training/test_loss_functions.py
@@ -311,7 +311,7 @@ def test_vmf3d_log_cmk_closed_form(dtype: torch.dtype = torch.float64) -> None:
     against d/dk log C_3(k) = 1/k - coth(k).
     """
     k = torch.tensor(
-        data=[0.1, 0.5, 1.0, 3.0, 10.0, 100.0, 1000.0, 10000.0],
+        data=[0.1, 0.5, 1.0, 3.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0],
         requires_grad=True,
         dtype=dtype,
     )
@@ -413,13 +413,13 @@ def test_vmf3d_loss_no_gradient_dead_zone(
     The optimum concentration satisfies A_3(kappa) = coth(kappa) - 1/kappa =
     cos(theta). A derivative that is discontinuous somewhere in kappa leaves
     a band of cos(theta) values with no stationary point, so gradient descent
-    pins kappa at the discontinuity for those events. Alignments in
-    (0.9900, 0.9998) probe kappa ~ 100...5000.
+    pins kappa at the discontinuity for those events. The alignments below
+    place the optimum at kappa ~ 100...20000.
     """
     loss = VonMisesFisher3DLoss()
-    for cos_theta in [0.9905, 0.995, 0.999]:
+    for cos_theta in [0.9905, 0.995, 0.999, 0.99995]:
         sin_theta = float(np.sqrt(1 - cos_theta**2))
-        kappa = torch.logspace(1, 4, 400, dtype=dtype, requires_grad=True)
+        kappa = torch.logspace(1, 5, 500, dtype=dtype, requires_grad=True)
         n = kappa.size(0)
         direction = torch.tensor([[0.0, 0.0, 1.0]], dtype=dtype).repeat(n, 1)
         target = torch.tensor(


### PR DESCRIPTION
Closes #900.

## Problem

`VonMisesFisherLoss.log_cmk` switches from the Bessel-exact branch to `log_cmk_approx` at `kappa_switch=100`. The continuity offset makes the value continuous but not the derivative: the loss gradient w.r.t. κ is `A₃(κ) − cosθ`, and `A₃` jumps from ≈0.9900 to ≈0.9998 across the switch. Events with alignment in that band have no stationary point, so gradient descent pins the learned concentration at κ ≈ 100 (details and reproduction in #900). Additionally, the exact branch routes every forward and backward through `scipy.special.iv`, costing a GPU→CPU→GPU round trip and a CUDA sync twice per training step.

## Change

`VonMisesFisher3DLoss` is rewritten as a standalone `LossFunction` subclass (no longer a child of the generic `VonMisesFisherLoss`, whose Bessel machinery it no longer uses). For m=3 the normalizer has a closed form, `C₃(κ) = κ / (4π sinh κ)`:

- The class evaluates `log(e^κ C₃(κ)) = log((κ+ε)/(1−e^(−2κ)+2ε)) − log 2π` (private static method) — elementary torch ops, finite for all κ, differentiable end-to-end on device, derivative continuous everywhere (no switch, no dead zone). The `2ε` pairing keeps the exact uniform limit `−log 4π` at κ=0, and `eps` is a constructor argument captured by config serialization.
- The angular term is computed as `κ‖t−μ̂‖²/2` instead of via `1 − cosθ`: the squared-chord form keeps float32 accurate at high concentration, where `1 − cosθ` is comparable to the float32 epsilon and would otherwise lose all significant digits.
- No hidden numerics management: all arithmetic runs in the dtype of the inputs (under AMP, autocast's op policies apply as for every other loss), and degenerate input (a zero direction vector) fails loudly rather than being silently clamped.

The `[N, 4]` prediction contract is unchanged, so `DirectionReconstructionWithKappa`, `RMSEVonMisesFisher3DLoss`, and existing model configs work as before. The generic m-dimensional path and `VonMisesFisher2DLoss` are untouched.

Known trade-off (documented in the constructor docstring): gradients lose accuracy below κ ~ √ε ≈ 10⁻⁴, where the distribution is essentially uniform on the sphere and the pull on κ carries no usable information.

## Tests

Six new unit tests in `tests/training/test_loss_functions.py`:

- values and gradients against the m=3 closed form, and independently against the Bessel-based `log_cmk_exact`
- κ→0 limits (exact `−log 4π` at κ=0) and finiteness of values and gradients
- elementwise loss values against the plain NLL formula for random directions and κ ∈ [0.1, 1000]
- **regression for #900**: for cosθ ∈ {0.9905, 0.995, 0.999} — inside the formerly unreachable band — the κ-gradient crosses zero exactly once, at κ* satisfying `A₃(κ*) = cosθ`
- float32 at κ=10⁴, θ=10⁻³ recovers the angular term to 0.1%; κ=10⁷ stays finite in value and gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pqUKMMW7ZPkhc9EChzCux