### PR TITLE
Add torch 2.9/2.10/2.12 support via torch-geometric 2.8

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -19,13 +19,13 @@ inputs:
     description: "Version of PyTorch"
     required: true
     default: "2.6.0"
-    options: ["2.7.0", "2.6.0", "2.5.1", "2.4.0"]
+    options: ["2.12.1", "2.10.0", "2.9.1", "2.7.0", "2.6.0", "2.5.1", "2.4.0"]
 
   hardware:
     description: "The requirements file depends on the hardware, i.e., CPU, GPU, or macOS"
     required: true
     default: "cpu"
-    options: ["cpu", "cu118", "cu121", "cu124", "cu126", "macos"]
+    options: ["cpu", "cu118", "cu121", "cu124", "cu126", "cu128", "cu130", "cu132", "macos"]
 
   use_vm:
     description: "Should the installation happen in a virtual environment named venv?"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        torch_version: ['2.7.0']
+        torch_version: ['2.10.0']
         hardware: ["cpu"]
     container:
       # GitHub Actions overwrite the docker container entrypoint
@@ -123,7 +123,7 @@ jobs:
           source ~/venv/bin/activate
           pip show torch
           pip show torch-geometric
-          pip show torch-cluster
+          pip show pyg-lib
           pip show torch-sparse
           pip show torch-scatter
           pip show jammy_flows
@@ -156,7 +156,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11']
-        torch_version: ['2.7.0', '2.6.0', '2.5.0']
+        torch_version: ['2.12.1', '2.10.0', '2.9.1']
         hardware: ["cpu"]
     steps:
       - uses: actions/checkout@v4
@@ -184,7 +184,7 @@ jobs:
         run: |
           pip show torch
           pip show torch-geometric
-          pip show torch-cluster
+          pip show pyg-lib
           pip show torch-sparse
           pip show torch-scatter
           pip show dill
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11']
-        torch_version: ['2.7.0']
+        torch_version: ['2.10.0']
         hardware: ["cpu"]
 
     steps:
@@ -230,7 +230,7 @@ jobs:
         run: |
             pip show torch
             pip show torch-geometric
-            pip show torch-cluster
+            pip show pyg-lib
             pip show torch-sparse
             pip show torch-scatter
       - name: Run unit tests and generate coverage report

--- a/docs/source/installation/quick-start.html
+++ b/docs/source/installation/quick-start.html
@@ -80,6 +80,9 @@
   ];
 
   var torchList = [
+    ['torch-2.12.1', 'PyTorch 2.12.1'],
+    ['torch-2.10.0', 'PyTorch 2.10.0'],
+    ['torch-2.9.1', 'PyTorch 2.9.1'],
     ['torch-2.7.0', 'PyTorch 2.7.0'],
     ['torch-2.6.0', 'PyTorch 2.6.0'],
     ['torch-2.5.1', 'PyTorch 2.5.1'],
@@ -97,19 +100,68 @@
     ['cu124', '12.4'],
     ['cu126', '12.6'],
     ['cu128', '12.8'],
+    ['cu130', '13.0'],
+    ['cu132', '13.2'],
     ['cpu', 'CPU'],
   ];
 
   var torchWheelMap = {
+    "torch-2.12.1": "2.12.1",
+    "torch-2.10.0": "2.10.0",
+    "torch-2.9.1": "2.9.1",
     "torch-2.7.0": "2.7.0",
     "torch-2.6.0": "2.6.0",
     "torch-2.5.1": "2.5.1"
   };
 
   var torchExtrasMap = {
+    "torch-2.12.1": "torch-212",
+    "torch-2.10.0": "torch-210",
+    "torch-2.9.1": "torch-29",
     "torch-2.7.0": "torch-27",
     "torch-2.6.0": "torch-26",
     "torch-2.5.1": "torch-25"
+  };
+
+  // A torch/CUDA pair is offered iff it has an entry here; the CUDA rows
+  // mirror the wheel flavors published for each release.
+  var pytorchInstallCommands = {
+    "torch-2.5.1": {
+      "cu118": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu118",
+      "cu121": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu121",
+      "cu124": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu124",
+      "cpu": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cpu"
+    },
+    "torch-2.6.0": {
+      "cu118": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118",
+      "cu124": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124",
+      "cu126": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu126",
+      "cpu": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cpu"
+    },
+    "torch-2.7.0": {
+      "cu118": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118",
+      "cu126": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126",
+      "cu128": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
+      "cpu": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
+    },
+    "torch-2.9.1": {
+      "cu126": "pip3 install torch==2.9.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126",
+      "cu128": "pip3 install torch==2.9.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
+      "cu130": "pip3 install torch==2.9.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130",
+      "cpu": "pip3 install torch==2.9.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
+    },
+    "torch-2.10.0": {
+      "cu126": "pip3 install torch==2.10.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126",
+      "cu128": "pip3 install torch==2.10.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
+      "cu130": "pip3 install torch==2.10.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130",
+      "cpu": "pip3 install torch==2.10.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
+    },
+    "torch-2.12.1": {
+      "cu126": "pip3 install torch==2.12.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126",
+      "cu130": "pip3 install torch==2.12.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130",
+      "cu132": "pip3 install torch==2.12.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu132",
+      "cpu": "pip3 install torch==2.12.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
+    }
   };
 
   for (var i = 0; i < graphnetList.length; i++) {
@@ -151,11 +203,7 @@
       return;
     }
 
-    if (
-      (torch === "torch-2.7.0" && (cuda === "cu121" || cuda === "cu124")) ||
-      (torch === "torch-2.6.0" && (cuda === "cu121" || cuda === "cu128")) ||
-      (torch === "torch-2.5.1" && (cuda === "cu126" || cuda === "cu128"))
-    ) {
+    if (torch !== "no_torch" && !pytorchInstallCommands[torch][cuda]) {
       $("#command pre").text('# PyTorch version does not support CUDA ' + formatCudaLabel(cuda));
       return;
     }
@@ -181,29 +229,7 @@
     var wheelUrl = "https://data.pyg.org/whl/torch-" + torchVersion + "+" + (cuda === "cpu" ? "cpu" : cuda) + ".html";
     installLine += " -f " + wheelUrl;
 
-    var pytorchInstallCommands = {
-      "torch-2.5.1": {
-        "cu118": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu118",
-        "cu121": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu121",
-        "cu124": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu124",
-        "cpu": "pip3 install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cpu"
-      },
-      "torch-2.6.0": {
-        "cu118": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118",
-        "cu124": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124",
-        "cu126": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu126",
-        "cpu": "pip3 install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cpu"
-      },
-      "torch-2.7.0": {
-        "cu118": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118",
-        "cu126": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126",
-        "cu128": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128",
-        "cpu": "pip3 install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
-      }
-    };
-
-    var pytorchCmd = pytorchInstallCommands[torch][cuda] ||
-                     pytorchInstallCommands[torch]["cpu"];
+    var pytorchCmd = pytorchInstallCommands[torch][cuda];
 
     $("#command pre").text([
       "# Install PyTorch",
@@ -215,7 +241,7 @@
       installLine,
       " ",
       "# Optionally, install jammy_flows for normalizing flow support:",
-      "pip3 install git+https://github.com/thoglu/jammy_flows.git"
+      "pip3 install \"numpy>=1.22,<2.0\" git+https://github.com/thoglu/jammy_flows.git"
     ].join("\n"));
   }
 

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,36 @@ EXTRAS_REQUIRE = {
         "torch_spline_conv",
         "pytorch-lightning>=2.0,<=2.6.1",
     ],
+    # The extras below use torch-geometric 2.8, whose knn/radius graphs run
+    # on pyg-lib (>=0.6.0, torch>=2.8 only) instead of torch-cluster, so
+    # torch-cluster and the unused torch-spline-conv are dropped.
+    # --- PyTorch 2.9.1 ---
+    "torch-29": [
+        "torch==2.9.1",
+        "torch-geometric==2.8.*",
+        "pyg_lib",
+        "torch_scatter",
+        "torch_sparse",
+        "pytorch-lightning>=2.0,<=2.6.1",
+    ],
+    # --- PyTorch 2.10.0 ---
+    "torch-210": [
+        "torch==2.10.0",
+        "torch-geometric==2.8.*",
+        "pyg_lib",
+        "torch_scatter",
+        "torch_sparse",
+        "pytorch-lightning>=2.0,<=2.6.1",
+    ],
+    # --- PyTorch 2.12.1 ---
+    "torch-212": [
+        "torch==2.12.1",
+        "torch-geometric==2.8.*",
+        "pyg_lib",
+        "torch_scatter",
+        "torch_sparse",
+        "pytorch-lightning>=2.0,<=2.6.1",
+    ],
 }
 
 # https://pypi.org/classifiers/

--- a/src/graphnet/deployment/icecube/cleaning_module.py
+++ b/src/graphnet/deployment/icecube/cleaning_module.py
@@ -180,14 +180,17 @@ class I3PulseCleanerModule(I3InferenceModule):
         pulses = dataclasses.I3RecoPulseSeriesMap.from_frame(
             frame, self._total_pulsemap_name
         )
-        for P in pulses:
-            om = omGeoMap[P[0]]
+        # Iterating an I3Map directly yields OMKeys, and OMKey is itself
+        # indexable (om_key[0] is the string number), so pair-style unpacking
+        # silently produces invalid geometry lookups. Use items() instead.
+        for om_key, om_pulses in pulses.items():
+            om = omGeoMap[om_key]
             if om.omtype == 130:  # "mDOM"
-                mDOMMap[P[0]] = P[1]
+                mDOMMap[om_key] = om_pulses
             elif om.omtype == 120:  # "DEgg"
-                DEggMap[P[0]] = P[1]
+                DEggMap[om_key] = om_pulses
             elif om.omtype == 20:  # "IceCube / pDOM"
-                IceCubeMap[P[0]] = P[1]
+                IceCubeMap[om_key] = om_pulses
         return mDOMMap, DEggMap, IceCubeMap
 
     def _construct_prediction_map(

--- a/src/graphnet/models/data_representation/graphs/edges/edges.py
+++ b/src/graphnet/models/data_representation/graphs/edges/edges.py
@@ -75,6 +75,13 @@ class KNNEdges(EdgeDefinition):  # pylint: disable=too-few-public-methods
 
     def _construct_edges(self, graph: Data) -> Data:
         """Define K-NN edges."""
+        # pyg-lib's knn kernel segfaults on empty input when `batch` is None.
+        if graph.x.shape[0] == 0:
+            graph.edge_index = torch.empty((2, 0), dtype=torch.long).to(
+                self.device
+            )
+            return graph
+
         graph.edge_index = knn_graph(
             graph.x[:, self._columns],
             self._nb_nearest_neighbours,
@@ -165,6 +172,14 @@ class RadialEdges(EdgeDefinition):
 
     def _construct_edges(self, graph: Data) -> Data:
         """Define radial edges."""
+        # pyg-lib's radius kernel segfaults on empty input when `batch` is
+        # None, like its knn kernel.
+        if graph.x.shape[0] == 0:
+            graph.edge_index = torch.empty((2, 0), dtype=torch.long).to(
+                self.device
+            )
+            return graph
+
         graph.edge_index = radius_graph(
             graph.x[:, self._columns],
             self._radius,


### PR DESCRIPTION
## Summary

Adds `torch-29`, `torch-210`, and `torch-212` extras (torch 2.9.1 / 2.10.0 / 2.12.1), enabled by simultaneously moving these extras to `torch-geometric==2.8.*` — plus fixes for two latent graphnet bugs the new stack exposed.

## Why torch-geometric 2.8 is the key

torch-geometric 2.8 rewrote `knn_graph`/`radius_graph` to run on `pyg-lib>=0.6.0` (`torch.ops.pyg.knn`/`radius`) and dropped the torch-cluster backend — and pyg-lib >=0.6.0 wheels exist for all torch >=2.8. This resolves the reason for the existing `torch-geometric<2.8` cap, which stays in place for the older extras (their torch versions have no compatible pyg-lib). The new extras therefore drop `torch_cluster` (superseded by pyg-lib) and `torch_spline_conv` (never imported by graphnet).

## Wheel availability at data.pyg.org (why the ceiling is 2.12.1)

| torch | pyg_lib | torch_scatter/sparse | torch_cluster | torch_spline_conv |
|---|---|---|---|---|
| ≤2.10 | ✓ | ✓ | ✓ | ✓ |
| 2.11 | ✓ | ✓ | ✓ | — |
| 2.12.x | ✓ | ✓ | — | — |
| 2.13/2.14 | ✓ | — | — | — |

`torch_scatter`/`torch_sparse` are still imported directly by graphnet models, so 2.12.1 is the highest reachable version without migrating those imports to `torch_geometric.utils.scatter`/native ops — left for a follow-up.

## Latent bugs exposed by the backend swap (fixed here)

The first CI run failed two icetray-job tests. Both turned out to be pre-existing graphnet bugs that the knn-backend change surfaced, reproduced and verified in the `icecube/icetray:icetray-devel-v1.13.0` container:

1. **`cleaning_module._split_pulsemap_in_dom_types`**: iterating an `I3Map` yields OMKeys (not key/value pairs), and OMKey is itself indexable (`om_key[0]` is the string number), so the `P[0]`-style unpacking raised `TypeError: Invalid index type` on the first non-empty cleaned pulsemap. The loop body had never executed in CI — the QUESO test model cleaned away every pulse in the tiny test file, and pyg-lib's different knn tie-breaking now lets pulses survive the threshold. Fixed by iterating `items()`; correct on the old stack too.

2. **`KNNEdges`/`RadialEdges` on empty events**: pyg-lib's knn/radius kernels **segfault** on empty input when `batch` is None (`knn_graph(torch.rand(0, 3), k=8)` reproduces it; with an explicit batch tensor it is fine — worth an upstream pyg-lib report). An empty event inside a DataLoader worker is exactly this call, killing the worker (`DataLoader worker ... killed by signal: Segmentation fault`). Not icetray-specific — the ERDA test just only runs in the icetray job. Fixed with an explicit empty `edge_index` guard, matching torch-cluster's behaviour.

## Changes

- `setup.py`: three new extras; existing extras untouched.
- `src/graphnet/deployment/icecube/cleaning_module.py`, `src/graphnet/models/data_representation/graphs/edges/edges.py`: the two fixes above.
- `.github/workflows/build.yml`: icetray and macOS jobs on 2.10.0, Ubuntu examples matrix on 2.12.1/2.10.0/2.9.1. `pip show torch-cluster` → `pip show pyg-lib` (the step runs under `bash -e`, and torch-cluster is no longer installed).
- `.github/actions/install/action.yml`: extended the documented `torch_version`/`hardware` option lists (cu128/cu130/cu132).
- `docs/source/installation/quick-start.html`: picker offers the new versions with their CUDA flavors (verified against the published wheel indexes: 2.9.1/2.10.0 → cu126/cu128/cu130, 2.12.1 → cu126/cu130/cu132); unsupported torch/CUDA pairs are now derived from the install-command map instead of a hand-maintained blacklist. The optional jammy_flows line also gets the `numpy<2` constraint from #914.

## Validation

- Examples matrix (2.9.1/2.10.0/2.12.1), macOS, docs: green on the first CI run already.
- The two icetray failures were reproduced in the v1.13.0 container on a local cluster, root-caused as above, and both tests pass there with the fixes (alone and in CI test ordering, torch 2.10.0 + tg 2.8).
- Behavioral note: the knn backend changes from torch-cluster to pyg-lib; semantics are equivalent up to tie-breaking among equidistant neighbors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H5hSfPGXaV5aabm1g45oH