### PR TITLE
Add tiled version of spacetime encoder and relative bias for DeepIce

### DIFF
--- a/src/graphnet/models/components/embedding.py
+++ b/src/graphnet/models/components/embedding.py
@@ -218,6 +218,27 @@ class SpacetimeEncoder(LightningModule):
         rel_attn = self.projection(sin_emb)
         return rel_attn
 
+    def forward_tiled(
+        self,
+        x: Tensor,
+        start: int,
+        end: int,
+    ) -> Tensor:
+        """Tiled version of the forward pass."""
+        pos = x[:, :, :3]
+        time = x[:, :, 3]
+        dpos = pos[:, start:end, None, :] - pos[:, None, :, :]  # [B,tile,L,3]
+        dt = time[:, start:end, None] - time[:, None, :]  # [B,tile,L]
+        spacetime_interval = dpos.pow(2).sum(-1) - (
+            dt * (3e4 / 500 * 3e-1)
+        ).pow(2)  # [B,tile,L]
+        four_distance = torch.sign(spacetime_interval) * torch.sqrt(
+            torch.abs(spacetime_interval)
+        )
+        sin_emb = self.sin_emb(1024 * four_distance.clip(-4, 4))  # [B,tile,L]
+        rel_attn = self.projection(sin_emb)
+        return rel_attn
+
 
 class RRWPLinearNodeEncoder(LightningModule):
     """Relative random walk probability node encoder.

--- a/src/graphnet/models/components/layers.py
+++ b/src/graphnet/models/components/layers.py
@@ -1,6 +1,14 @@
 """Class(es) implementing layers to be used in `graphnet` models."""
 
-from typing import Any, Callable, Optional, Sequence, Union, List
+from typing import (
+    Any,
+    Callable,
+    Optional,
+    Sequence,
+    Union,
+    List,
+    TYPE_CHECKING,
+)
 
 import torch
 import torch.nn as nn
@@ -22,6 +30,9 @@ from torch_scatter import scatter
 
 from pytorch_lightning import LightningModule
 from torch_geometric.utils import degree
+
+if TYPE_CHECKING:
+    from graphnet.models.components.embedding import SpacetimeEncoder
 
 
 class DynEdgeConv(EdgeConv, LightningModule):
@@ -392,6 +403,54 @@ class Block_rel(LightningModule):
             x = x + self.drop_path(self.gamma_2 * self.mlp(self.norm2(x)))
         return x
 
+    def forward_tiled(
+        self,
+        x: Tensor,
+        rel_pos_encoder: "SpacetimeEncoder",
+        coords: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+        q_tile: int = 64,
+        use_checkpoint: bool = False,
+    ) -> Tensor:
+        """Forward pass with the relative bias computed query-tiled.
+
+        Numerically identical to `forward` called with a `rel_pos_bias`
+        precomputed as `rel_pos_encoder(coords)`, but the relative bias is
+        built one query-tile at a time so the `[B, L, L, H]` tensor is never 
+        fully materialised.
+
+        Args:
+            x: Input tensor of shape `[B, L, input_dim]`.
+            rel_pos_encoder: The `SpacetimeEncoder` providing the relative
+                bias via its `forward_tiled` method.
+            coords: Raw coordinates `[B, L, >=4]` (positions 0:3, time
+                3) fed to `rel_pos_encoder`.
+            key_padding_mask: Float mask `[B, L]` (0 valid, -inf pad).
+            q_tile: Number of query rows processed per tile.
+            use_checkpoint: Recompute each tile in the backward pass so the
+                per-tile intermediates are not retained (memory saving during
+                training, at the cost of extra compute).
+
+        Returns:
+            Tensor of shape `[B, L, input_dim]`.
+        """
+        xn = self.norm1(x)
+        attn = self.attn.forward_tiled(
+            xn,
+            rel_pos_encoder,
+            coords,
+            key_padding_mask=key_padding_mask,
+            q_tile=q_tile,
+            use_checkpoint=use_checkpoint,
+        )
+        if self.gamma_1 is None:
+            x = x + self.drop_path(attn)
+            x = x + self.drop_path(self.mlp(self.norm2(x)))
+        else:
+            x = x + self.drop_path(self.gamma_1 * self.drop_path(attn))
+            x = x + self.drop_path(self.gamma_2 * self.mlp(self.norm2(x)))
+        return x
+
 
 class Attention_rel(LightningModule):
     """Attention mechanism with relative position bias."""
@@ -504,6 +563,118 @@ class Attention_rel(LightningModule):
         x = self.proj(x)
         x = self.proj_drop(x)
         return x
+
+    def forward_tiled(
+        self,
+        x: Tensor,
+        rel_pos_encoder: "SpacetimeEncoder",
+        coords: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+        q_tile: int = 64,
+        use_checkpoint: bool = False,
+    ) -> Tensor:
+        """Query-tiled self-attention with an on-the-fly relative bias.
+
+        Numerically identical to `forward` called with a `rel_pos_bias`
+        precomputed as `rel_pos_encoder(coords)`,  but the relative bias for
+        each block of `q_tile` query rows is built from
+        `rel_pos_encoder.forward_tiled` and consumed immediately, so the
+        `[B, L, L, H]` bias tensor is never fully materialised.
+        Each query row still attends to all keys with a full-row softmax, so
+        the per-row arithmetic (and hence the result) matches `forward`
+        exactly, while peak memory for the bias drops from `O(L^2 * H)` to
+        `O(q_tile * L * H)`.
+
+        Args:
+            x: Input tensor of shape `[B, L, input_dim]`.
+            rel_pos_encoder: The `SpacetimeEncoder` whose `forward_tiled`
+                supplies the relative bias for a query tile.
+            coords: Raw coordinates `[B, L, >=4]` (positions 0:3, time
+                3) fed to `rel_pos_encoder`.
+            key_padding_mask: Float mask `[B, L]` (0 valid, -inf pad),
+                as used by `forward`.
+            q_tile: Number of query rows processed per tile.
+            use_checkpoint: Recompute each tile in the backward pass so the
+                per-tile intermediates are not retained across tiles (needed to
+                realise the memory saving during training); otherwise autograd
+                keeps every tile's tensors. Costs roughly one extra forward.
+
+        Returns:
+            Tensor of shape `[B, L, input_dim]`, identical to `forward`.
+        """
+        batch_size, event_length, _ = x.shape
+        num_heads = self.num_heads
+        head_dim = self.proj_q.weight.shape[0] // num_heads
+
+        def to_heads(t: Tensor, weight: Tensor, bias: Optional[Tensor]) -> Tensor:
+            return (
+                linear(t, weight, bias)
+                .reshape(batch_size, event_length, num_heads, head_dim)
+                .permute(0, 2, 1, 3)
+            )
+
+        q = to_heads(x, self.proj_q.weight, self.q_bias) * self.scale
+        k = to_heads(x, self.proj_k.weight, None)
+        v = to_heads(x, self.proj_v.weight, self.v_bias)
+
+        pair_bias = None
+        if key_padding_mask is not None:
+            assert (
+                key_padding_mask.dtype == torch.float32
+                or key_padding_mask.dtype == torch.float16
+            ), "incorrect mask dtype"
+            pair_bias = torch.min(
+                key_padding_mask[:, None, :], key_padding_mask[:, :, None]
+            )
+            pair_bias[
+                torch.max(
+                    key_padding_mask[:, None, :], key_padding_mask[:, :, None]
+                )
+                < 0
+            ] = 0
+
+        def compute_tile(
+            q_slice: Tensor,
+            k_all: Tensor,
+            v_all: Tensor,
+            coords_all: Tensor,
+            pair: Optional[Tensor],
+            start: int,
+            end: int,
+        ) -> Tensor:
+            rel = rel_pos_encoder.forward_tiled(coords_all, start, end)
+            scores = q_slice @ k_all.transpose(-2, -1)
+            scores = scores + torch.einsum("bhic,bijc->bhij", q_slice, rel)
+            if pair is not None:
+                scores = scores + pair[:, start:end].unsqueeze(1)
+            attn = self.attn_drop(scores.softmax(dim=-1))
+            out = (attn @ v_all).transpose(1, 2)
+            return out + torch.einsum("bhij,bijc->bihc", attn, rel)
+
+        out = x.new_zeros(batch_size, event_length, num_heads, head_dim)
+        for start in range(0, event_length, q_tile):
+            end = min(start + q_tile, event_length)
+            q_slice = q[:, :, start:end]
+            if use_checkpoint and torch.is_grad_enabled():
+                tile_out = torch.utils.checkpoint.checkpoint(
+                    compute_tile,
+                    q_slice,
+                    k,
+                    v,
+                    coords,
+                    pair_bias,
+                    start,
+                    end,
+                    use_reentrant=False,
+                )
+            else:
+                tile_out = compute_tile(
+                    q_slice, k, v, coords, pair_bias, start, end
+                )
+            out[:, start:end] = tile_out
+
+        out = out.reshape(batch_size, event_length, -1)
+        return self.proj_drop(self.proj(out))
 
 
 class Block(LightningModule):

--- a/src/graphnet/models/gnn/icemix.py
+++ b/src/graphnet/models/gnn/icemix.py
@@ -43,6 +43,9 @@ class DeepIce(GNN):
         include_dynedge: bool = False,
         dynedge_args: Optional[Dict[str, Any]] = None,
         n_features: int = 6,
+        rel_attention: str = "dense",
+        q_tile: int = 64,
+        tiled_checkpoint: bool = True,
     ):
         """Construct `DeepIce`.
 
@@ -62,7 +65,20 @@ class DeepIce(GNN):
                 Competition settings. If `include_dynedge` is False, this
                 argument have no impact.
             n_features: The number of features in the input data.
+            rel_attention: How the relative-attention sandwich computes its
+                spacetime bias. `"dense"` (default) precomputes the full
+                `[B, L, L, H]` bias (original behaviour). `"tiled"` computes 
+                the bias one query-tile at a time.
+            q_tile: Number of query rows per tile when `rel_attention="tiled"`.
+            tiled_checkpoint: When `rel_attention="tiled"`, recompute each tile
+                in the backward pass (during training) at the cost of one 
+                extra forward.
         """
+        if rel_attention not in ("dense", "tiled"):
+            raise ValueError(
+                f"rel_attention must be 'dense' or 'tiled', "
+                f"got {rel_attention!r}"
+            )
         super().__init__(seq_length, hidden_dim)
         fourier_out_dim = hidden_dim // 2 if include_dynedge else hidden_dim
         self.fourier_ext = FourierEncoder(
@@ -117,6 +133,9 @@ class DeepIce(GNN):
             self.dyn_edge = DynEdge(**dynedge_args)
 
         self.include_dynedge = include_dynedge
+        self.rel_attention = rel_attention
+        self.q_tile = q_tile
+        self.tiled_checkpoint = tiled_checkpoint
 
     @torch.jit.ignore
     def no_weight_decay(self) -> Set:
@@ -129,7 +148,9 @@ class DeepIce(GNN):
             data.x, data.batch, padding_value=0
         )
         x = self.fourier_ext(x0, seq_length)
-        rel_pos_bias = self.rel_pos(x0)
+        tiled = (self.rel_attention == "tiled")
+
+        rel_pos_bias = None if tiled else self.rel_pos(x0)
         batch_size = mask.shape[0]
         if self.include_dynedge:
             graph = self.dyn_edge(data)
@@ -140,7 +161,17 @@ class DeepIce(GNN):
         attn_mask[~mask] = -torch.inf
 
         for i, blk in enumerate(self.sandwich):
-            x = blk(x, attn_mask, rel_pos_bias)
+            if tiled and i < self.n_rel:
+                x = blk.forward_tiled(
+                    x,
+                    self.rel_pos,
+                    x0,
+                    key_padding_mask=attn_mask,
+                    q_tile=self.q_tile,
+                    use_checkpoint=self.tiled_checkpoint and self.training,
+                )
+            else:
+                x = blk(x, attn_mask, rel_pos_bias)
             if i + 1 == self.n_rel:
                 rel_pos_bias = None
 

--- a/tests/models/test_deepice_tiled.py
+++ b/tests/models/test_deepice_tiled.py
@@ -1,0 +1,122 @@
+"""Tests for DeepIce's query-tiled relative-attention path."""
+
+import pytest
+import torch
+from torch_geometric.data import Data, Batch
+from torch_geometric.nn import knn_graph
+
+from graphnet.models.gnn import DeepIce
+
+N_FEATURES = 6
+
+def _synth_batch(
+    nev: int = 4,
+    with_edges: bool = False,
+    dtype: torch.dtype = torch.float64,
+) -> Batch:
+    """Build a small batch of variable-length synthetic events."""
+    g = torch.Generator().manual_seed(1)
+    events = []
+    for _ in range(nev):
+        n = int(torch.randint(15, 50, (1,), generator=g))
+        x = torch.randn(n, N_FEATURES, generator=g, dtype=dtype)
+        x[:, 5] = torch.randint(0, 2, (n,), generator=g).to(dtype)
+        data = Data(x=x)
+        if with_edges:
+            data.edge_index = knn_graph(x[:, :3].float(), k=8)
+        data.n_pulses = torch.tensor([n])
+        events.append(data)
+    return Batch.from_data_list(events)
+
+def _kwargs(include_dynedge: bool = False) -> dict:
+    kw = dict(
+        hidden_dim=128,
+        seq_length=64,
+        depth=2,
+        head_size=32,
+        depth_rel=3,
+        n_rel=2,
+        scaled_emb=True,
+        include_dynedge=include_dynedge,
+        n_features=N_FEATURES,
+    )
+    if include_dynedge:
+        kw["dynedge_args"] = {
+            "nb_inputs": N_FEATURES,
+            "nb_neighbours": 8,
+            "post_processing_layer_sizes": [64, 64],
+            "activation_layer": "gelu",
+            "add_norm_layer": True,
+            "skip_readout": True,
+        }
+    return kw
+
+@pytest.mark.parametrize("q_tile", [8, 64, 1000])
+@pytest.mark.parametrize("include_dynedge", [False, True])
+def test_tiled_bit_identical_to_dense(q_tile: int, include_dynedge: bool):
+    """Same weights -> identical output, at any tile size."""
+    torch.manual_seed(0)
+    dense = DeepIce(**_kwargs(include_dynedge)).double().eval()
+    tiled = (
+        DeepIce(
+            **_kwargs(include_dynedge),
+            rel_attention="tiled",
+            q_tile=q_tile,
+        )
+        .double()
+        .eval()
+    )
+    # A stock (dense) checkpoint loads into a tiled model unchanged.
+    tiled.load_state_dict(dense.state_dict())
+
+    batch = _synth_batch(with_edges=include_dynedge)
+    with torch.no_grad():
+        out_dense = dense(batch)
+        out_tiled = tiled(batch)
+    assert (out_dense - out_tiled).abs().max().item() == 0.0
+
+def test_tiled_gradients_match_dense():
+    """Gradients agree, including the checkpointed per-tile recompute.
+
+    Run in train mode (all dropouts / drop-paths are 0, so it is
+    deterministic).
+    """
+    torch.manual_seed(0)
+    dense = DeepIce(**_kwargs()).double().train()
+    tiled = (
+        DeepIce(**_kwargs(), rel_attention="tiled", q_tile=16)
+        .double()
+        .train()
+    )
+    tiled.load_state_dict(dense.state_dict())
+
+    batch = _synth_batch()
+    dense(batch).pow(2).sum().backward()
+    tiled(batch).pow(2).sum().backward()
+
+    dense_grads = dict(dense.named_parameters())
+    max_err = 0.0
+    for name, p in tiled.named_parameters():
+        if p.grad is None:
+            continue
+        gd = dense_grads[name].grad
+        assert gd is not None
+        max_err = max(max_err, (p.grad - gd).abs().max().item())
+    assert max_err < 1e-8, max_err
+
+def test_tiled_trains_with_checkpoint():
+    """Train mode: finite loss, gradients flow through checkpointed tiles."""
+    torch.manual_seed(0)
+    tiled = (
+        DeepIce(**_kwargs(), rel_attention="tiled", q_tile=8)
+        .double()
+        .train()
+    )
+    out = tiled(_synth_batch())
+    out.pow(2).sum().backward()
+    gsum = sum(
+        p.grad.abs().sum().item()
+        for p in tiled.parameters()
+        if p.grad is not None
+    )
+    assert torch.isfinite(out).all() and gsum > 0


### PR DESCRIPTION
Implementation of a tiled approach to the relative position bias attention w/ the SpacetimeEncoder.

The idea is to break it down into tiles to reduce memory constraints imposed by the [B, L, L, H]-sized tensor, but at the cost of recomputing some components of the forward pass again during backprop. This means the memory of the intermediate tensors scales as tile_size * L rather than L^2. This will help people train models on longer sequences without needing a device with large GPU memory.

The default method uses the original form without tiling, and the values and gradients should be identical between the two paths (see tests).

Checking just the speed/memory of the attention operation itself using `q_tile=64`:
| Configuration | Memory reduction vs dense | Time increase vs dense |
| --- | --- | --- |
| B=64, L=256, Tiled, `use_checkpoint=False`| 1.33x | 1.13x |
| B=64, L=256, Tiled, `use_checkpoint=True`| 2.84x | 1.67x |
| B=32, L=768, Tiled, `use_checkpoint=False`| 1.48x | 1.40x |
| B=32, L=768, Tiled, `use_checkpoint=True`| 8.04x | 2.11x |
