### PR TITLE
Add Neptune point-transformer backbone

### DIFF
--- a/examples/04_training/09_train_neptune_model.py
+++ b/examples/04_training/09_train_neptune_model.py
@@ -1,0 +1,285 @@
+"""Example of training the Neptune point transformer.
+
+Neptune tokenizes an event by farthest point sampling over the 4D
+`(x, y, z, t)` point cloud, so it needs neither edges nor a cap on the number
+of pulses: an `EdgelessGraph` over `NodesAsPulses` is all it requires.
+
+See https://arxiv.org/abs/2510.01733.
+"""
+
+import os
+from typing import Any, Dict, List, Optional
+
+from pytorch_lightning.loggers import WandbLogger
+from torch.optim.adam import Adam
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+from graphnet.constants import EXAMPLE_DATA_DIR, EXAMPLE_OUTPUT_DIR
+from graphnet.data.constants import FEATURES, TRUTH
+from graphnet.models import StandardModel
+from graphnet.models.data_representation import EdgelessGraph, NodesAsPulses
+from graphnet.models.detector.prometheus import Prometheus
+from graphnet.models.task.reconstruction import (
+    DirectionReconstructionWithKappa,
+)
+from graphnet.models.transformer import Neptune
+from graphnet.training.labels import Direction
+from graphnet.training.loss_functions import VonMisesFisher3DLoss
+from graphnet.utilities.argparse import ArgumentParser
+from graphnet.utilities.logging import Logger
+from graphnet.data import GraphNeTDataModule
+from graphnet.data.dataset import SQLiteDataset
+from graphnet.data.dataset import ParquetDataset
+
+# Constants
+features = FEATURES.PROMETHEUS
+truth = TRUTH.PROMETHEUS_LEGACY
+
+
+def main(
+    path: str,
+    pulsemap: str,
+    target: str,
+    truth_table: str,
+    gpus: Optional[List[int]],
+    max_epochs: int,
+    early_stopping_patience: int,
+    batch_size: int,
+    num_workers: int,
+    wandb: bool = False,
+) -> None:
+    """Run example."""
+    # Construct Logger
+    logger = Logger()
+
+    # Initialise Weights & Biases (W&B) run
+    if wandb:
+        # Make sure W&B output directory exists
+        wandb_dir = "./wandb/"
+        os.makedirs(wandb_dir, exist_ok=True)
+        wandb_logger = WandbLogger(
+            project="example-script",
+            entity="graphnet-team",
+            save_dir=wandb_dir,
+            log_model=True,
+        )
+
+    logger.info(f"features: {features}")
+    logger.info(f"truth: {truth}")
+
+    # Configuration
+    config: Dict[str, Any] = {
+        "path": path,
+        "pulsemap": pulsemap,
+        "batch_size": batch_size,
+        "num_workers": num_workers,
+        "target": target,
+        "early_stopping_patience": early_stopping_patience,
+        "fit": {
+            "gpus": gpus,
+            "max_epochs": max_epochs,
+        },
+        "dataset_reference": (
+            SQLiteDataset if path.endswith(".db") else ParquetDataset
+        ),
+    }
+
+    # Neptune consumes the raw pulse cloud directly, so no edges and no
+    # pulse-count cap are needed.
+    data_representation = EdgelessGraph(
+        detector=Prometheus(),
+        node_definition=NodesAsPulses(),
+        input_feature_names=features,
+    )
+
+    archive = os.path.join(EXAMPLE_OUTPUT_DIR, "train_neptune_model")
+    run_name = "Neptune_{}_example".format(config["target"])
+    if wandb:
+        # Log configuration to W&B
+        wandb_logger.experiment.config.update(config)
+
+    # Use GraphNetDataModule to load in data
+    dm = GraphNeTDataModule(
+        dataset_reference=config["dataset_reference"],
+        dataset_args={
+            "truth": truth,
+            "truth_table": truth_table,
+            "features": features,
+            "data_representation": data_representation,
+            "pulsemaps": [config["pulsemap"]],
+            "path": config["path"],
+            "index_column": "event_no",
+            "labels": {
+                "direction": Direction(
+                    azimuth_key="injection_azimuth",
+                    zenith_key="injection_zenith",
+                )
+            },
+        },
+        train_dataloader_kwargs={
+            "batch_size": config["batch_size"],
+            "num_workers": config["num_workers"],
+        },
+        test_dataloader_kwargs={
+            "batch_size": config["batch_size"],
+            "num_workers": config["num_workers"],
+        },
+    )
+
+    training_dataloader = dm.train_dataloader
+    validation_dataloader = dm.val_dataloader
+
+    # Building model. `Prometheus` standardizes positions as metres / 100 and
+    # time as nanoseconds / 1.05e4, so `xyz_scale=0.1` and `time_scale=10.5`
+    # bring them to the kilometres and microseconds Neptune expects. This
+    # detector records no charge, hence `charge_column=None`.
+    #
+    # Note that the geometric priors -- `fourier_freq_min` / `_max`,
+    # `rope_scales`, and the tokenizer's `metric_time_scale` -- are left at
+    # their IceCube-tuned defaults here. Rescale them for a production run on
+    # a detector of a very different size.
+    backbone = Neptune(
+        nb_inputs=data_representation.nb_outputs,
+        coordinate_columns=[0, 1, 2],
+        time_column=3,
+        charge_column=None,
+        xyz_scale=0.1,
+        time_scale=10.5,
+        num_patches=32,
+        token_dim=64,
+        num_layers=2,
+        num_heads=4,
+        hidden_dim=128,
+        tokenizer_kwargs={"mlp_layers": [32, 64]},
+        # `compile_encoder=True` is worth 2-4x on GPU, and is what enables
+        # the packed attention path. Left off here to keep the example quick.
+        compile_encoder=False,
+    )
+    task = DirectionReconstructionWithKappa(
+        hidden_size=backbone.nb_outputs,
+        target_labels=config["target"],
+        loss_function=VonMisesFisher3DLoss(),
+    )
+    model = StandardModel(
+        data_representation=data_representation,
+        backbone=backbone,
+        tasks=[task],
+        optimizer_class=Adam,
+        optimizer_kwargs={"lr": 1e-03, "eps": 1e-03},
+        scheduler_class=ReduceLROnPlateau,
+        scheduler_kwargs={
+            "patience": config["early_stopping_patience"],
+        },
+        scheduler_config={
+            "frequency": 1,
+            "monitor": "val_loss",
+        },
+    )
+
+    # Training model
+    model.fit(
+        training_dataloader,
+        validation_dataloader,
+        early_stopping_patience=config["early_stopping_patience"],
+        logger=wandb_logger if wandb else None,
+        **config["fit"],
+    )
+
+    # Get predictions
+    additional_attributes = [
+        "injection_zenith",
+        "injection_azimuth",
+        "event_no",
+    ]
+    prediction_columns = [
+        config["target"] + "_x_pred",
+        config["target"] + "_y_pred",
+        config["target"] + "_z_pred",
+        config["target"] + "_kappa_pred",
+    ]
+
+    assert isinstance(additional_attributes, list)  # mypy
+
+    results = model.predict_as_dataframe(
+        validation_dataloader,
+        additional_attributes=additional_attributes,
+        prediction_columns=prediction_columns,
+        gpus=config["fit"]["gpus"],
+    )
+
+    # Save predictions and model to file
+    db_name = path.split("/")[-1].split(".")[0]
+    path = os.path.join(archive, db_name, run_name)
+    logger.info(f"Writing results to {path}")
+    os.makedirs(path, exist_ok=True)
+
+    # Save results as .csv
+    results.to_csv(f"{path}/results.csv")
+
+    # Save model config and state dict - Version safe save method.
+    model.save_state_dict(f"{path}/state_dict.pth")
+    model.save_config(f"{path}/model_config.yml")
+
+
+if __name__ == "__main__":
+
+    # Parse command-line arguments
+    parser = ArgumentParser(description="""
+Train the Neptune point transformer without the use of config files.
+""")
+
+    parser.add_argument(
+        "--path",
+        help="Path to dataset file (default: %(default)s)",
+        default=f"{EXAMPLE_DATA_DIR}/sqlite/prometheus/prometheus-events.db",
+    )
+
+    parser.add_argument(
+        "--pulsemap",
+        help="Name of pulsemap to use (default: %(default)s)",
+        default="total",
+    )
+
+    parser.add_argument(
+        "--target",
+        help=(
+            "Name of feature to use as regression target (default: "
+            "%(default)s)"
+        ),
+        default="direction",
+    )
+
+    parser.add_argument(
+        "--truth-table",
+        help="Name of truth table to be used (default: %(default)s)",
+        default="mc_truth",
+    )
+
+    parser.with_standard_arguments(
+        "gpus",
+        ("max-epochs", 1),
+        ("early-stopping-patience", 2),
+        ("batch-size", 16),
+        ("num-workers", 2),
+    )
+
+    parser.add_argument(
+        "--wandb",
+        action="store_true",
+        help="If True, Weights & Biases are used to track the experiment.",
+    )
+
+    args, unknown = parser.parse_known_args()
+
+    main(
+        args.path,
+        args.pulsemap,
+        args.target,
+        args.truth_table,
+        args.gpus,
+        args.max_epochs,
+        args.early_stopping_patience,
+        args.batch_size,
+        args.num_workers,
+        args.wandb,
+    )

--- a/src/graphnet/models/components/embedding.py
+++ b/src/graphnet/models/components/embedding.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 from torch.functional import Tensor
 
-from typing import Optional
+from typing import Optional, Sequence
 
 from pytorch_lightning import LightningModule
 from torch_geometric.utils import add_self_loops
@@ -402,3 +402,107 @@ class RWSELinearNodeEncoder(LightningModule):
         data.x = torch.cat((x, rwse), dim=1)
 
         return data
+
+
+class FourierPositionEncoder(LightningModule):
+    """Absolute position encoding via log-spaced Fourier features.
+
+    Lifts the spatial coordinates through sine/cosine at several log-spaced
+    frequencies before a small MLP. This mitigates the spectral bias of a
+    raw-coordinate MLP (Tancik et al. 2020), letting the encoder represent
+    sharp position dependence such as detector boundaries and depth
+    structure.
+
+    Distinct from :class:`FourierEncoder` in the same module, which embeds
+    per-pulse *features* (position, time, charge, auxiliary) with sinusoidal
+    embeddings. This class embeds *position only*, and is applied to token
+    centroids rather than to individual pulses.
+
+    Time is deliberately excluded: callers are expected to centre time per
+    event, which makes absolute time close to meaningless, and relative time
+    is handled by the rotary embedding inside attention.
+    """
+
+    freqs: Tensor
+    axis_scales: Tensor
+
+    def __init__(
+        self,
+        token_dim: int,
+        in_dim: int = 3,
+        num_bands: int = 20,
+        freq_min: float = 3.0,
+        freq_max: float = 180.0,
+        axis_scales: Sequence[float] = (1.0, 1.0, 1.0),
+        dropout: float = 0.1,
+    ):
+        """Construct `FourierPositionEncoder`.
+
+        Args:
+            token_dim: Output dimension.
+            in_dim: Number of leading coordinate axes to encode. Any further
+                axes of the input, such as time, are ignored.
+            num_bands: Number of log-spaced frequency bands per axis.
+            freq_min: Lowest angular frequency, in radians per coordinate
+                unit.
+            freq_max: Highest angular frequency, in radians per coordinate
+                unit.
+            axis_scales: Per-axis multiplier on the frequency bands. Must
+                have length `in_dim`.
+            dropout: Dropout inside the MLP.
+        """
+        super().__init__()
+        if num_bands < 1:
+            raise ValueError(f"num_bands must be >= 1 (got {num_bands})")
+        if len(axis_scales) != in_dim:
+            raise ValueError(
+                f"axis_scales must have length in_dim={in_dim} "
+                f"(got {len(axis_scales)})"
+            )
+        self.in_dim = in_dim
+
+        if num_bands == 1:
+            freqs = torch.tensor([float(freq_min)])
+        else:
+            exponents = torch.arange(num_bands, dtype=torch.float32) / (
+                num_bands - 1
+            )
+            freqs = (
+                float(freq_min)
+                * (float(freq_max) / float(freq_min)) ** exponents
+            )
+        self.register_buffer("freqs", freqs)
+        self.register_buffer(
+            "axis_scales", torch.tensor(axis_scales, dtype=torch.float32)
+        )
+
+        feat_dim = in_dim * num_bands * 2  # sine and cosine per (axis, band)
+        self.mlp = nn.Sequential(
+            nn.Linear(feat_dim, token_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(token_dim, token_dim),
+        )
+
+    def forward(self, coords: Tensor) -> Tensor:
+        """Encode the leading `in_dim` axes of `coords`.
+
+        Args:
+            coords: `[B, S, C]` coordinates with `C >= in_dim`.
+
+        Returns:
+            `[B, S, token_dim]` position embeddings.
+        """
+        # Trig in float32 for accuracy; the MLP follows the ambient autocast
+        # dtype.
+        xyz = coords[..., : self.in_dim].float()
+        scaled = self.freqs.unsqueeze(0) * self.axis_scales.unsqueeze(1)
+        ang = xyz.unsqueeze(-1) * scaled
+        feats = torch.cat([ang.sin(), ang.cos()], dim=-1).flatten(-2)
+        # The trigonometry runs in float32 for accuracy, but the MLP may
+        # hold low-precision weights when the module itself was converted
+        # rather than run under autocast -- Lightning's "16-true" and
+        # "bf16-true" modes do exactly that, and `Linear` will not cast for
+        # us there. Under autocast the weights are still float32, so this is
+        # a no-op and autocast handles the cast as before.
+        return self.mlp(feats.to(next(self.mlp.parameters()).dtype))

--- a/src/graphnet/models/components/fps.py
+++ b/src/graphnet/models/components/fps.py
@@ -1,0 +1,634 @@
+"""Farthest point sampling (FPS) for point-cloud tokenization.
+
+Ported from the Neptune reference implementation
+(https://github.com/felixyu7/neptune, MIT licence), described in
+https://arxiv.org/abs/2510.01733.
+
+FPS greedily selects `K` points that are maximally spread out, which is how
+`graphnet.models.components.tokenizers.FPSTokenizer` picks token centroids for
+an event. Two fused variants are provided because the FPS loop already computes
+every point-to-centroid distance: nearest-centroid (Voronoi) assignment and a
+k-nearest-neighbour gather both come almost for free.
+
+Two backends, selected automatically and producing identical indices:
+
+- **Triton** (CUDA, non-float64), in
+  :mod:`graphnet.models.components.fps_triton`. Streams distances, so nothing
+  of size `[B, N, K]` is ever materialised.
+- **Pure PyTorch**, below. Vectorised over the batch; the only Python loop is
+  the inherently sequential `K` iterations. Note that the assignment path
+  materialises a `[B, N, K]` distance tensor -- roughly 400 MB in float32 at
+  `B=256, N=3000, K=128` -- which the Triton path avoids.
+
+Semantics shared by both backends:
+
+- validity = `valid_mask` AND all-finite coordinates,
+- distances accumulate in float32 (float64 for double inputs),
+- ties select the lowest index,
+- an out-of-range start falls back to index 0; once valid candidates are
+  exhausted (`K` > valid count) the last selection is repeated,
+- kNN neighbours are closest-first over all valid points (the centroid and
+  already-selected points included); rows with fewer than `k` valid points
+  pad with the centroid index.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from graphnet.utilities.imports import has_triton_package
+
+# ------------------------------------------------------------------------
+# Pure-PyTorch backend
+# ------------------------------------------------------------------------
+
+
+def _acc(points: Tensor) -> Tensor:
+    """Return `points` in the accumulation dtype (float32, or float64)."""
+    return points if points.dtype == torch.float64 else points.float()
+
+
+def _fps_state(
+    points: Tensor, mask: Tensor, start_idx: Tensor
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Set up the accumulators shared by the pure-PyTorch FPS routines."""
+    _, n_points, _ = points.shape
+    pts = _acc(points)
+    valid = mask & points.isfinite().all(dim=-1)
+    inf = float("inf")
+    min_d = torch.where(valid, inf, -inf).to(pts.dtype)
+    in_range = (start_idx >= 0) & (start_idx < n_points)
+    last = torch.where(in_range, start_idx, torch.zeros_like(start_idx))
+    return pts, valid, min_d, last
+
+
+def _fps_reference(
+    points: Tensor, mask: Tensor, start_idx: Tensor, k: int
+) -> Tensor:
+    """Select `k` farthest points per row, returning `[B, k]` indices."""
+    batch_size = points.shape[0]
+    idx = torch.empty(batch_size, k, device=points.device, dtype=torch.long)
+    pts, valid, min_d, last = _fps_state(points, mask, start_idx)
+    rows = torch.arange(batch_size, device=points.device)
+    for i in range(k):
+        idx[:, i] = last
+        min_d[rows, last] = -float("inf")
+        if i + 1 == k:
+            break
+        centroid = pts[rows, last]
+        dist = (pts - centroid[:, None, :]).square().sum(dim=2)
+        # Kernel-exact update: invalid lanes keep -inf, and NaN distances
+        # (only reachable via a pathological non-finite start) never
+        # overwrite.
+        min_d = torch.where(valid & (dist < min_d), dist, min_d)
+        vals, nxt = min_d.max(dim=1)
+        # Exhausted rows (all -inf) repeat the previous selection.
+        last = torch.where(vals.isneginf(), last, nxt)
+    return idx
+
+
+def _assign_reference(points: Tensor, idx: Tensor) -> Tensor:
+    """Assign every point to its nearest centroid among `idx`.
+
+    Returns `[B, N]` int64 in `[0, K)`; values at invalid lanes are
+    unspecified. Per-dimension accumulation in float32 matches the
+    Triton kernels' order bitwise, and NaN distances promote to +inf so
+    a degenerate centroid is never chosen.
+    """
+    batch_size, n_points, n_dims = points.shape
+    pts = _acc(points)
+    cents = torch.gather(
+        pts, 1, idx.unsqueeze(-1).expand(-1, -1, n_dims)
+    )  # [B, K, D]
+    dist = pts.new_zeros(batch_size, n_points, idx.size(1))
+    for dim in range(n_dims):
+        diff = pts[:, :, dim].unsqueeze(-1) - cents[:, :, dim].unsqueeze(1)
+        dist = dist + diff * diff
+    dist = torch.where(dist == dist, dist, float("inf"))
+    return dist.argmin(dim=-1)
+
+
+def _fps_knn_reference(
+    points: Tensor,
+    mask: Tensor,
+    start_idx: Tensor,
+    k: int,
+    k_neighbors: int,
+) -> Tuple[Tensor, Tensor]:
+    """Select `k` centroids and gather their `k_neighbors` nearest points."""
+    _, _, n_dims = points.shape
+    centroid_idx = _fps_reference(points, mask, start_idx, k)
+    pts = _acc(points)
+    valid = mask & points.isfinite().all(dim=-1)
+    cents = torch.gather(
+        pts, 1, centroid_idx.unsqueeze(-1).expand(-1, -1, n_dims)
+    )
+    dist = (cents.unsqueeze(2) - pts.unsqueeze(1)).square().sum(dim=-1)
+    dist = torch.where(valid.unsqueeze(1), dist, float("inf"))
+    # Stable sort => lowest index first among exact ties, like the kernels.
+    svals, sidx = dist.sort(dim=-1, stable=True)
+    svals, sidx = svals[..., :k_neighbors], sidx[..., :k_neighbors]
+    # Slots past the row's valid count carry +inf -> pad with the centroid.
+    return centroid_idx, torch.where(
+        svals.isinf(), centroid_idx.unsqueeze(-1), sidx
+    )
+
+
+def _nearest_assign_reference(
+    p_flat: Tensor,
+    cents: Tensor,
+    starts: Tensor,
+    counts: Tensor,
+    k: int,
+) -> Tensor:
+    """Nearest-centroid assignment over batch-segmented flat points."""
+    n_points, n_dims = p_flat.shape
+    batch_size = starts.numel()
+    seg = torch.repeat_interleave(
+        torch.arange(batch_size, device=p_flat.device),
+        counts,
+        output_size=n_points,
+    )
+    cents_per_point = cents.view(batch_size, k, n_dims).index_select(0, seg)
+    pts = p_flat.float()
+    dist = pts.new_zeros(n_points, k)
+    for dim in range(n_dims):
+        diff = pts[:, dim].unsqueeze(-1) - cents_per_point[:, :, dim]
+        dist = dist + diff * diff
+    dist = torch.where(dist == dist, dist, float("inf"))
+    return dist.argmin(dim=1)
+
+
+# ------------------------------------------------------------------------
+# Backend dispatch
+# ------------------------------------------------------------------------
+
+
+def _use_triton(points: Tensor) -> bool:
+    """Return whether the Triton backend can serve `points`."""
+    return (
+        points.is_cuda
+        and points.dtype != torch.float64
+        and has_triton_package()
+    )
+
+
+def _dispatch(
+    points: Tensor,
+    mask: Tensor,
+    start_idx: Tensor,
+    k: int,
+    k_neighbors: Optional[int],
+) -> Tensor | Tuple[Tensor, Tensor]:
+    """Route a resolved call to the best available backend."""
+    if _use_triton(points):
+        # Imported here, never at module scope: `graphnet.models` is
+        # walk-imported by `ModelConfig`'s class discovery, and Triton is
+        # absent on e.g. macOS.
+        from graphnet.models.components import fps_triton
+
+        if k_neighbors is None:
+            return fps_triton.fps(points, mask, start_idx, k)
+        return fps_triton.fps_knn(points, mask, start_idx, k, k_neighbors)
+    if k_neighbors is None:
+        return _fps_reference(points, mask, start_idx, k)
+    return _fps_knn_reference(points, mask, start_idx, k, k_neighbors)
+
+
+# ------------------------------------------------------------------------
+# Front-end: validation and start resolution
+# ------------------------------------------------------------------------
+
+
+def _resolve_start_idx(
+    valid: Tensor,
+    counts: Optional[Tensor],
+    batch_size: int,
+    n_points: int,
+    k: int,
+    device: torch.device,
+    start_idx: Optional[Tensor],
+    random_start: bool,
+    generator: Optional[torch.Generator],
+    validate: bool = True,
+) -> Tensor:
+    """Produce a validated contiguous `[B]` long start index.
+
+    `valid` marks selectable points: mask-true AND all-finite coordinates.
+    With `validate=False` the checks (and their host sync) are skipped
+    entirely, and `counts` may then be None on the `start_idx is None` path.
+    All start resolution is pure-tensor: no host-device sync beyond
+    validation.
+    """
+    if start_idx is None:
+        if validate:
+            assert counts is not None
+            if bool((counts < k).any()):
+                raise ValueError(
+                    "FPS requires K <= number of valid points. Found "
+                    f"batch(es) with K={k} but fewer valid points."
+                )
+        if not random_start:
+            # Deterministic start: first valid index per row (all-invalid
+            # rows give 0; the backend pads those rows anyway).
+            return valid.long().argmax(dim=1).contiguous()
+        # Random start: masked-random argmax draws uniformly over valid
+        # points without multinomial's float32 probability copy. All-invalid
+        # rows argmax to 0, matching the documented pad behaviour.
+        scores = torch.rand(
+            batch_size, n_points, device=device, generator=generator
+        )
+        scores = torch.where(valid, scores, float("-inf"))
+        return scores.argmax(dim=1).contiguous()
+
+    # User-supplied path. Fuse all validation into a single sync. Bad inputs
+    # (K > counts, out-of-range) raise; a start index pointing at an invalid
+    # slot is silently repaired to the first valid index in that row.
+    if start_idx.device != device:
+        raise ValueError(
+            "start_idx must be on the same device as points (a cross-device "
+            "copy here would silently synchronize the host)"
+        )
+    start_idx = start_idx.to(dtype=torch.long)
+    if start_idx.numel() != batch_size:
+        raise ValueError("start_idx must have shape [B]")
+    start_idx = start_idx.reshape(batch_size)
+
+    if validate:
+        assert counts is not None
+        out_of_range = (start_idx < 0) | (start_idx >= n_points)
+        insufficient = counts < k
+        if bool((out_of_range | insufficient).any()):
+            if bool(insufficient.any()):
+                raise ValueError(
+                    "FPS requires K <= number of valid points. Found "
+                    f"batch(es) with K={k} but fewer valid points."
+                )
+            raise ValueError("start_idx values must be within [0, N)")
+
+    # Repair a start index pointing at an invalid slot. Pure-tensor, no sync.
+    assert counts is not None
+    has_valid = counts > 0
+    safe_start = start_idx.clamp(0, max(n_points - 1, 0))
+    supplied_valid = valid.gather(1, safe_start.unsqueeze(-1)).squeeze(-1)
+    first_valid = torch.argmax(valid.long(), dim=1)
+    repaired = torch.where(supplied_valid | ~has_valid, start_idx, first_valid)
+    return repaired.contiguous()
+
+
+def _prepare(
+    points: Tensor, valid_mask: Tensor, precision: Optional[torch.dtype]
+) -> Tuple[Tensor, Tensor]:
+    """Cast inputs to the compute dtype and make them contiguous."""
+    device = points.device
+    if precision is None:
+        if points.dtype != torch.float32:
+            points = points.to(dtype=torch.float32)
+    else:
+        if device.type == "cpu" and precision == torch.bfloat16:
+            raise ValueError(
+                "bfloat16 is not supported on CPU (use float16, float32, or "
+                "float64)"
+            )
+        if points.dtype != precision:
+            points = points.to(dtype=precision)
+    if valid_mask.device != device:
+        valid_mask = valid_mask.to(device)
+    valid_mask = valid_mask.to(dtype=torch.bool)
+    return points.contiguous(), valid_mask.contiguous()
+
+
+def _prepare_and_resolve(
+    points: Tensor,
+    valid_mask: Tensor,
+    k: int,
+    start_idx: Optional[Tensor],
+    random_start: bool,
+    generator: Optional[torch.Generator],
+    precision: Optional[torch.dtype],
+    validate: bool,
+    assume_finite: bool,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Run shape checks, dtype prep, validity and start resolution."""
+    if points.dim() != 3:
+        raise ValueError("points tensor must have shape [B, N, D]")
+    if valid_mask.dim() != 2:
+        raise ValueError("valid_mask tensor must have shape [B, N]")
+    if points.shape[:2] != valid_mask.shape:
+        raise ValueError(
+            "points and valid_mask must agree on batch & point dims"
+        )
+    if k < 0:
+        raise ValueError("K must be non-negative")
+
+    device = points.device
+    points_c, mask_c = _prepare(points, valid_mask, precision)
+    batch_size, n_points, _ = points_c.shape
+
+    # Empty-input edge cases: with K == 0 skip start resolution entirely (the
+    # callers early-return an empty result and never use start_idx; argmax
+    # over N == 0 would raise). N == 0 with K > 0 can never satisfy
+    # K <= valid points, so reject it deterministically even when
+    # validate=False.
+    if k == 0:
+        return (
+            points_c,
+            mask_c,
+            torch.zeros(batch_size, dtype=torch.long, device=device),
+        )
+    if n_points == 0:
+        raise ValueError(
+            "FPS with K > 0 requires at least one point (got N=0)"
+        )
+
+    # Selectable = mask-true AND all-finite; validation and start repair both
+    # count from this same predicate, so validate=True enforces exactly the
+    # documented "K <= valid points" precondition. assume_finite skips the
+    # [B, N, D] finiteness pass on the caller's guarantee.
+    valid = (
+        mask_c if assume_finite else (mask_c & points_c.isfinite().all(dim=-1))
+    )
+    counts = (
+        valid.sum(dim=1, dtype=torch.long)
+        if (validate or start_idx is not None)
+        else None
+    )
+    resolved = _resolve_start_idx(
+        valid,
+        counts,
+        batch_size,
+        n_points,
+        k,
+        device,
+        start_idx,
+        random_start,
+        generator,
+        validate,
+    )
+    return points_c, mask_c, resolved
+
+
+# ------------------------------------------------------------------------
+# Public API
+# ------------------------------------------------------------------------
+
+
+def farthest_point_sampling(
+    points: Tensor,
+    valid_mask: Tensor,
+    k: int,
+    *,
+    start_idx: Optional[Tensor] = None,
+    random_start: bool = True,
+    generator: Optional[torch.Generator] = None,
+    precision: Optional[torch.dtype] = None,
+    validate: bool = True,
+    assume_finite: bool = False,
+) -> Tensor:
+    """Select `k` maximally spread-out points per batch row.
+
+    Args:
+        points: Float tensor `[B, N, D]` (batch, points, coordinates).
+        valid_mask: Bool tensor `[B, N]`; False marks padded/invalid points.
+        k: Number of samples to draw per batch element. Must satisfy
+            `k <= number of valid points` for every row.
+        start_idx: Optional `[B]` long tensor giving the first index per row.
+            Must live on the same device as `points`; an index pointing at an
+            invalid slot is repaired to that row's first valid index.
+        random_start: If True (default) and `start_idx` is not given, draw a
+            random first index from the valid points. If False, the row's
+            first valid index is used. Callers typically pass `self.training`
+            so that the random start acts as a train-time augmentation and
+            evaluation stays deterministic.
+        generator: Optional generator for deterministic random starts.
+        precision: Optional dtype for internal computation. None (default)
+            uses float32 on all devices. float16/float32/float64 everywhere,
+            bfloat16 on GPU only.
+        validate: If True (default), verify `k <= valid count` per row and
+            range-check a user-supplied `start_idx`. Costs one host-device
+            sync; callers that already guarantee the precondition can pass
+            False to keep the call fully asynchronous. With `validate=False`
+            a violated precondition is not diagnosed -- the output is padded
+            with repeated indices instead.
+        assume_finite: If True, the caller guarantees every mask-true point
+            has finite coordinates and the `[B, N, D]` finiteness pass is
+            skipped.
+
+    Returns:
+        Long tensor `[B, k]` of selected point indices.
+    """
+    points_c, mask_c, resolved = _prepare_and_resolve(
+        points,
+        valid_mask,
+        k,
+        start_idx,
+        random_start,
+        generator,
+        precision,
+        validate,
+        assume_finite,
+    )
+    if k == 0:
+        return torch.zeros(
+            (points_c.shape[0], 0),
+            device=points_c.device,
+            dtype=torch.long,
+        )
+    result = _dispatch(points_c, mask_c, resolved, k, None)
+    assert isinstance(result, Tensor)
+    return result
+
+
+def farthest_point_sampling_with_knn(
+    points: Tensor,
+    valid_mask: Tensor,
+    k: int,
+    k_neighbors: int,
+    *,
+    start_idx: Optional[Tensor] = None,
+    random_start: bool = True,
+    generator: Optional[torch.Generator] = None,
+    precision: Optional[torch.dtype] = None,
+    validate: bool = True,
+    assume_finite: bool = False,
+) -> Tuple[Tensor, Tensor]:
+    """Run FPS and gather each centroid's `k_neighbors` nearest points.
+
+    The distances computed during FPS are reused for the neighbour search.
+    Neighbours are sorted closest-first; the centroid itself and
+    already-selected points are eligible, and rows with fewer than
+    `k_neighbors` valid points pad with the centroid index. All other
+    arguments behave as in :func:`farthest_point_sampling`.
+
+    Args:
+        points: Float tensor `[B, N, D]`.
+        valid_mask: Bool tensor `[B, N]`; False marks padded/invalid points.
+        k: Number of centroids to draw per batch element.
+        k_neighbors: Neighbours per centroid; must satisfy `0 < k_neighbors
+            <= N`.
+        start_idx: Optional `[B]` long tensor giving the first index per row.
+        random_start: Draw a random first index when `start_idx` is None.
+        generator: Optional generator for deterministic random starts.
+        precision: Optional dtype for internal computation.
+        validate: Verify the `k <= valid count` precondition.
+        assume_finite: Skip the finiteness pass over `points`.
+
+    Returns:
+        Tuple of the `[B, k]` centroid indices and the `[B, k, k_neighbors]`
+        neighbour indices, sorted by distance (closest first).
+    """
+    if k_neighbors <= 0:
+        raise ValueError("k_neighbors must be positive")
+
+    points_c, mask_c, resolved = _prepare_and_resolve(
+        points,
+        valid_mask,
+        k,
+        start_idx,
+        random_start,
+        generator,
+        precision,
+        validate,
+        assume_finite,
+    )
+    batch_size, n_points, _ = points_c.shape
+
+    if k == 0:
+        return (
+            torch.zeros(
+                (batch_size, 0), device=points_c.device, dtype=torch.long
+            ),
+            torch.zeros(
+                (batch_size, 0, k_neighbors),
+                device=points_c.device,
+                dtype=torch.long,
+            ),
+        )
+
+    if k_neighbors > n_points:
+        raise ValueError(
+            f"k_neighbors ({k_neighbors}) must be <= N ({n_points})"
+        )
+
+    result = _dispatch(points_c, mask_c, resolved, k, k_neighbors)
+    assert isinstance(result, tuple)
+    return result
+
+
+def farthest_point_sampling_with_assign(
+    points: Tensor,
+    valid_mask: Tensor,
+    k: int,
+    *,
+    start_idx: Optional[Tensor] = None,
+    random_start: bool = True,
+    generator: Optional[torch.Generator] = None,
+    precision: Optional[torch.dtype] = None,
+    validate: bool = True,
+    assume_finite: bool = False,
+) -> Tuple[Tensor, Tensor]:
+    """Run FPS and assign every point to its nearest centroid.
+
+    The FPS loop already computes each point's distance to every selected
+    centroid, so the Voronoi assignment is nearly free on the fused CUDA
+    path. Ties assign to the lowest centroid index. All other arguments
+    behave as in :func:`farthest_point_sampling`.
+
+    Args:
+        points: Float tensor `[B, N, D]`.
+        valid_mask: Bool tensor `[B, N]`; False marks padded/invalid points.
+        k: Number of centroids to draw per batch element.
+        start_idx: Optional `[B]` long tensor giving the first index per row.
+        random_start: Draw a random first index when `start_idx` is None.
+        generator: Optional generator for deterministic random starts.
+        precision: Optional dtype for internal computation.
+        validate: Verify the `k <= valid count` precondition.
+        assume_finite: Skip the finiteness pass over `points`.
+
+    Returns:
+        Tuple of the `[B, k]` centroid indices and a `[B, N]` assignment
+        tensor holding each point's nearest centroid as a position in
+        `[0, k)` -- an index into the centroid tensor, not into `points`.
+        Values at invalid lanes are unspecified.
+    """
+    points_c, mask_c, resolved = _prepare_and_resolve(
+        points,
+        valid_mask,
+        k,
+        start_idx,
+        random_start,
+        generator,
+        precision,
+        validate,
+        assume_finite,
+    )
+    batch_size, n_points, n_dims = points_c.shape
+
+    if k == 0:
+        return (
+            torch.zeros(
+                (batch_size, 0), device=points_c.device, dtype=torch.long
+            ),
+            torch.zeros(
+                (batch_size, n_points),
+                device=points_c.device,
+                dtype=torch.long,
+            ),
+        )
+
+    if _use_triton(points_c):
+        from graphnet.models.components import fps_triton
+
+        cap = fps_triton._single_tile_cap(fps_triton.SINGLE_TILE_MAX_N, n_dims)
+        if n_points <= cap:
+            return fps_triton.fps_assign(points_c, mask_c, resolved, k)
+
+    # Composed route: tiled-N CUDA, CPU, and other devices.
+    idx = _dispatch(points_c, mask_c, resolved, k, None)
+    assert isinstance(idx, Tensor)
+    return idx, _assign_reference(points_c, idx)
+
+
+def nearest_assign(
+    p_flat: Tensor,
+    cents: Tensor,
+    starts: Tensor,
+    counts: Tensor,
+    n_max: int,
+    k: int,
+) -> Tensor:
+    """Assign batch-segmented flat points to their nearest centroid.
+
+    Used by the charge-weighted Lloyd refinement in
+    :class:`~graphnet.models.components.tokenizers.FPSTokenizer`, where the
+    centroids are updated cell means rather than points of the cloud.
+    Deterministic (lowest centroid index on exact ties) and gradient-free:
+    the inputs are detached, since assignment is integer routing.
+
+    Args:
+        p_flat: Float32 `[N, D]` flat points, rows grouped per event.
+        cents: Float32 `[B * k, D]` centroids.
+        starts: Int64 `[B]` start offset of each event in `p_flat`.
+        counts: Int64 `[B]` number of points in each event.
+        n_max: Largest value in `counts`, as a host-side int.
+        k: Number of centroids per event.
+
+    Returns:
+        Int64 `[N]` cell indices in `[0, k)`.
+    """
+    p_detached = p_flat.detach()
+    c_detached = cents.detach()
+    if p_detached.numel() == 0 or starts.numel() == 0:
+        return torch.empty(
+            p_detached.shape[0], device=p_detached.device, dtype=torch.long
+        )
+    if _use_triton(p_detached):
+        from graphnet.models.components import fps_triton
+
+        return fps_triton.nearest_assign(
+            p_detached, c_detached, starts, counts, n_max, k
+        )
+    return _nearest_assign_reference(p_detached, c_detached, starts, counts, k)

--- a/src/graphnet/models/components/fps_triton.py
+++ b/src/graphnet/models/components/fps_triton.py
@@ -1,0 +1,670 @@
+"""Triton CUDA kernels for farthest point sampling.
+
+Ported from the Neptune reference implementation
+(https://github.com/felixyu7/neptune, MIT licence) and used by
+:mod:`graphnet.models.components.fps`, which owns the public API and routes
+here only on CUDA when Triton is installed.
+
+One program per batch row (grid=(B,)); the K selection loop runs inside the
+kernel, so a call is a single launch with no host syncs. Two regimes:
+
+- single-tile (N <= SINGLE_TILE_MAX_N, scaled down for D > 4): coordinates
+  and the min-distance array stay register-resident across the whole K-loop.
+- tiled (larger N): min distances (and current distances for kNN) live in a
+  global fp32 scratch; each iteration sweeps N in BLOCK_N tiles, folding a
+  running argmax with earlier-tile-wins tie-breaking.
+
+Semantics mirror the pure-PyTorch backend exactly: fp32 accumulation in
+coordinate order, lowest-index tie-breaking, non-finite coordinates invalid,
+out-of-range start falls back to 0, exhausted rows repeat the last selection,
+kNN closest-first with the centroid padding short rows. D is a compile-time
+constant (static unroll), so any geometry compiles a matching kernel; float64
+is routed to the pure-PyTorch backend by the API layer.
+"""
+
+# mypy: ignore-errors
+# Triton kernel signatures are not meaningfully annotatable: `tl.constexpr`
+# parameters and pointer arguments have no static Python types.
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from graphnet.utilities.imports import has_triton_package
+
+if has_triton_package():
+    import triton
+    import triton.language as tl
+else:  # pragma: no cover - the kernels below are unreachable without Triton
+
+    class _TritonUnavailable:
+        """Import-time stand-in used when Triton is not installed.
+
+        `graphnet.models` is walk-imported by `ModelConfig`'s class discovery
+        (`graphnet.utilities.config.parsing.list_all_submodules`), so this
+        module must import on machines without Triton -- macOS, for instance.
+        Only `@triton.jit` and the `_INF` constant below touch Triton at module
+        scope, and `from __future__ import annotations` keeps `tl.constexpr`
+        parameter annotations unevaluated, so an identity shim is enough.
+        Every entry point here is reached exclusively through
+        `graphnet.models.components.fps`, which checks `has_triton_package()`
+        first.
+        """
+
+        def __getattr__(self, name: str) -> Any:
+            def _identity(*args: Any, **kwargs: Any) -> Any:
+                if len(args) == 1 and callable(args[0]) and not kwargs:
+                    return args[0]
+                return None
+
+            return _identity
+
+    triton = tl = _TritonUnavailable()
+
+SINGLE_TILE_MAX_N = 16384  # register-resident cap for D<=4 (scaled by D below)
+KNN_SINGLE_TILE_MAX_N = 8192  # fused kernel holds one extra vector
+TILE_N = 4096  # sweep width of the tiled kernels
+
+_INF = tl.constexpr(float("inf"))
+
+
+def _num_warps(block_n: int) -> int:
+    if block_n <= 2048:
+        return 4
+    if block_n <= 8192:
+        return 8
+    return 16
+
+
+def _single_tile_cap(cap: int, D: int) -> int:
+    # register budget ~ (D+1) vectors of BLOCK_N floats; keep parity with D=4
+    return cap if D <= 4 else max(1024, cap * 5 // (D + 1))
+
+
+@triton.jit
+def _load_coords(p_base, inb, valid, D: tl.constexpr):
+    coords = ()
+    for d in tl.static_range(D):
+        v = tl.load(p_base + d, mask=inb, other=0.0).to(tl.float32)
+        valid = valid & (tl.abs(v) < _INF)  # finite: excludes NaN and +/-inf
+        coords = coords + (v,)
+    return coords, valid
+
+
+@triton.jit
+def _dist_to(coords, sel, D: tl.constexpr):
+    # centroid coords are extracted from the register-resident tiles;
+    # sequential accumulation over d matches the C++/CUDA kernels bitwise
+    dist = tl.zeros(sel.shape, dtype=tl.float32)
+    for d in tl.static_range(D):
+        c = tl.sum(tl.where(sel, coords[d], 0.0))
+        diff = coords[d] - c
+        dist += diff * diff
+    return dist
+
+
+@triton.jit
+def _resolve_start(start_ptr, b, N):
+    start = tl.load(start_ptr + b).to(tl.int32)
+    return tl.where((start >= 0) & (start < N), start, 0)
+
+
+@triton.jit
+def _fps_single_kernel(
+    points_ptr,
+    mask_ptr,
+    start_ptr,
+    idx_ptr,
+    assign_ptr,
+    N,
+    K,
+    stride_pb,
+    stride_pn,
+    stride_mb,
+    stride_ib,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    WITH_ASSIGN: tl.constexpr,
+):
+    b = tl.program_id(0).to(tl.int64)
+    offs = tl.arange(0, BLOCK_N)
+    inb = offs < N
+    p_base = points_ptr + b * stride_pb + offs * stride_pn
+    m = tl.load(mask_ptr + b * stride_mb + offs, mask=inb, other=0)
+    coords, valid = _load_coords(p_base, inb, (m != 0) & inb, D)
+
+    min_d = tl.where(valid, _INF, -_INF)
+    last = _resolve_start(start_ptr, b, N)
+    if WITH_ASSIGN:
+        # running nearest-centroid: the K-loop computes every hit's distance
+        # to each selected centroid anyway, so the Voronoi assignment is free
+        best_d = tl.full((BLOCK_N,), _INF, dtype=tl.float32)
+        best_i = tl.zeros((BLOCK_N,), dtype=tl.int32)
+
+    for i in range(K):
+        sel = offs == last
+        dist = _dist_to(coords, sel, D)
+        if WITH_ASSIGN:
+            # raw dist, before selection-marking; strict < keeps the earliest
+            # centroid on exact ties (= argmin first-occurrence), and NaN
+            # dist never updates
+            upd = valid & (dist < best_d)
+            best_d = tl.where(upd, dist, best_d)
+            best_i = tl.where(upd, i, best_i)
+        # exact CUDA update: NaN dist and -inf (invalid/selected) lanes keep old
+        min_d = tl.where(valid & (dist < min_d), dist, min_d)
+        min_d = tl.where(sel, -_INF, min_d)
+        tl.store(idx_ptr + b * stride_ib + i, last.to(tl.int64))
+        bv, bi = tl.max(
+            min_d,
+            axis=0,
+            return_indices=True,
+            return_indices_tie_break_left=True,
+        )
+        # exhausted rows (all -inf) repeat the previous selection
+        last = tl.where(bv == -_INF, last, bi)
+
+    if WITH_ASSIGN:
+        tl.store(assign_ptr + b * N + offs, best_i.to(tl.int64), mask=inb)
+
+
+@triton.jit
+def _fps_knn_single_kernel(
+    points_ptr,
+    mask_ptr,
+    start_ptr,
+    idx_ptr,
+    nbr_ptr,
+    N,
+    K,
+    k_nbrs,
+    stride_pb,
+    stride_pn,
+    stride_mb,
+    stride_ib,
+    stride_nb,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b = tl.program_id(0).to(tl.int64)
+    offs = tl.arange(0, BLOCK_N)
+    inb = offs < N
+    p_base = points_ptr + b * stride_pb + offs * stride_pn
+    m = tl.load(mask_ptr + b * stride_mb + offs, mask=inb, other=0)
+    coords, valid = _load_coords(p_base, inb, (m != 0) & inb, D)
+
+    min_d = tl.where(valid, _INF, -_INF)
+    last = _resolve_start(start_ptr, b, N)
+
+    for i in range(K):
+        sel = offs == last
+        dist = _dist_to(coords, sel, D)
+        # neighbor candidates: all valid points (self and already-selected
+        # included); NaN from a pathological NaN centroid promotes to +inf
+        nd = tl.where(valid, dist, _INF)
+        nd = tl.where(nd == nd, nd, _INF)
+        min_d = tl.where(valid & (dist < min_d), dist, min_d)
+        min_d = tl.where(sel, -_INF, min_d)
+        tl.store(idx_ptr + b * stride_ib + i, last.to(tl.int64))
+
+        for nn in range(k_nbrs):
+            bv, bi = tl.min(
+                nd,
+                axis=0,
+                return_indices=True,
+                return_indices_tie_break_left=True,
+            )
+            # no valid candidate left -> pad with the centroid itself
+            chosen = tl.where(bv == _INF, last, bi)
+            tl.store(
+                nbr_ptr + b * stride_nb + i * k_nbrs + nn, chosen.to(tl.int64)
+            )
+            nd = tl.where(offs == bi, _INF, nd)
+
+        bv, bi = tl.max(
+            min_d,
+            axis=0,
+            return_indices=True,
+            return_indices_tie_break_left=True,
+        )
+        last = tl.where(bv == -_INF, last, bi)
+
+
+@triton.jit
+def _centroid_coords(
+    points_ptr, b, last, stride_pb, stride_pn, D: tl.constexpr
+):
+    cents = ()
+    for d in tl.static_range(D):
+        c = tl.load(
+            points_ptr + b * stride_pb + last.to(tl.int64) * stride_pn + d
+        ).to(tl.float32)
+        cents = cents + (c,)
+    return cents
+
+
+@triton.jit
+def _tile_valid_dist(
+    points_ptr,
+    mask_ptr,
+    b,
+    offs,
+    inb,
+    cents,
+    stride_pb,
+    stride_pn,
+    stride_mb,
+    D: tl.constexpr,
+):
+    m = tl.load(mask_ptr + b * stride_mb + offs, mask=inb, other=0)
+    valid = (m != 0) & inb
+    dist = tl.zeros(offs.shape, dtype=tl.float32)
+    for d in tl.static_range(D):
+        v = tl.load(
+            points_ptr + b * stride_pb + offs * stride_pn + d,
+            mask=inb,
+            other=0.0,
+        ).to(tl.float32)
+        valid = valid & (tl.abs(v) < _INF)
+        diff = v - cents[d]
+        dist += diff * diff
+    return valid, dist
+
+
+@triton.jit
+def _fps_tiled_kernel(
+    points_ptr,
+    mask_ptr,
+    start_ptr,
+    idx_ptr,
+    min_ptr,
+    N,
+    K,
+    stride_pb,
+    stride_pn,
+    stride_mb,
+    stride_ib,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b = tl.program_id(0).to(tl.int64)
+    mrow = min_ptr + b * N
+    n_tiles = tl.cdiv(N, BLOCK_N)
+
+    for t in range(n_tiles):
+        offs = t * BLOCK_N + tl.arange(0, BLOCK_N)
+        inb = offs < N
+        m = tl.load(mask_ptr + b * stride_mb + offs, mask=inb, other=0)
+        valid = (m != 0) & inb
+        for d in tl.static_range(D):
+            v = tl.load(
+                points_ptr + b * stride_pb + offs * stride_pn + d,
+                mask=inb,
+                other=0.0,
+            ).to(tl.float32)
+            valid = valid & (tl.abs(v) < _INF)
+        tl.store(mrow + offs, tl.where(valid, _INF, -_INF), mask=inb)
+
+    last = _resolve_start(start_ptr, b, N)
+
+    for i in range(K):
+        tl.store(idx_ptr + b * stride_ib + i, last.to(tl.int64))
+        tl.store(
+            mrow + last, -_INF
+        )  # mark before the sweep: 0 < -inf is false
+        cents = _centroid_coords(points_ptr, b, last, stride_pb, stride_pn, D)
+
+        run_bv = -_INF
+        run_bi = 0
+        for t in range(n_tiles):
+            offs = t * BLOCK_N + tl.arange(0, BLOCK_N)
+            inb = offs < N
+            valid, dist = _tile_valid_dist(
+                points_ptr,
+                mask_ptr,
+                b,
+                offs,
+                inb,
+                cents,
+                stride_pb,
+                stride_pn,
+                stride_mb,
+                D,
+            )
+            old = tl.load(mrow + offs, mask=inb, other=-_INF)
+            new = tl.where(valid & (dist < old), dist, old)
+            tl.store(mrow + offs, new, mask=inb)
+            tv, ti = tl.max(
+                new,
+                axis=0,
+                return_indices=True,
+                return_indices_tie_break_left=True,
+            )
+            better = tv > run_bv  # strict: earlier tile wins ties
+            run_bi = tl.where(better, t * BLOCK_N + ti, run_bi)
+            run_bv = tl.where(better, tv, run_bv)
+
+        last = tl.where(run_bv == -_INF, last, run_bi)
+
+
+@triton.jit
+def _fps_knn_tiled_kernel(
+    points_ptr,
+    mask_ptr,
+    start_ptr,
+    idx_ptr,
+    nbr_ptr,
+    min_ptr,
+    curr_ptr,
+    N,
+    K,
+    k_nbrs,
+    stride_pb,
+    stride_pn,
+    stride_mb,
+    stride_ib,
+    stride_nb,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b = tl.program_id(0).to(tl.int64)
+    mrow = min_ptr + b * N
+    crow = curr_ptr + b * N
+    n_tiles = tl.cdiv(N, BLOCK_N)
+
+    for t in range(n_tiles):
+        offs = t * BLOCK_N + tl.arange(0, BLOCK_N)
+        inb = offs < N
+        m = tl.load(mask_ptr + b * stride_mb + offs, mask=inb, other=0)
+        valid = (m != 0) & inb
+        for d in tl.static_range(D):
+            v = tl.load(
+                points_ptr + b * stride_pb + offs * stride_pn + d,
+                mask=inb,
+                other=0.0,
+            ).to(tl.float32)
+            valid = valid & (tl.abs(v) < _INF)
+        tl.store(mrow + offs, tl.where(valid, _INF, -_INF), mask=inb)
+
+    last = _resolve_start(start_ptr, b, N)
+
+    for i in range(K):
+        tl.store(idx_ptr + b * stride_ib + i, last.to(tl.int64))
+        tl.store(mrow + last, -_INF)
+        cents = _centroid_coords(points_ptr, b, last, stride_pb, stride_pn, D)
+
+        run_bv = -_INF
+        run_bi = 0
+        for t in range(n_tiles):
+            offs = t * BLOCK_N + tl.arange(0, BLOCK_N)
+            inb = offs < N
+            valid, dist = _tile_valid_dist(
+                points_ptr,
+                mask_ptr,
+                b,
+                offs,
+                inb,
+                cents,
+                stride_pb,
+                stride_pn,
+                stride_mb,
+                D,
+            )
+            nd = tl.where(valid, dist, _INF)
+            nd = tl.where(nd == nd, nd, _INF)
+            tl.store(crow + offs, nd, mask=inb)
+            old = tl.load(mrow + offs, mask=inb, other=-_INF)
+            new = tl.where(valid & (dist < old), dist, old)
+            tl.store(mrow + offs, new, mask=inb)
+            tv, ti = tl.max(
+                new,
+                axis=0,
+                return_indices=True,
+                return_indices_tie_break_left=True,
+            )
+            better = tv > run_bv
+            run_bi = tl.where(better, t * BLOCK_N + ti, run_bi)
+            run_bv = tl.where(better, tv, run_bv)
+
+        for nn in range(k_nbrs):
+            nb_bv = _INF
+            nb_bi = 0
+            for t in range(n_tiles):
+                offs = t * BLOCK_N + tl.arange(0, BLOCK_N)
+                inb = offs < N
+                cd = tl.load(crow + offs, mask=inb, other=_INF)
+                tv, ti = tl.min(
+                    cd,
+                    axis=0,
+                    return_indices=True,
+                    return_indices_tie_break_left=True,
+                )
+                better = tv < nb_bv  # strict: earlier tile wins ties
+                nb_bi = tl.where(better, t * BLOCK_N + ti, nb_bi)
+                nb_bv = tl.where(better, tv, nb_bv)
+            chosen = tl.where(nb_bv == _INF, last, nb_bi)
+            tl.store(
+                nbr_ptr + b * stride_nb + i * k_nbrs + nn, chosen.to(tl.int64)
+            )
+            tl.store(crow + nb_bi, _INF)
+
+        last = tl.where(run_bv == -_INF, last, run_bi)
+
+
+@triton.jit
+def _nearest_assign_kernel(
+    p_ptr,
+    c_ptr,
+    starts_ptr,
+    counts_ptr,
+    out_ptr,
+    K,
+    stride_p,
+    stride_c,
+    D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    b = tl.program_id(0).to(tl.int64)
+    tile = tl.program_id(1)
+    start = tl.load(starts_ptr + b)
+    count = tl.load(counts_ptr + b)
+
+    offs_n = tile * BLOCK_N + tl.arange(0, BLOCK_N)
+    ok_n = offs_n < count
+    rows = start + offs_n.to(tl.int64)
+    offs_k = tl.arange(0, BLOCK_K)
+    ok_k = offs_k < K
+    c_rows = (b * K + offs_k.to(tl.int64)) * stride_c
+
+    d = tl.zeros((BLOCK_N, BLOCK_K), dtype=tl.float32)
+    for dim in tl.static_range(D):
+        p = tl.load(p_ptr + rows * stride_p + dim, mask=ok_n, other=0.0).to(
+            tl.float32
+        )
+        c = tl.load(c_ptr + c_rows + dim, mask=ok_k, other=0.0).to(tl.float32)
+        diff = p[:, None] - c[None, :]
+        d += diff * diff
+    # NaN centroids (reachable via degenerate Lloyd charge weights) and the
+    # k >= K padding lanes must never win the argmin
+    d = tl.where(d == d, d, _INF)
+    d = tl.where(ok_k[None, :], d, _INF)
+    a = tl.argmin(d, axis=1, tie_break_left=True)
+    tl.store(out_ptr + rows, a.to(tl.int64), mask=ok_n)
+
+
+def nearest_assign(
+    p_flat: Tensor,
+    cents: Tensor,
+    starts: Tensor,
+    counts: Tensor,
+    n_max: int,
+    K: int,
+) -> Tensor:
+    """Nearest-centroid assignment over batch-segmented flat points.
+
+    p_flat [N, D] fp32 flat hits (rows grouped per event), cents [B*K,
+    D] fp32 centroids, starts/counts [B] int64 segment bounds, n_max =
+    max count (host int). Returns [N] int64 cell indices in [0, K).
+    Deterministic (lowest centroid index on exact ties), sync-free,
+    gradient-free: inputs are detached — assignment is integer routing
+    and stays out of the graph.
+    """
+    N, D = p_flat.shape
+    B = starts.numel()
+    out = torch.empty(N, device=p_flat.device, dtype=torch.long)
+    if N == 0 or B == 0:
+        return out
+    if K > 512:
+        raise ValueError(f"nearest_assign supports K <= 512, got {K}")
+    p = p_flat.detach().contiguous()
+    c = cents.detach().contiguous()
+    BLOCK_K = max(triton.next_power_of_2(K), 16)
+    # small tiles: the [BLOCK_N, BLOCK_K] fp32 distance tile must stay
+    # register-resident (larger budgets spill and run 2-8x slower)
+    BLOCK_N = max(16, 2048 // BLOCK_K)
+    grid = (B, triton.cdiv(max(n_max, 1), BLOCK_N))
+    _nearest_assign_kernel[grid](
+        p,
+        c,
+        starts,
+        counts,
+        out,
+        K,
+        p.stride(0),
+        c.stride(0),
+        D=D,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        num_warps=2,
+    )
+    return out
+
+
+def fps(points: Tensor, mask: Tensor, start_idx: Tensor, K: int) -> Tensor:
+    """Select `K` farthest points per row, returning `[B, K]` indices."""
+    B, N, D = points.shape
+    idx = torch.empty(B, K, device=points.device, dtype=torch.long)
+    if B == 0 or K == 0:
+        return idx
+    if N <= _single_tile_cap(SINGLE_TILE_MAX_N, D):
+        BLOCK_N = max(triton.next_power_of_2(N), 16)
+        _fps_single_kernel[(B,)](
+            points,
+            mask,
+            start_idx,
+            idx,
+            idx,
+            N,
+            K,
+            points.stride(0),
+            points.stride(1),
+            mask.stride(0),
+            idx.stride(0),
+            D=D,
+            BLOCK_N=BLOCK_N,
+            WITH_ASSIGN=False,
+            num_warps=_num_warps(BLOCK_N),
+        )
+    else:
+        min_d = torch.empty(B, N, device=points.device, dtype=torch.float32)
+        _fps_tiled_kernel[(B,)](
+            points,
+            mask,
+            start_idx,
+            idx,
+            min_d,
+            N,
+            K,
+            points.stride(0),
+            points.stride(1),
+            mask.stride(0),
+            idx.stride(0),
+            D=D,
+            BLOCK_N=TILE_N,
+            num_warps=8,
+        )
+    return idx
+
+
+def fps_assign(
+    points: Tensor, mask: Tensor, start_idx: Tensor, K: int
+) -> tuple[Tensor, Tensor]:
+    """Run fused FPS and nearest-centroid assignment.
+
+    Single-tile sizes only; the API layer composes plain FPS with the
+    pure-PyTorch assignment beyond the cap.
+    """
+    B, N, D = points.shape
+    idx = torch.empty(B, K, device=points.device, dtype=torch.long)
+    assign = torch.zeros(B, N, device=points.device, dtype=torch.long)
+    if B == 0 or K == 0:
+        return idx, assign
+    BLOCK_N = max(triton.next_power_of_2(N), 16)
+    _fps_single_kernel[(B,)](
+        points,
+        mask,
+        start_idx,
+        idx,
+        assign,
+        N,
+        K,
+        points.stride(0),
+        points.stride(1),
+        mask.stride(0),
+        idx.stride(0),
+        D=D,
+        BLOCK_N=BLOCK_N,
+        WITH_ASSIGN=True,
+        num_warps=_num_warps(BLOCK_N),
+    )
+    return idx, assign
+
+
+def fps_knn(
+    points: Tensor, mask: Tensor, start_idx: Tensor, K: int, k_neighbors: int
+) -> tuple[Tensor, Tensor]:
+    """Fused FPS + kNN gather, returning `[B, K]` and `[B, K, k]`."""
+    B, N, D = points.shape
+    idx = torch.empty(B, K, device=points.device, dtype=torch.long)
+    nbr = torch.empty(
+        B, K, k_neighbors, device=points.device, dtype=torch.long
+    )
+    if B == 0 or K == 0:
+        return idx, nbr
+    args = (
+        points,
+        mask,
+        start_idx,
+        idx,
+        nbr,
+        N,
+        K,
+        k_neighbors,
+        points.stride(0),
+        points.stride(1),
+        mask.stride(0),
+        idx.stride(0),
+        nbr.stride(0),
+    )
+    if N <= _single_tile_cap(KNN_SINGLE_TILE_MAX_N, D):
+        BLOCK_N = max(triton.next_power_of_2(N), 16)
+        _fps_knn_single_kernel[(B,)](
+            *args, D=D, BLOCK_N=BLOCK_N, num_warps=_num_warps(BLOCK_N)
+        )
+    else:
+        min_d = torch.empty(B, N, device=points.device, dtype=torch.float32)
+        curr_d = torch.empty(B, N, device=points.device, dtype=torch.float32)
+        _fps_knn_tiled_kernel[(B,)](
+            *args[:5],
+            min_d,
+            curr_d,
+            *args[5:],
+            D=D,
+            BLOCK_N=TILE_N,
+            num_warps=8,
+        )
+    return idx, nbr

--- a/src/graphnet/models/components/layers.py
+++ b/src/graphnet/models/components/layers.py
@@ -1,6 +1,15 @@
 """Class(es) implementing layers to be used in `graphnet` models."""
 
-from typing import Any, Callable, Optional, Sequence, Union, List
+from typing import (
+    Any,
+    Callable,
+    cast,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import torch
 import torch.nn as nn
@@ -22,6 +31,8 @@ from torch_scatter import scatter
 
 from pytorch_lightning import LightningModule
 from torch_geometric.utils import degree
+
+from graphnet.models.utils import flex_attention
 
 
 class DynEdgeConv(EdgeConv, LightningModule):
@@ -220,16 +231,44 @@ class DropPath(LightningModule):
         super(DropPath, self).__init__()
         self.drop_prob = drop_prob
 
-    def forward(self, x: Tensor) -> Tensor:
-        """Forward pass."""
+    def forward(
+        self,
+        x: Tensor,
+        doc_id: Optional[Tensor] = None,
+        num_docs: Optional[int] = None,
+    ) -> Tensor:
+        """Forward pass.
+
+        Args:
+            x: Input tensor. On the padded path this is `[B, ...]` and one
+                decision is drawn per row of the batch dimension.
+            doc_id: Optional `[N]` event index per token, for a packed
+                `[1, N, D]` input where the batch dimension no longer
+                separates events. One decision is then drawn per event and
+                gathered to its tokens, matching the per-event granularity of
+                the padded path.
+            num_docs: Number of distinct events in `doc_id`. Required when
+                `doc_id` is given.
+
+        Returns:
+            Tensor of the same shape as `x`.
+        """
         if self.drop_prob == 0.0 or not self.training:
             return x
         keep_prob = 1 - self.drop_prob
-        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
-        random_tensor = x.new_empty(shape).bernoulli_(keep_prob)
+        if doc_id is None:
+            shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+            random_tensor = x.new_empty(shape).bernoulli_(keep_prob)
+            if keep_prob > 0.0:
+                random_tensor.div_(keep_prob)
+            return x * random_tensor
+
+        assert num_docs is not None, "`num_docs` is required with `doc_id`"
+        event_mask = x.new_empty((num_docs, 1)).bernoulli_(keep_prob)
         if keep_prob > 0.0:
-            random_tensor.div_(keep_prob)
-        return x * random_tensor
+            event_mask = event_mask.div(keep_prob)
+        token_mask = event_mask.index_select(0, doc_id).unsqueeze(0)
+        return x * token_mask
 
     def extra_repr(self) -> str:
         """Return extra representation of the module."""
@@ -1000,3 +1039,562 @@ class SANGraphHead(LightningModule):
         # Original code applied a final linear layer to project to dim_out,
         # but we will let the Task layer do that.
         return graph_emb
+
+
+class RMSNorm(LightningModule):
+    """Root-mean-square layer normalization.
+
+    Equivalent to `torch.nn.RMSNorm`, but the weight is cast to the input
+    dtype before the call. The standard-library module keeps its weight in
+    float32, which forces an unfused path under autocast; casting lets the
+    fused bfloat16/float16 kernel fire instead.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-5):
+        """Construct `RMSNorm`.
+
+        Args:
+            dim: Size of the normalized (last) dimension.
+            eps: Term added to the denominator for numerical stability.
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+        self.normalized_shape = (dim,)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Normalize `x` over its last dimension."""
+        return torch.nn.functional.rms_norm(
+            x, self.normalized_shape, self.weight.to(x.dtype), self.eps
+        )
+
+
+class SwiGLU(LightningModule):
+    """Feed-forward block with a SwiGLU gate.
+
+    The two input projections are fused into a single `Linear`, which is
+    both faster and keeps the parameter count identical to the unfused form.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        dropout: float = 0.1,
+        bias: bool = True,
+    ):
+        """Construct `SwiGLU`.
+
+        Args:
+            dim: Input and output dimension.
+            hidden_dim: Inner dimension of the gated projection.
+            dropout: Dropout applied to the block output.
+            bias: Whether the projections carry a bias.
+        """
+        super().__init__()
+        self.w13 = nn.Linear(dim, 2 * hidden_dim, bias=bias)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=bias)
+        self.dropout = nn.Dropout(dropout)
+        self._initialize_weights()
+
+    def _initialize_weights(self) -> None:
+        """Apply Xavier-uniform weights and zero biases."""
+        for module in (self.w13, self.w2):
+            nn.init.xavier_uniform_(module.weight)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply the gated feed-forward transform."""
+        a, b = self.w13(x).chunk(2, dim=-1)
+        return self.dropout(self.w2(torch.nn.functional.silu(a) * b))
+
+
+class RoPE4D(LightningModule):
+    """Rotary position embedding over four coordinates `(x, y, z, t)`.
+
+    Implements the standard axis-aligned 4D construction: each coordinate
+    axis is given its own rotation planes, so the four generators stay
+    linearly independent. Planes are allocated one per axis first and then
+    round-robin, which is what guarantees that independence for any even
+    `dim >= 8`.
+
+    Pair `j` rotates dimensions `(j, dim / 2 + j)` via a contiguous
+    `chunk`/`cat` on the last axis; each side of the rotation is then a
+    contiguous half, which is markedly faster than a strided
+    `(2j, 2j + 1)` layout.
+
+    See https://arxiv.org/abs/2504.06308.
+    """
+
+    freqs: Tensor
+    coord_select: Tensor
+
+    def __init__(
+        self,
+        dim: int,
+        scales: Sequence[float] = (1.0, 1.0, 1.0, 1.0),
+        base: int = 10000,
+    ):
+        """Construct `RoPE4D`.
+
+        Args:
+            dim: Head dimension. Must be even and at least 8.
+            scales: Per-axis frequency scale for `(x, y, z, t)`, in radians
+                per coordinate unit.
+            base: Ratio between the lowest and highest frequency in each
+                axis' band, i.e. frequencies span `scale / base` to `scale`.
+        """
+        super().__init__()
+        if dim % 2 != 0:
+            raise ValueError(f"RoPE4D dim must be even (got {dim})")
+        if dim < 8:
+            raise ValueError(
+                f"RoPE4D requires dim >= 8 for 4 axes (got {dim})"
+            )
+        if len(scales) != 4:
+            raise ValueError(f"RoPE4D expects 4 scales (got {len(scales)})")
+        self.dim = dim
+        self.scales = tuple(scales)
+        self.base = base
+
+        num_planes = dim // 2
+
+        # One plane per axis first (ensures linear independence), then
+        # distribute what is left round-robin.
+        allocation = [1, 1, 1, 1]
+        for i in range(num_planes - 4):
+            allocation[i % 4] += 1
+
+        all_freqs = [
+            self._build_freqs(n_planes, scale)
+            for n_planes, scale in zip(allocation, self.scales)
+        ]
+        self.register_buffer("freqs", torch.cat(all_freqs))  # (dim / 2,)
+
+        coord_select: List[int] = []
+        for axis_idx, n_planes in enumerate(allocation):
+            coord_select.extend([axis_idx] * n_planes)
+        self.register_buffer(
+            "coord_select", torch.tensor(coord_select, dtype=torch.long)
+        )
+
+    def _build_freqs(self, num_bands: int, scale: float) -> Tensor:
+        """Build log-spaced frequency bands for one axis."""
+        if num_bands == 1:
+            return torch.tensor([1.0 / self.base]) * scale
+        exponents = torch.arange(num_bands, dtype=torch.float32) / (
+            num_bands - 1
+        )
+        freqs = (1.0 / self.base) * (self.base**exponents)
+        return freqs * scale
+
+    def compute_tables(
+        self, coords: Tensor, dtype: Optional[torch.dtype] = None
+    ) -> Tuple[Tensor, Tensor]:
+        """Precompute the `(cos, sin)` rotation tables for `coords`.
+
+        Every layer of an encoder stack sees the same coordinates and the
+        same RoPE configuration, so the tables are computed once and shared.
+
+        Args:
+            coords: `[B, S, 4]` coordinates.
+            dtype: Optional dtype to cast the tables to. Trig is always
+                evaluated in float32 for accuracy; casting once here lets the
+                per-layer rotation stay in the model dtype.
+
+        Returns:
+            A `(cos, sin)` pair, each of shape `[B, 1, S, dim / 2]`.
+        """
+        coords_f = coords if coords.dtype == torch.float32 else coords.float()
+        coord_per_plane = coords_f.index_select(
+            dim=-1, index=self.coord_select
+        )
+        angles = (coord_per_plane * self.freqs).unsqueeze(1)
+        cos_a = torch.cos(angles)
+        sin_a = torch.sin(angles)
+        if dtype is not None and dtype != cos_a.dtype:
+            cos_a = cos_a.to(dtype)
+            sin_a = sin_a.to(dtype)
+        return cos_a, sin_a
+
+    def forward(
+        self,
+        x: Tensor,
+        coords: Tensor,
+        tables: Optional[Tuple[Tensor, Tensor]] = None,
+    ) -> Tensor:
+        """Rotate queries or keys according to their coordinates.
+
+        The rotation is `(a, b) -> (a cos t - b sin t, a sin t + b cos t)`
+        for pair `j = (j, dim / 2 + j)`.
+
+        Args:
+            x: `[B, H, S, dim]` queries or keys.
+            coords: `[B, S, 4]` coordinates `(x, y, z, t)`.
+            tables: Optional precomputed `(cos, sin)` pair from
+                :meth:`compute_tables`, avoiding recomputation of the
+                transcendentals for every layer and for both Q and K.
+
+        Returns:
+            The rotated tensor, shaped like `x`.
+        """
+        if tables is None:
+            tables = self.compute_tables(coords, dtype=x.dtype)
+        cos_a, sin_a = tables
+
+        # Fast path: same-dtype tables, so stay entirely in x's dtype.
+        if cos_a.dtype == x.dtype:
+            x1, x2 = x.chunk(2, dim=-1)
+            return torch.cat(
+                (x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a), dim=-1
+            )
+
+        # Mixed-dtype fallback: do the maths in float32 and cast back.
+        x_f = x if x.dtype == torch.float32 else x.float()
+        x1, x2 = x_f.chunk(2, dim=-1)
+        out = torch.cat(
+            (x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a), dim=-1
+        )
+        return out if out.dtype == x.dtype else out.to(x.dtype)
+
+
+class AttentionPool(LightningModule):
+    """Pool a sequence to one vector, attending from a learned query."""
+
+    def __init__(self, dim: int):
+        """Construct `AttentionPool`.
+
+        Args:
+            dim: Feature dimension of the sequence and of the output.
+        """
+        super().__init__()
+        self.q = nn.Parameter(torch.randn(1, 1, dim) * (dim**-0.5))
+        self.kv = nn.Linear(dim, 2 * dim, bias=False)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        """Pool `x` to a single vector per batch element.
+
+        Args:
+            x: `[B, S, D]` sequence.
+            mask: Optional bool `[B, S]`; True marks a valid element.
+
+        Returns:
+            `[B, D]` pooled features, zero for fully-masked rows.
+        """
+        batch_size, _, n_features = x.shape
+        q = self.q.expand(batch_size, -1, -1)
+        k, v = self.kv(x).chunk(2, dim=-1)
+
+        attn = torch.bmm(q, k.transpose(1, 2)) * (n_features**-0.5)
+        if mask is not None:
+            # A finite fill rather than -inf: a fully-masked row (a zero-hit
+            # event) must soft-max to finite garbage, which is zeroed below.
+            # -inf would yield NaN and poison the whole batch.
+            attn = attn.masked_fill(
+                ~mask.unsqueeze(1), torch.finfo(attn.dtype).min
+            )
+        attn = torch.nn.functional.softmax(attn, dim=-1)
+        out = torch.bmm(attn, v).squeeze(1)
+        out = self.proj(out)
+        if mask is not None:
+            out = out * mask.any(dim=1, keepdim=True).to(out.dtype)
+        return out
+
+
+class NeptuneTransformerEncoderLayer(LightningModule):
+    """Pre-norm transformer encoder layer with 4D rotary attention.
+
+    Used by :class:`~graphnet.models.transformer.neptune.Neptune`. Compared
+    with a vanilla encoder layer it uses RMSNorm instead of LayerNorm, a
+    fused QKV projection, per-head query/key normalization before the rotary
+    embedding, LayerScale on both residual branches, and a SwiGLU
+    feed-forward network.
+
+    Attention-matrix dropout is deliberately unused: `flex_attention` cannot
+    express it, so omitting it keeps the packed and padded attention paths
+    regularized identically. Residual/feed-forward dropout and stochastic
+    depth still apply.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        nhead: int,
+        dim_feedforward: int,
+        dropout: float = 0.1,
+        layer_norm_eps: float = 1e-5,
+        bias: bool = True,
+        ff_bias: bool = False,
+        qk_norm: bool = True,
+        rope_scales: Sequence[float] = (180.0, 180.0, 180.0, 40.0),
+        rope_base: int = 60,
+        drop_path_rate: float = 0.0,
+        layerscale_init: float = 1e-5,
+    ):
+        """Construct `NeptuneTransformerEncoderLayer`.
+
+        Args:
+            d_model: Token dimension.
+            nhead: Number of attention heads. `d_model / nhead` must be even
+                and at least 8, as required by :class:`RoPE4D`.
+            dim_feedforward: Inner dimension of the SwiGLU network.
+            dropout: Dropout on the residual and feed-forward branches.
+            layer_norm_eps: Epsilon of the RMSNorm layers.
+            bias: Whether the attention projections carry a bias.
+            ff_bias: Whether the feed-forward projections carry a bias.
+            qk_norm: Whether to RMS-normalize queries and keys per head
+                before applying the rotary embedding.
+            rope_scales: Per-axis rotary frequency scales for `(x, y, z, t)`.
+            rope_base: Rotary frequency span, see :class:`RoPE4D`.
+            drop_path_rate: Stochastic-depth rate for this layer.
+            layerscale_init: Initial value of the LayerScale parameters.
+        """
+        super().__init__()
+        if d_model % nhead != 0:
+            raise ValueError("d_model must be divisible by nhead")
+        self.d_model = d_model
+        self.nhead = nhead
+        self.head_dim = d_model // nhead
+        if self.head_dim % 2 != 0:
+            raise ValueError(
+                f"head_dim must be even for RoPE4D (got {self.head_dim})"
+            )
+
+        self.qkv_proj = nn.Linear(d_model, 3 * d_model, bias=bias)
+        self.out_proj = nn.Linear(d_model, d_model, bias=bias)
+        self._initialize_weights()
+
+        self.norm1 = RMSNorm(d_model, eps=layer_norm_eps)
+        self.norm2 = RMSNorm(d_model, eps=layer_norm_eps)
+
+        self.qk_norm = qk_norm
+        if qk_norm:
+            self.q_norm = RMSNorm(self.head_dim, eps=layer_norm_eps)
+            self.k_norm = RMSNorm(self.head_dim, eps=layer_norm_eps)
+
+        self.ffn = SwiGLU(d_model, dim_feedforward, dropout, bias=ff_bias)
+        self.rope = RoPE4D(
+            dim=self.head_dim, scales=rope_scales, base=rope_base
+        )
+
+        # LayerScale: learnable per-channel gain on each residual branch.
+        self.gamma_1 = nn.Parameter(layerscale_init * torch.ones(d_model))
+        self.gamma_2 = nn.Parameter(layerscale_init * torch.ones(d_model))
+
+        self.dropout = nn.Dropout(dropout)
+        self.drop_path1 = DropPath(drop_path_rate)
+        self.drop_path2 = DropPath(drop_path_rate)
+
+    def _initialize_weights(self) -> None:
+        """Apply Xavier-uniform weights and zero biases."""
+        nn.init.xavier_uniform_(self.qkv_proj.weight)
+        if self.qkv_proj.bias is not None:
+            nn.init.zeros_(self.qkv_proj.bias)
+        nn.init.xavier_uniform_(self.out_proj.weight)
+        if self.out_proj.bias is not None:
+            nn.init.zeros_(self.out_proj.bias)
+
+    def _attn(
+        self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        attn_mask: Optional[Tensor],
+        block_mask: Any,
+    ) -> Tensor:
+        """Dispatch to packed block-diagonal flex attention or padded SDPA."""
+        if block_mask is not None:
+            return flex_attention(q, k, v, block_mask=block_mask)
+        return torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False
+        )
+
+    def prepare_attention_mask(
+        self, key_padding_mask: Optional[Tensor], device: torch.device
+    ) -> Optional[Tensor]:
+        """Convert a key-padding mask to the boolean SDPA convention.
+
+        Args:
+            key_padding_mask: Bool `[B, S]` where True marks *padding*, as in
+                `torch.nn.MultiheadAttention`.
+            device: Device to build the mask on.
+
+        Returns:
+            Bool `[B, 1, 1, S]` where True marks positions that *may* be
+            attended, or None if no mask was given.
+        """
+        if key_padding_mask is None:
+            return None
+        allow = ~key_padding_mask.to(torch.bool).to(device)
+        # A fully-padded row (a zero-hit event) would soft-max over all -inf
+        # and NaN-poison the batch; let it attend everywhere instead. Pooling
+        # zeroes those rows afterwards, matching the packed path.
+        allow = allow | ~allow.any(dim=-1, keepdim=True)
+        return allow.unsqueeze(1).unsqueeze(2)
+
+    def forward(
+        self,
+        src: Tensor,
+        centroids: Tensor,
+        src_key_padding_mask: Optional[Tensor] = None,
+        rope_tables: Optional[Tuple[Tensor, Tensor]] = None,
+        attn_mask: Optional[Tensor] = None,
+        block_mask: Any = None,
+        doc_id: Optional[Tensor] = None,
+        num_docs: Optional[int] = None,
+    ) -> Tensor:
+        """Apply one encoder layer.
+
+        Args:
+            src: `[B, S, d_model]` token features.
+            centroids: `[B, S, 4]` token coordinates driving the rotary
+                embedding.
+            src_key_padding_mask: Bool `[B, S]` where True marks padding.
+                Only used when neither `attn_mask` nor `block_mask` is given.
+            rope_tables: Optional shared `(cos, sin)` tables.
+            attn_mask: Optional prebuilt boolean SDPA mask.
+            block_mask: Optional `flex_attention` `BlockMask` selecting the
+                packed path.
+            doc_id: Optional `[N]` event index per token, on the packed path.
+            num_docs: Number of events in `doc_id`.
+
+        Returns:
+            `[B, S, d_model]` updated token features.
+        """
+        batch_size, seq_length, _ = src.shape
+
+        x = src
+        x_norm = self.norm1(x)
+
+        qkv = self.qkv_proj(x_norm)
+        qkv = qkv.reshape(batch_size, seq_length, 3, self.nhead, self.head_dim)
+        qkv = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, S, D)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        if self.qk_norm:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+
+        q = self.rope(q, centroids, tables=rope_tables)
+        k = self.rope(k, centroids, tables=rope_tables)
+
+        # Use the mask prebuilt by the encoder when available; otherwise
+        # build one here for single-layer callers. Skipped entirely on the
+        # packed path, which masks via `block_mask`.
+        if attn_mask is None and block_mask is None:
+            attn_mask = self.prepare_attention_mask(
+                src_key_padding_mask, q.device
+            )
+
+        attn_output = self._attn(q, k, v, attn_mask, block_mask)
+        attn_output = attn_output.transpose(1, 2)  # (B, S, H, D)
+        attn_output = attn_output.contiguous().view(
+            batch_size, seq_length, self.d_model
+        )
+        attn_output = self.out_proj(attn_output)
+
+        x = x + self.drop_path1(
+            self.dropout(self.gamma_1 * attn_output), doc_id, num_docs
+        )
+
+        x_norm = self.norm2(x)
+        ff_output = self.ffn(x_norm)
+        x = x + self.drop_path2(self.gamma_2 * ff_output, doc_id, num_docs)
+
+        return x
+
+
+class NeptuneTransformerEncoder(LightningModule):
+    """Stack of :class:`NeptuneTransformerEncoderLayer`.
+
+    Layers are built by a factory so each depth gets its own stochastic-depth
+    rate, ramped linearly from 0 to `drop_path_rate`. Because every layer
+    shares the same coordinates and rotary configuration, the `(cos, sin)`
+    tables and the attention mask are built once here and threaded through
+    the stack.
+    """
+
+    def __init__(
+        self,
+        layer_factory: Callable[[float], NeptuneTransformerEncoderLayer],
+        num_layers: int,
+        norm: Optional[LightningModule] = None,
+        drop_path_rate: float = 0.0,
+    ):
+        """Construct `NeptuneTransformerEncoder`.
+
+        Args:
+            layer_factory: Callable mapping a stochastic-depth rate to a
+                fresh :class:`NeptuneTransformerEncoderLayer`.
+            num_layers: Number of layers in the stack.
+            norm: Optional module applied to the stack output.
+            drop_path_rate: Stochastic-depth rate of the final layer; earlier
+                layers are scaled linearly towards zero.
+        """
+        super().__init__()
+        if num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+        if num_layers == 1:
+            drop_rates = [drop_path_rate]
+        else:
+            drop_rates = [
+                drop_path_rate * float(i) / (num_layers - 1)
+                for i in range(num_layers)
+            ]
+        self.layers = nn.ModuleList(
+            [layer_factory(rate) for rate in drop_rates]
+        )
+        self.num_layers = num_layers
+        self.norm = norm
+
+    def forward(
+        self,
+        src: Tensor,
+        centroids: Tensor,
+        src_key_padding_mask: Optional[Tensor] = None,
+        block_mask: Any = None,
+        doc_id: Optional[Tensor] = None,
+        num_docs: Optional[int] = None,
+    ) -> Tensor:
+        """Run the encoder stack.
+
+        Args:
+            src: `[B, S, d_model]` token features.
+            centroids: `[B, S, 4]` token coordinates.
+            src_key_padding_mask: Bool `[B, S]` where True marks padding.
+            block_mask: Optional `flex_attention` `BlockMask` for the packed
+                path.
+            doc_id: Optional `[N]` event index per token, on the packed path.
+            num_docs: Number of events in `doc_id`.
+
+        Returns:
+            `[B, S, d_model]` encoded tokens.
+        """
+        first = cast(NeptuneTransformerEncoderLayer, self.layers[0])
+        # Pre-cast the tables to src.dtype so the per-layer rotation skips a
+        # float32 round-trip on bfloat16/float16 paths.
+        rope_tables = first.rope.compute_tables(centroids, dtype=src.dtype)
+        attn_mask = (
+            first.prepare_attention_mask(src_key_padding_mask, src.device)
+            if block_mask is None
+            else None
+        )
+
+        output = src
+        for layer in self.layers:
+            output = layer(
+                output,
+                centroids,
+                rope_tables=rope_tables,
+                attn_mask=attn_mask,
+                block_mask=block_mask,
+                doc_id=doc_id,
+                num_docs=num_docs,
+            )
+
+        if self.norm is not None:
+            output = self.norm(output)
+
+        return output

--- a/src/graphnet/models/components/tokenizers.py
+++ b/src/graphnet/models/components/tokenizers.py
@@ -1,0 +1,826 @@
+"""Learnable tokenizers turning point clouds into transformer tokens."""
+
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch.functional import Tensor
+
+from pytorch_lightning import LightningModule
+
+from graphnet.models.components.fps import (
+    farthest_point_sampling_with_assign,
+    farthest_point_sampling_with_knn,
+    nearest_assign,
+)
+
+
+class FPSTokenizer(LightningModule):
+    """Tokenize a batch of point clouds by farthest point sampling.
+
+    Ported from the Neptune reference implementation
+    (https://github.com/felixyu7/neptune, MIT licence), described in
+    https://arxiv.org/abs/2510.01733.
+
+    The pipeline is:
+
+    1. A per-point MLP lifts the input features.
+    2. Events with at most `max_tokens` points are passed through
+       one-token-per-point: no sampling, no pooling.
+    3. Larger events are reduced to `max_tokens` centroids by farthest point
+       sampling in a 4D `(x, y, z, t)` metric, then pooled per token either
+       by nearest-centroid (Voronoi) assignment -- every point contributes to
+       exactly one token, so nothing is discarded -- or, with
+       `assign_mode="knn"`, by a k-nearest-neighbour gather around each
+       centroid.
+    4. Four per-token summary scalars (multiplicity, total charge, time
+       spread, spatial RMS radius) are appended to the pooled features.
+    5. A second MLP refines the tokens, applied in both branches so the depth
+       is consistent.
+
+    The forward pass performs exactly one host synchronization (a device-to-
+    host copy of the batch indices) and uses no data-dependent-shape
+    operations such as `nonzero` or boolean indexing: small and large events
+    are routed with precomputed index tensors, and only the large subset is
+    ever padded, and only to its own maximum length. One very bright event
+    therefore does not inflate the memory of the whole batch.
+    """
+
+    N_EXTRA = 4  # multiplicity, total charge, time spread, RMS radius
+
+    metric_scale: Tensor
+
+    def __init__(
+        self,
+        feature_dim: int,
+        max_tokens: int = 128,
+        token_dim: int = 768,
+        mlp_layers: Optional[List[int]] = None,
+        k_neighbors: int = 8,
+        dropout: float = 0.0,
+        knn_pool: str = "max",
+        rel_pos_hidden: int = 64,
+        charge_weighted_mean: bool = True,
+        charge_col: int = 0,
+        assign_mode: str = "voronoi",
+        metric_time_scale: float = 0.3,
+        lloyd_iters: int = 0,
+    ):
+        """Construct `FPSTokenizer`.
+
+        Args:
+            feature_dim: Number of input features per point.
+            max_tokens: Maximum number of tokens produced per event.
+            token_dim: Output token dimension.
+            mlp_layers: Hidden sizes of the per-point MLP. Defaults to
+                `[256, 512, 768]`.
+            k_neighbors: Neighbours gathered per centroid when
+                `assign_mode="knn"`.
+            dropout: Dropout inside both MLPs.
+            knn_pool: `"max"` for masked max pooling, or `"max_mean"` to
+                concatenate a charge-weighted mean, doubling the pooled
+                width.
+            rel_pos_hidden: Hidden size of the relative-geometry encoder.
+            charge_weighted_mean: Whether the mean pooling and the summary
+                scalars are weighted by charge. The weight is the `log1p`
+                charge as stored in `charge_col`, not the physical charge:
+                a deliberate compression that stops one very bright sensor
+                from dominating a token. Only the total-charge summary
+                scalar and the Lloyd refinement use physical charge.
+            charge_col: Column of the feature tensor holding `log1p` of the
+                point's total charge. The tokenizer applies `expm1` to it to
+                recover the physical charge, so any other scaling breaks the
+                charge-weighted statistics.
+            assign_mode: `"voronoi"` or `"knn"`, see the class docstring.
+            metric_time_scale: Weight of the time axis in the sampling and
+                assignment metric only, in coordinate units per time unit.
+                With positions in km and time in microseconds, the default of
+                0.3 km/us is roughly the speed of light and balances space
+                against time; 0.22 is the photon group velocity in ice, and
+                1.0 leaves the raw units. At raw units the time axis carries
+                almost all of the 4D metric variance on real events, so
+                selection would cluster nearly purely by arrival time. The
+                returned centroids, relative offsets, and summary scalars
+                always stay in raw units -- the scale changes token
+                membership, never the representation.
+            lloyd_iters: Number of charge-weighted Lloyd (k-means)
+                refinement steps applied to the sampled centroids. Ignored
+                in `"knn"` mode. Farthest point sampling solves a
+                k-center-style objective (equal cell *radius*), which
+                over-compresses dense bright cores and spends tokens on stray
+                peripheral points; Lloyd refinement moves centroids towards
+                the charge-weighted vector-quantization optimum. With
+                `lloyd_iters > 0` the centroids become virtual points
+                (charge-weighted cell means in raw units over the final
+                membership) rather than points of the cloud, so relative
+                offsets are zero-mean per cell. Cells may then be empty,
+                giving an all-zero token whose multiplicity scalar is 0 while
+                its mask entry stays True.
+        """
+        super().__init__()
+        if mlp_layers is None:
+            mlp_layers = [256, 512, 768]
+        if assign_mode not in ("voronoi", "knn"):
+            raise ValueError(
+                f"assign_mode must be 'voronoi' or 'knn', got '{assign_mode}'"
+            )
+        if lloyd_iters < 0:
+            raise ValueError(f"lloyd_iters must be >= 0, got {lloyd_iters}")
+        self.max_tokens = max_tokens
+        self.token_dim = token_dim
+        self.k_neighbors = k_neighbors
+        self.knn_pool = knn_pool
+        self.charge_weighted_mean = charge_weighted_mean
+        self.charge_col = charge_col
+        self.assign_mode = assign_mode
+        self.metric_time_scale = metric_time_scale
+        self.lloyd_iters = lloyd_iters
+
+        # MLP 1: per-point feature extraction.
+        mlp1: List[nn.Module] = []
+        in_dim = feature_dim
+        for out_dim in mlp_layers:
+            mlp1 += [
+                nn.Linear(in_dim, out_dim),
+                nn.GELU(),
+                nn.Dropout(dropout),
+            ]
+            in_dim = out_dim
+        mlp1 += [nn.Linear(in_dim, token_dim)]
+        self.mlp1 = nn.Sequential(*mlp1)
+
+        # MLP 2: token refinement, always applied. The input width doubles
+        # with max+mean pooling; the summary scalars are appended either way.
+        pooled_dim = 2 * token_dim if knn_pool == "max_mean" else token_dim
+        self.mlp2 = nn.Sequential(
+            nn.Linear(pooled_dim + self.N_EXTRA, token_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(token_dim, token_dim),
+        )
+
+        # Relative-geometry encoder: embeds each point's (dx, dy, dz, dt)
+        # offset from its token centroid and adds it to the point feature
+        # before pooling, so a token encodes local cluster shape (otherwise
+        # lost in a pure feature max/mean). Runs only on the large-event path.
+        self.rel_encoder = nn.Sequential(
+            nn.Linear(4, rel_pos_hidden),
+            nn.GELU(),
+            nn.Linear(rel_pos_hidden, token_dim),
+        )
+
+        # A buffer rather than a per-forward host tensor, which would cost a
+        # pageable host-to-device copy plus a stream sync on every call.
+        self.register_buffer(
+            "metric_scale",
+            torch.tensor([1.0, 1.0, 1.0, float(metric_time_scale)]),
+            persistent=False,
+        )
+
+    @staticmethod
+    def _route_subset(
+        rows_dev: Tensor,
+        csub: Tensor,
+        starts: Tensor,
+        n_sub: int,
+        device: torch.device,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        """Build index tensors routing a subset out of batch-sorted arrays.
+
+        The inputs are device slices of the single packed routing transfer,
+        so there is no per-call host-to-device sync and no `nonzero`.
+
+        Args:
+            rows_dev: `[B_sub]` original event index of each subset member.
+            csub: `[B_sub]` point count of each subset member.
+            starts: `[B_sub]` offset of each subset member in the sorted
+                arrays.
+            n_sub: Total number of points in the subset.
+            device: Device to build the indices on.
+
+        Returns:
+            `(seg, local, src)`: the subset-event id of each point, its
+            position within that event, and its row in the batch-sorted flat
+            arrays.
+        """
+        seg = torch.repeat_interleave(
+            torch.arange(rows_dev.numel(), device=device),
+            csub,
+            output_size=n_sub,
+        )
+        local = (
+            torch.arange(n_sub, device=device)
+            - (torch.cumsum(csub, 0) - csub)[seg]
+        )
+        src = starts[seg] + local
+        return seg, local, src
+
+    def forward(
+        self,
+        coords: Tensor,
+        features: Tensor,
+        batch_ids: Tensor,
+        times: Tensor,
+        batch_size: Optional[int] = None,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        """Tokenize a ragged batch of point clouds.
+
+        Args:
+            coords: `[N, 3]` spatial coordinates `(x, y, z)`.
+            features: `[N, F]` per-point features.
+            batch_ids: `[N]` event index of each point.
+            times: `[N, 1]` time coordinate of each point.
+            batch_size: True number of events. Strongly recommended: without
+                it the batch size is inferred as `max(batch_ids) + 1`, which
+                silently drops trailing events with no points and misaligns
+                the output with the labels.
+
+        Returns:
+            `(tokens [B, max_tokens, token_dim], centroids [B, max_tokens, 4]
+            in `(x, y, z, t)`, masks [B, max_tokens] bool)`.
+        """
+        device = coords.device
+        dtype_p = coords.dtype
+        dtype_f = features.dtype
+        n_tokens = self.max_tokens
+        token_dim = self.token_dim
+
+        if coords.numel() == 0:
+            n_events = batch_size or 0
+            return (
+                torch.zeros(
+                    (n_events, n_tokens, token_dim),
+                    device=device,
+                    dtype=dtype_f,
+                ),
+                torch.zeros(
+                    (n_events, n_tokens, 4), device=device, dtype=dtype_p
+                ),
+                torch.zeros(
+                    (n_events, n_tokens), device=device, dtype=torch.bool
+                ),
+            )
+
+        batch_idx = batch_ids.long()
+        points4 = torch.cat([coords[:, :3], times], dim=-1)  # raw units
+        point_feats = self.mlp1(features)
+        charge = features[:, self.charge_col]  # log1p charge
+
+        # The single host sync: one device-to-host copy of the indices.
+        # `bincount` on a CUDA tensor would itself sync, since it reads
+        # max(batch_idx) on the host to size its output, so counting happens
+        # on the CPU copy instead.
+        counts_list = torch.bincount(
+            batch_idx.cpu(), minlength=(batch_size or 0)
+        ).tolist()
+        n_events = len(counts_list)
+
+        # Sort points by event so each event is a contiguous run.
+        sort_idx = torch.argsort(batch_idx, stable=True)
+        p_sorted = points4.index_select(0, sort_idx)
+        f_sorted = point_feats.index_select(0, sort_idx)
+        q_sorted = charge.index_select(0, sort_idx)
+
+        # Host-side split into small (at most `max_tokens` points: every
+        # point is a token) and large (sampling plus pooling) events. All
+        # routing below derives from these lists -- no boolean indexing, no
+        # `nonzero`, no further syncs.
+        offsets: List[int] = [0] * n_events
+        acc = 0
+        for i, count in enumerate(counts_list):
+            offsets[i] = acc
+            acc += count
+        small_rows = [i for i, c in enumerate(counts_list) if c <= n_tokens]
+        large_rows = [i for i, c in enumerate(counts_list) if c > n_tokens]
+        counts_s = [counts_list[i] for i in small_rows]
+        counts_l = [counts_list[i] for i in large_rows]
+        n_small, n_large = len(small_rows), len(large_rows)
+        pts_small, pts_large = sum(counts_s), sum(counts_l)
+
+        # All routing metadata goes up in one pinned, non-blocking transfer;
+        # a per-list `torch.tensor(..., device=...)` would each be a pageable
+        # copy plus a full stream sync.
+        routing_host = torch.tensor(
+            small_rows
+            + counts_s
+            + [offsets[r] for r in small_rows]
+            + large_rows
+            + counts_l
+            + [offsets[r] for r in large_rows],
+            dtype=torch.long,
+        )
+        if device.type == "cuda":
+            routing_host = routing_host.pin_memory()
+        routing = routing_host.to(device, non_blocking=True)
+        rows_s_dev = routing[:n_small]
+        csub_s = routing[n_small : 2 * n_small]
+        starts_s = routing[2 * n_small : 3 * n_small]
+        off = 3 * n_small
+        rows_l_dev = routing[off : off + n_large]
+        csub_l = routing[off + n_large : off + 2 * n_large]
+        starts_l_abs = routing[off + 2 * n_large : off + 3 * n_large]
+
+        pooled_dim = (
+            2 * token_dim if self.knn_pool == "max_mean" else token_dim
+        )
+        feat_dtype = point_feats.dtype  # autocast-aware compute dtype
+
+        pre = torch.zeros(
+            n_events,
+            n_tokens,
+            pooled_dim + self.N_EXTRA,
+            device=device,
+            dtype=feat_dtype,
+        )
+        cents_out = torch.zeros(
+            n_events, n_tokens, 4, device=device, dtype=dtype_p
+        )
+        masks = torch.zeros(
+            n_events, n_tokens, device=device, dtype=torch.bool
+        )
+
+        if n_small > 0:
+            self._tokenize_small(
+                pre,
+                cents_out,
+                masks,
+                rows_s_dev,
+                csub_s,
+                starts_s,
+                pts_small,
+                f_sorted,
+                p_sorted,
+                q_sorted,
+                pooled_dim,
+                feat_dtype,
+                dtype_p,
+            )
+
+        if n_large > 0:
+            self._tokenize_large(
+                pre,
+                cents_out,
+                masks,
+                rows_l_dev,
+                csub_l,
+                starts_l_abs,
+                pts_large,
+                max(counts_l),
+                f_sorted,
+                p_sorted,
+                q_sorted,
+                feat_dtype,
+                dtype_p,
+            )
+
+        # MLP 2: token refinement, applied to both branches.
+        tokens = self.mlp2(pre)
+
+        # Zero out padded positions.
+        tokens = tokens * masks.unsqueeze(-1)
+        cents_out = cents_out * masks.unsqueeze(-1)
+
+        return tokens.to(dtype_f), cents_out, masks
+
+    def _tokenize_small(
+        self,
+        pre: Tensor,
+        cents_out: Tensor,
+        masks: Tensor,
+        rows_dev: Tensor,
+        csub: Tensor,
+        starts: Tensor,
+        n_pts: int,
+        f_sorted: Tensor,
+        p_sorted: Tensor,
+        q_sorted: Tensor,
+        pooled_dim: int,
+        feat_dtype: torch.dtype,
+        dtype_p: torch.dtype,
+    ) -> None:
+        """Fill `pre`/`cents_out`/`masks` for events with few points.
+
+        Every point becomes its own token: no sampling, no padding, and no
+        pooling.
+        """
+        device = pre.device
+        n_tokens = self.max_tokens
+        n_sub = rows_dev.numel()
+        seg, local, src = self._route_subset(
+            rows_dev, csub, starts, n_pts, device
+        )
+        feats = f_sorted.index_select(0, src)
+        points = p_sorted.index_select(0, src)
+        charge = q_sorted.index_select(0, src)
+        dest = seg * n_tokens + local  # unique: local < counts <= n_tokens
+
+        pooled = (
+            torch.cat([feats, feats], dim=-1)
+            if self.knn_pool == "max_mean"
+            else feats
+        )
+        # A single point: multiplicity 1 (log1p(1) = log 2), its own charge,
+        # and zero spreads.
+        zeros = torch.zeros_like(charge)
+        extras = torch.stack(
+            [
+                torch.full_like(charge, 0.6931471805599453),
+                charge,
+                zeros,
+                zeros,
+            ],
+            dim=-1,
+        )
+        pre_sub = torch.zeros(
+            n_sub * n_tokens,
+            pooled_dim + self.N_EXTRA,
+            device=device,
+            dtype=feat_dtype,
+        )
+        pre_sub.index_copy_(
+            0, dest, torch.cat([pooled, extras.to(feat_dtype)], dim=-1)
+        )
+        cents_sub = torch.zeros(
+            n_sub * n_tokens, 4, device=device, dtype=dtype_p
+        )
+        cents_sub.index_copy_(0, dest, points)
+
+        pre.index_copy_(0, rows_dev, pre_sub.view(n_sub, n_tokens, -1))
+        cents_out.index_copy_(0, rows_dev, cents_sub.view(n_sub, n_tokens, 4))
+        masks.index_copy_(
+            0,
+            rows_dev,
+            torch.arange(n_tokens, device=device)[None, :] < csub[:, None],
+        )
+
+    def _tokenize_large(
+        self,
+        pre: Tensor,
+        cents_out: Tensor,
+        masks: Tensor,
+        rows_dev: Tensor,
+        csub: Tensor,
+        starts_abs: Tensor,
+        n_pts: int,
+        n_max: int,
+        f_sorted: Tensor,
+        p_sorted: Tensor,
+        q_sorted: Tensor,
+        feat_dtype: torch.dtype,
+        dtype_p: torch.dtype,
+    ) -> None:
+        """Fill `pre`/`cents_out`/`masks` for events with many points.
+
+        Centroids come from farthest point sampling; features are pooled
+        per token by Voronoi assignment or a kNN gather.
+        """
+        device = pre.device
+        n_tokens = self.max_tokens
+        n_sub = rows_dev.numel()
+        seg, local, src = self._route_subset(
+            rows_dev, csub, starts_abs, n_pts, device
+        )
+        feats = f_sorted.index_select(0, src)
+        points = p_sorted.index_select(0, src)  # raw units
+        charge = q_sorted.index_select(0, src)
+
+        # Metric copy for sampling and assignment: float32, time axis
+        # scaled. Padding stays zero (finite) -- the backend masks it but
+        # must not see NaNs.
+        points_m = points.float() * self.metric_scale
+        padded_m = torch.zeros(n_sub * n_max, 4, device=device)
+        dest_pad = seg * n_max + local
+        padded_m.index_copy_(0, dest_pad, points_m)
+        padded_m = padded_m.view(n_sub, n_max, 4)
+        valid = torch.arange(n_max, device=device)[None, :] < csub[:, None]
+
+        # Offsets of each subset event within the flat subset arrays.
+        starts_sub = torch.cumsum(csub, 0) - csub
+
+        if self.assign_mode == "voronoi":
+            pre_sub, cents_sub = self._pool_voronoi(
+                padded_m,
+                valid,
+                points,
+                points_m,
+                feats,
+                charge,
+                seg,
+                dest_pad,
+                starts_sub,
+                csub,
+                n_sub,
+                n_max,
+                feat_dtype,
+            )
+        else:
+            pre_sub, cents_sub = self._pool_knn(
+                padded_m,
+                valid,
+                points,
+                feats,
+                charge,
+                dest_pad,
+                starts_sub,
+                n_sub,
+                n_max,
+                feat_dtype,
+            )
+
+        pre.index_copy_(0, rows_dev, pre_sub.view(n_sub, n_tokens, -1))
+        cents_out.index_copy_(
+            0, rows_dev, cents_sub.view(n_sub, n_tokens, 4).to(dtype_p)
+        )
+        masks.index_copy_(
+            0,
+            rows_dev,
+            torch.ones(n_sub, n_tokens, device=device, dtype=torch.bool),
+        )
+
+    def _pool_voronoi(
+        self,
+        padded_m: Tensor,
+        valid: Tensor,
+        points: Tensor,
+        points_m: Tensor,
+        feats: Tensor,
+        charge: Tensor,
+        seg: Tensor,
+        dest_pad: Tensor,
+        starts_sub: Tensor,
+        csub: Tensor,
+        n_sub: int,
+        n_max: int,
+        feat_dtype: torch.dtype,
+    ) -> Tuple[Tensor, Tensor]:
+        """Pool by nearest-centroid assignment, optionally Lloyd-refined."""
+        device = points.device
+        n_tokens = self.max_tokens
+        token_dim = self.token_dim
+        n_cells = n_sub * n_tokens
+
+        # Fused sampling and assignment: the sampling loop already computes
+        # every point-to-centroid distance, so the initial Voronoi
+        # assignment is free. Runs in float32 regardless of autocast.
+        # `random_start` gates the augmentation on training mode, so
+        # evaluation always tokenizes an event identically. `validate=False`
+        # is safe here: counts > max_tokens holds by construction of the
+        # subset.
+        fps_idx, assign_pad = farthest_point_sampling_with_assign(
+            padded_m,
+            valid,
+            n_tokens,
+            random_start=self.training,
+            validate=False,
+            assume_finite=True,
+        )
+        cent_flat = (starts_sub[:, None] + fps_idx).reshape(-1)
+        cents_raw = points.index_select(0, cent_flat)
+        cents_m = points_m.index_select(0, cent_flat).view(n_sub, n_tokens, 4)
+
+        # Every point joins exactly one token (coverage is 1 by
+        # construction); assignment happens in the scaled metric.
+        assign = assign_pad.reshape(-1).index_select(0, dest_pad)
+        cell = seg * n_tokens + assign
+
+        q_phys = torch.expm1(charge.float().clamp(min=0))
+
+        if self.lloyd_iters > 0:
+            # Charge-weighted Lloyd refinement towards the
+            # vector-quantization optimum. Empty cells keep their previous
+            # centroid; assignment uses standard alternating updates in the
+            # scaled metric.
+            cm_flat = cents_m.reshape(n_cells, 4)
+            cell4 = cell.unsqueeze(-1).expand(-1, 4)
+            for _ in range(self.lloyd_iters):
+                wsum = torch.zeros(n_cells, device=device).scatter_add_(
+                    0, cell, q_phys
+                )
+                csum = torch.zeros(n_cells, 4, device=device).scatter_add_(
+                    0, cell4, points_m * q_phys[:, None]
+                )
+                cm_flat = torch.where(
+                    (wsum > 0)[:, None],
+                    csum / wsum.clamp(min=1e-9)[:, None],
+                    cm_flat,
+                )
+                assign = nearest_assign(
+                    points_m, cm_flat, starts_sub, csub, n_max, n_tokens
+                )
+                cell = seg * n_tokens + assign
+                cell4 = cell.unsqueeze(-1).expand(-1, 4)
+            # Raw-unit centroids: charge-weighted cell means over the FINAL
+            # membership, giving zero-mean relative offsets per cell. Empty
+            # cells fall back to their sampled point position.
+            wsum = torch.zeros(n_cells, device=device).scatter_add_(
+                0, cell, q_phys
+            )
+            craw = torch.zeros(n_cells, 4, device=device).scatter_add_(
+                0, cell4, points * q_phys[:, None]
+            )
+            cents_raw = torch.where(
+                (wsum > 0)[:, None],
+                (craw / wsum.clamp(min=1e-9)[:, None]).to(cents_raw.dtype),
+                cents_raw,
+            )
+
+        rel = points - cents_raw.index_select(0, cell)  # raw units
+        hidden = feats + self.rel_encoder(rel).to(feat_dtype)
+
+        cell_t = cell.unsqueeze(-1).expand(-1, token_dim)
+        pooled = torch.full(
+            (n_cells, token_dim),
+            float("-inf"),
+            device=device,
+            dtype=hidden.dtype,
+        )
+        pooled = pooled.scatter_reduce(
+            0, cell_t, hidden, reduce="amax", include_self=True
+        )
+        pooled = torch.where(
+            torch.isfinite(pooled), pooled, torch.zeros_like(pooled)
+        )
+
+        # float32 accumulators for the weighted mean and summary scalars.
+        weight = (
+            charge.float()
+            if self.charge_weighted_mean
+            else torch.ones_like(charge, dtype=torch.float32)
+        )
+        wsum = torch.zeros(n_cells, device=device).scatter_add_(
+            0, cell, weight
+        )
+        wsafe = wsum.clamp(min=1e-6)
+
+        if self.knn_pool == "max_mean":
+            weighted = hidden.float() * weight[:, None]
+            hsum = torch.zeros(n_cells, token_dim, device=device).scatter_add_(
+                0, cell_t, weighted
+            )
+            mean = (hsum / wsafe[:, None]).to(hidden.dtype)
+            pooled = torch.cat([pooled, mean], dim=-1)
+
+        ones = torch.ones(points.shape[0], device=device)
+        n_c = torch.zeros(n_cells, device=device).scatter_add_(0, cell, ones)
+        mult = torch.log1p(n_c)
+        total_q = torch.log1p(
+            torch.zeros(n_cells, device=device).scatter_add_(0, cell, q_phys)
+        )
+        dtime = rel[:, 3].float()
+        m1 = (
+            torch.zeros(n_cells, device=device).scatter_add_(
+                0, cell, weight * dtime
+            )
+            / wsafe
+        )
+        m2 = (
+            torch.zeros(n_cells, device=device).scatter_add_(
+                0, cell, weight * dtime * dtime
+            )
+            / wsafe
+        )
+        # Clamp INSIDE the square root: single-point cells have exactly zero
+        # variance and radius, and the derivative of sqrt at 0 is infinite,
+        # which would NaN the backward pass.
+        dt_std = (m2 - m1 * m1).clamp(min=1e-12).sqrt()
+        r2 = torch.zeros(n_cells, device=device).scatter_add_(
+            0, cell, rel[:, :3].float().pow(2).sum(-1)
+        )
+        rms = (r2 / n_c.clamp(min=1)).clamp(min=1e-12).sqrt()
+        extras = torch.stack([mult, total_q, dt_std, rms], dim=-1)
+
+        return (
+            torch.cat([pooled, extras.to(feat_dtype)], dim=-1),
+            cents_raw,
+        )
+
+    def _pool_knn(
+        self,
+        padded_m: Tensor,
+        valid: Tensor,
+        points: Tensor,
+        feats: Tensor,
+        charge: Tensor,
+        dest_pad: Tensor,
+        starts_sub: Tensor,
+        n_sub: int,
+        n_max: int,
+        feat_dtype: torch.dtype,
+    ) -> Tuple[Tensor, Tensor]:
+        """Pool by a k-nearest-neighbour gather around each centroid.
+
+        Uses the same relative encoding and masked max / charge-weighted
+        mean as the Voronoi path, with the summary scalars computed over
+        the neighbour sets so the second MLP sees a consistent layout in
+        both modes.
+        """
+        device = points.device
+        n_tokens = self.max_tokens
+        token_dim = self.token_dim
+        k_global = min(self.k_neighbors, n_max)
+
+        fps_idx, knn_idx = farthest_point_sampling_with_knn(
+            padded_m,
+            valid,
+            n_tokens,
+            k_global,
+            random_start=self.training,
+            validate=False,
+        )
+
+        cent_flat = (starts_sub[:, None] + fps_idx).reshape(-1)
+        cents_raw = points.index_select(0, cent_flat)
+
+        # Padded [features | charge] and geometry for the neighbour gathers.
+        feats_pad = torch.zeros(
+            n_sub * n_max, token_dim + 1, device=device, dtype=feat_dtype
+        )
+        feats_pad.index_copy_(
+            0,
+            dest_pad,
+            torch.cat([feats, charge.unsqueeze(-1).to(feat_dtype)], dim=-1),
+        )
+        points_pad = torch.zeros(
+            n_sub * n_max, 4, device=device, dtype=points.dtype
+        )
+        points_pad.index_copy_(0, dest_pad, points)
+
+        k_local = knn_idx.size(2)
+        base = torch.arange(n_sub, device=device, dtype=knn_idx.dtype) * n_max
+        flat_knn = (knn_idx + base.view(-1, 1, 1)).reshape(-1)
+
+        neigh_aug = feats_pad.index_select(0, flat_knn).reshape(
+            n_sub, n_tokens, k_local, token_dim + 1
+        )
+        neigh_feats = neigh_aug[..., :token_dim]
+        knn_valid = (
+            valid.reshape(-1)
+            .index_select(0, flat_knn)
+            .reshape(n_sub, n_tokens, k_local)
+        )
+        # The sampling backend pads a short neighbour list by repeating the
+        # centroid index, which is itself a valid point, so `valid` alone
+        # marks those slots as real. Padding always occupies the ranks at or
+        # beyond the event's own point count, so mask those out as well --
+        # otherwise the centroid is counted several times in the
+        # multiplicity, total charge, mean and spread scalars. Reachable
+        # whenever `k_neighbors` exceeds an event's point count, which on
+        # this branch means `k_neighbors > max_tokens`.
+        counts = valid.sum(dim=1)
+        ranks = torch.arange(k_local, device=device)
+        knn_valid = knn_valid & (ranks.view(1, 1, -1) < counts.view(-1, 1, 1))
+
+        neigh_xyzt = points_pad.index_select(0, flat_knn).reshape(
+            n_sub, n_tokens, k_local, 4
+        )
+        rel = neigh_xyzt - cents_raw.view(n_sub, n_tokens, 1, 4)
+        neigh_feats = neigh_feats + self.rel_encoder(rel).to(neigh_feats.dtype)
+
+        masked = neigh_feats.masked_fill(
+            ~knn_valid.unsqueeze(-1), float("-inf")
+        )
+        pooled = masked.max(dim=2).values
+        pooled = torch.where(
+            torch.isfinite(pooled), pooled, torch.zeros_like(pooled)
+        )
+
+        knn_charge = neigh_aug[..., token_dim]
+        if self.charge_weighted_mean:
+            weight = (knn_charge * knn_valid.to(knn_charge.dtype)).unsqueeze(
+                -1
+            )
+        else:
+            weight = knn_valid.unsqueeze(-1).to(neigh_feats.dtype)
+        if self.knn_pool == "max_mean":
+            mean = (neigh_feats * weight).sum(dim=2) / weight.sum(dim=2).clamp(
+                min=1e-6
+            )
+            pooled = torch.cat([pooled, mean.to(pooled.dtype)], dim=-1)
+
+        # Summary scalars over the neighbour sets, in float32, matching the
+        # Voronoi definitions.
+        valid_f = knn_valid.float()
+        n_c = valid_f.sum(dim=2)
+        mult = torch.log1p(n_c)
+        total_q = torch.log1p(
+            (torch.expm1(knn_charge.float().clamp(min=0)) * valid_f).sum(dim=2)
+        )
+        wq = (
+            (knn_charge.float() * valid_f)
+            if self.charge_weighted_mean
+            else valid_f
+        )
+        wsafe = wq.sum(dim=2).clamp(min=1e-6)
+        dtime = rel[..., 3].float()
+        m1 = (wq * dtime).sum(dim=2) / wsafe
+        m2 = (wq * dtime * dtime).sum(dim=2) / wsafe
+        # Clamp INSIDE the square root, see `_pool_voronoi`.
+        dt_std = (m2 - m1 * m1).clamp(min=1e-12).sqrt()
+        r2 = (rel[..., :3].float().pow(2).sum(-1) * valid_f).sum(dim=2)
+        rms = (r2 / n_c.clamp(min=1)).clamp(min=1e-12).sqrt()
+        extras = torch.stack([mult, total_q, dt_std, rms], dim=-1)
+
+        pre_sub = torch.cat([pooled, extras.to(feat_dtype)], dim=-1).view(
+            n_sub * n_tokens, -1
+        )
+        return pre_sub, cents_raw

--- a/src/graphnet/models/transformer/__init__.py
+++ b/src/graphnet/models/transformer/__init__.py
@@ -1,3 +1,4 @@
 """Transformer-specific modules."""
 
 from .iseecube import ISeeCube
+from .neptune import Neptune

--- a/src/graphnet/models/transformer/neptune.py
+++ b/src/graphnet/models/transformer/neptune.py
@@ -1,0 +1,696 @@
+"""Implementation of the Neptune point-transformer architecture.
+
+Neptune -- "a N Efficient Point Transformer for Ultrarelativistic
+Neutrino Events" -- treats an event as an irregular 4D point cloud and
+reconstructs it with a rotary-attention transformer over sampled tokens.
+
+- Paper: https://arxiv.org/abs/2510.01733
+- Reference implementation: https://github.com/felixyu7/neptune
+"""
+
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch.functional import Tensor
+from torch_geometric.data import Data
+
+from pytorch_lightning import LightningModule
+
+from graphnet.models.components.embedding import FourierPositionEncoder
+from graphnet.models.components.layers import (
+    AttentionPool,
+    NeptuneTransformerEncoder,
+    NeptuneTransformerEncoderLayer,
+    RMSNorm,
+)
+from graphnet.models.components.tokenizers import FPSTokenizer
+from graphnet.models.gnn.gnn import GNN
+from graphnet.models.utils import (
+    FLEX_AVAILABLE,
+    build_block_mask,
+    pack,
+    unpack,
+)
+
+DEFAULT_FOURIER_AXIS_SCALES = [1.0, 1.0, 1.0]
+DEFAULT_ROPE_SCALES = [180.0, 180.0, 180.0, 40.0]
+
+
+class PointTransformerEncoder(LightningModule):
+    """Rotary transformer encoder over tokens with known positions.
+
+    Adds a Fourier absolute position encoding of the token centroids to the
+    token features, runs the encoder stack, and pools the result to one
+    vector per event. Attention runs either over the padded `[B, S, D]`
+    batch or, on CUDA, over a packed `[1, N, D]` sequence with a
+    block-diagonal `flex_attention` mask -- mathematically identical, but
+    without pushing padded slots through every projection.
+    """
+
+    def __init__(
+        self,
+        token_dim: int = 768,
+        num_layers: int = 12,
+        num_heads: int = 12,
+        hidden_dim: int = 2048,
+        dropout: float = 0.1,
+        drop_path_rate: float = 0.0,
+        pool_type: str = "mean",
+        layerscale_init: float = 1e-5,
+        attn_impl: str = "auto",
+        fourier_num_bands: int = 20,
+        fourier_freq_min: float = 3.0,
+        fourier_freq_max: float = 180.0,
+        fourier_axis_scales: Optional[List[float]] = None,
+        rope_scales: Optional[List[float]] = None,
+        rope_base: int = 60,
+    ):
+        """Construct `PointTransformerEncoder`.
+
+        Args:
+            token_dim: Token dimension.
+            num_layers: Depth of the encoder stack.
+            num_heads: Number of attention heads.
+            hidden_dim: Inner dimension of the SwiGLU feed-forward network.
+            dropout: Dropout on the residual, feed-forward, and position
+                encoding paths.
+            drop_path_rate: Stochastic-depth rate of the last layer, ramped
+                linearly from zero over the stack.
+            pool_type: `"mean"` for masked mean pooling, or `"attention"`
+                for cross-attention pooling with a learned query.
+            layerscale_init: Initial value of the LayerScale parameters.
+            attn_impl: `"auto"`, `"padded"`, or `"packed"`. Purely a
+                throughput choice; all three are mathematically equivalent.
+            fourier_num_bands: Frequency bands of the absolute position
+                encoding.
+            fourier_freq_min: Lowest position-encoding frequency, in radians
+                per coordinate unit.
+            fourier_freq_max: Highest position-encoding frequency, in
+                radians per coordinate unit.
+            fourier_axis_scales: Per-axis multipliers for the position
+                encoding. Defaults to `[1.0, 1.0, 1.0]`.
+            rope_scales: Per-axis rotary frequency scales for
+                `(x, y, z, t)`. Defaults to `[180.0, 180.0, 180.0, 40.0]`.
+            rope_base: Rotary frequency span; see
+                :class:`~graphnet.models.components.layers.RoPE4D`.
+        """
+        super().__init__()
+        if pool_type not in ("mean", "attention"):
+            raise ValueError(
+                f"pool_type must be 'mean' or 'attention', got '{pool_type}'"
+            )
+        if attn_impl not in ("auto", "padded", "packed"):
+            raise ValueError(
+                "attn_impl must be 'auto', 'padded' or 'packed', got "
+                f"'{attn_impl}'"
+            )
+        if fourier_axis_scales is None:
+            fourier_axis_scales = list(DEFAULT_FOURIER_AXIS_SCALES)
+        if rope_scales is None:
+            rope_scales = list(DEFAULT_ROPE_SCALES)
+
+        self.token_dim = token_dim
+        self.pool_type = pool_type
+        # "auto": packed flex on CUDA, padded SDPA on CPU (where the packed
+        # batch is a single sequence anyway). "padded": always padded.
+        # "packed": force packed where supported. Dense batches and overflow
+        # fall back to padded inside `pack`.
+        self.attn_impl = attn_impl
+        # The "auto" packed path is only safe once a compiled flex path is
+        # active: eager `flex_attention` materializes the full packed N x N
+        # and can run out of memory. Set True by `compile_layers` on success,
+        # cleared on failure or fallback.
+        self.packed_flex_ready = False
+
+        def build_layer(rate: float) -> NeptuneTransformerEncoderLayer:
+            return NeptuneTransformerEncoderLayer(
+                d_model=token_dim,
+                nhead=num_heads,
+                dim_feedforward=hidden_dim,
+                dropout=dropout,
+                drop_path_rate=rate,
+                layerscale_init=layerscale_init,
+                rope_scales=rope_scales,
+                rope_base=rope_base,
+            )
+
+        # Absolute position encoding: log-spaced Fourier features on
+        # (x, y, z). Time is dropped -- events are time-centred, so absolute
+        # time is close to meaningless and the rotary embedding handles
+        # relative time. The encoder slices time off the 4D centroids
+        # internally.
+        self.abs_pos_encoder = FourierPositionEncoder(
+            token_dim,
+            in_dim=3,
+            num_bands=fourier_num_bands,
+            freq_min=fourier_freq_min,
+            freq_max=fourier_freq_max,
+            axis_scales=fourier_axis_scales,
+            dropout=dropout,
+        )
+        self.layers = NeptuneTransformerEncoder(
+            build_layer,
+            num_layers=num_layers,
+            drop_path_rate=drop_path_rate,
+        )
+        self.norm = RMSNorm(token_dim)
+
+        if pool_type == "attention":
+            self.pool = AttentionPool(token_dim)
+
+    def _use_packed(self, src: Tensor, masks: Optional[Tensor]) -> bool:
+        """Return whether the packed attention path should be used."""
+        if masks is None or not FLEX_AVAILABLE or self.attn_impl == "padded":
+            return False
+        if self.attn_impl == "packed":
+            # `flex_attention` has no CPU backward; under grad on CPU it
+            # raises at the forward call. Fall back to padded there even when
+            # the packed path is forced.
+            return src.is_cuda or not torch.is_grad_enabled()
+        # "auto": GPU packs only when the compiled flex path is active. CPU
+        # and uncompiled runs stay on padded SDPA.
+        return src.is_cuda and self.packed_flex_ready
+
+    def _encode(
+        self, src: Tensor, centroids: Tensor, masks: Optional[Tensor]
+    ) -> Tensor:
+        """Run the encoder stack, packed or padded.
+
+        Packing uses data-dependent shapes and stays eager; only
+        `self.layers` is ever compiled.
+        """
+        if self._use_packed(src, masks):
+            assert masks is not None
+            packed = pack(src, centroids, masks)
+            if packed is not None:  # None: empty or dense -> padded below
+                tokens, cents, doc_id, pack_idx = packed
+                block_mask = build_block_mask(doc_id, tokens.shape[1])
+                batch_size, seq_length = masks.shape
+                # doc_id (= pack_idx // S) indexes original events, so
+                # num_docs=B lets DropPath sample one decision per event.
+                out = self.layers(
+                    tokens,
+                    cents,
+                    block_mask=block_mask,
+                    doc_id=doc_id,
+                    num_docs=batch_size,
+                )
+                return unpack(out, pack_idx, batch_size, seq_length)
+        padding = (~masks) if masks is not None else None
+        return self.layers(src, centroids, src_key_padding_mask=padding)
+
+    def forward(
+        self,
+        tokens: Tensor,
+        centroids: Tensor,
+        masks: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Encode and pool a padded batch of tokens.
+
+        Args:
+            tokens: `[B, S, token_dim]` token features.
+            centroids: `[B, S, 4]` token positions `(x, y, z, t)`.
+            masks: Optional bool `[B, S]`; True marks a valid token.
+
+        Returns:
+            `[B, token_dim]` pooled event representation.
+        """
+        # No cast to `tokens.dtype`: the position encoder computes in float32
+        # anyway, and a bfloat16 round-trip of km-scale coordinates costs up
+        # to ~0.7 rad of phase at the default `fourier_freq_max`.
+        centroid_emb = self.abs_pos_encoder(centroids)
+        if masks is not None:
+            centroid_emb = centroid_emb * masks.to(
+                dtype=centroid_emb.dtype
+            ).unsqueeze(-1)
+        x = self._encode(tokens + centroid_emb, centroids, masks)
+        x = self.norm(x)
+
+        if self.pool_type == "attention":
+            return self.pool(x, masks)
+
+        if masks is None:
+            return x.mean(dim=1)
+        weights = masks.to(dtype=x.dtype).unsqueeze(-1)
+        denom = weights.sum(dim=1, keepdim=True).clamp_min(1.0)
+        return (x * weights).sum(dim=1) / denom.squeeze(1)
+
+
+class Neptune(GNN):
+    """Neptune: an efficient point transformer for neutrino events.
+
+    Tokenizes an event by farthest point sampling over the 4D
+    `(x, y, z, t)` point cloud, encodes the tokens with a rotary-attention
+    transformer, pools to a single event vector, and applies an MLP readout.
+    Unlike sequence-based transformers in GraphNeT it needs neither edges nor
+    a cap on the number of pulses: use it with
+    :class:`~graphnet.models.data_representation.graphs.graphs.EdgelessGraph`
+    and
+    :class:`~graphnet.models.data_representation.graphs.nodes.nodes.NodesAsPulses`.
+
+    **Input contract.** Neptune's geometric priors are expressed in physical
+    units: `fourier_freq_min` / `fourier_freq_max` and the first three
+    `rope_scales` are radians per kilometre, the fourth is radians per
+    microsecond, and `tokenizer_kwargs["metric_time_scale"]` is km/us. The
+    tokenizer additionally treats feature column 0 as `log1p` of the physical
+    charge. A GraphNeT `Detector` standardizes columns however its experiment
+    chose, so this class converts:
+
+    - the coordinate columns are multiplied by `xyz_scale` to reach km,
+    - the time column is multiplied by `time_scale` to reach microseconds and
+      then centred per event, and
+    - the charge column is converted from `charge_scaling` to `log1p` and
+      placed first in the feature vector.
+
+    Ready-made settings for detectors shipped with GraphNeT:
+
+    - `IceCube86`: `xyz_scale=0.5`, `time_scale=30.0`,
+      `charge_scaling="log10"`.
+    - `IceCubeKaggle`: as above plus `charge_scale=3.0`, since its charge
+      column holds `log10(charge) / 3` rather than `log10(charge)`.
+    - `Prometheus` / `ORCA150SuperDense`: `xyz_scale=0.1`,
+      `time_scale=10.5`, `charge_column=None` (no charge is recorded).
+
+    The defaults for `fourier_freq_*`, `rope_scales`, and
+    `metric_time_scale` are tuned to IceCube's roughly 1 km by 10 us scale.
+    For a substantially smaller detector, rescale them accordingly.
+
+    Note that `self.training` changes the *tokenization*, not only dropout:
+    farthest point sampling starts from a random point during training as an
+    augmentation, and from a deterministic one at evaluation.
+    """
+
+    def __init__(
+        self,
+        nb_inputs: int,
+        coordinate_columns: Optional[List[int]] = None,
+        time_column: int = 3,
+        charge_column: Optional[int] = None,
+        feature_columns: Optional[List[int]] = None,
+        xyz_scale: float = 1.0,
+        time_scale: float = 1.0,
+        center_time: bool = True,
+        charge_scaling: str = "log1p",
+        charge_scale: float = 1.0,
+        num_patches: int = 128,
+        token_dim: int = 768,
+        num_layers: int = 12,
+        num_heads: int = 12,
+        hidden_dim: int = 2048,
+        dropout: float = 0.1,
+        drop_path_rate: float = 0.0,
+        output_dim: Optional[int] = None,
+        pool_type: str = "mean",
+        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        layerscale_init: float = 1e-5,
+        attn_impl: str = "auto",
+        fourier_num_bands: int = 20,
+        fourier_freq_min: float = 3.0,
+        fourier_freq_max: float = 180.0,
+        fourier_axis_scales: Optional[List[float]] = None,
+        rope_scales: Optional[List[float]] = None,
+        rope_base: int = 60,
+        compile_encoder: bool = False,
+    ):
+        """Construct `Neptune`.
+
+        Args:
+            nb_inputs: Number of columns in `data.x`, i.e.
+                `data_representation.nb_outputs`.
+            coordinate_columns: Columns of `data.x` holding `(x, y, z)`.
+                Defaults to `[0, 1, 2]`.
+            time_column: Column of `data.x` holding the pulse time.
+            charge_column: Column of `data.x` holding the charge, in the
+                scaling given by `charge_scaling`. None if the detector
+                records no charge, in which case every pulse is given unit
+                charge and the charge-weighted statistics reduce to
+                unweighted ones.
+            feature_columns: Columns of `data.x` passed to the tokenizer in
+                addition to charge. Defaults to every column not used as a
+                coordinate, time, or charge.
+            xyz_scale: Multiplier converting the standardized coordinates to
+                kilometres.
+            time_scale: Multiplier converting the standardized time to
+                microseconds.
+            center_time: Whether to subtract a per-event charge-weighted mean
+                time. Strongly recommended: the rotary time frequencies are
+                relative, and the absolute position encoding drops time on
+                the assumption that events are centred. This also absorbs any
+                constant offset in the detector's time standardization, which
+                is why a single `time_scale` multiplier suffices. Note that
+                the reference implementation centres on the charge-weighted
+                *median*; the mean is used here because it needs no sort.
+            charge_scaling: Scaling the detector applied to the charge
+                column, one of `"log1p"`, `"log10"`, or `"linear"`.
+            charge_scale: Multiplier applied to the charge column before the
+                `charge_scaling` is undone, for detectors that rescale the
+                logarithm. `IceCubeKaggle`, for instance, stores
+                `log10(charge) / 3`, which needs `charge_scale=3.0`.
+            num_patches: Maximum number of tokens per event.
+            token_dim: Transformer hidden dimension.
+            num_layers: Number of transformer layers.
+            num_heads: Number of attention heads. `token_dim / num_heads`
+                must be even and at least 8.
+            hidden_dim: Inner dimension of the SwiGLU feed-forward network.
+            dropout: Dropout used throughout the model.
+            drop_path_rate: Stochastic-depth rate of the last transformer
+                layer, ramped linearly from zero over the stack.
+            output_dim: Width of the readout, i.e. `nb_outputs`. Defaults to
+                `token_dim`. A GraphNeT `Task` adds its own linear layer on
+                top; to reproduce the reference model exactly, set this to
+                the task's output width and construct the `Task` with
+                `disable_affine=True`.
+            pool_type: `"mean"` or `"attention"` pooling over tokens.
+            tokenizer_kwargs: Extra keyword arguments forwarded to
+                :class:`~graphnet.models.components.tokenizers.FPSTokenizer`,
+                for example `assign_mode`, `lloyd_iters`, `knn_pool`,
+                `k_neighbors`, `metric_time_scale`, or `mlp_layers`.
+            layerscale_init: Initial value of the LayerScale parameters.
+            attn_impl: `"auto"`, `"padded"`, or `"packed"` attention path.
+            fourier_num_bands: Frequency bands of the absolute position
+                encoding.
+            fourier_freq_min: Lowest position-encoding frequency, rad/km.
+            fourier_freq_max: Highest position-encoding frequency, rad/km.
+            fourier_axis_scales: Per-axis multipliers for the position
+                encoding. Defaults to `[1.0, 1.0, 1.0]`.
+            rope_scales: Per-axis rotary frequency scales for
+                `(x, y, z, t)`, in rad/km and rad/us. Defaults to
+                `[180.0, 180.0, 180.0, 40.0]`.
+            rope_base: Rotary frequency span; frequencies on each axis run
+                from `scale / rope_base` to `scale`.
+            compile_encoder: Whether to `torch.compile` the transformer
+                stack. Worth 2-4x throughput on GPU, and also what enables
+                the packed attention path. Off by default so that importing
+                and training the model has no compilation side effect; a
+                compilation failure at runtime falls back to the uncompiled
+                encoder rather than crashing.
+        """
+        if coordinate_columns is None:
+            coordinate_columns = [0, 1, 2]
+        if len(coordinate_columns) != 3:
+            raise ValueError(
+                "coordinate_columns must name exactly 3 columns, got "
+                f"{coordinate_columns}"
+            )
+        if charge_scaling not in ("log1p", "log10", "linear"):
+            raise ValueError(
+                "charge_scaling must be 'log1p', 'log10' or 'linear', got "
+                f"'{charge_scaling}'"
+            )
+        claimed = set(coordinate_columns) | {time_column}
+        if charge_column is not None:
+            claimed.add(charge_column)
+        if feature_columns is None:
+            feature_columns = [i for i in range(nb_inputs) if i not in claimed]
+        for column in [*coordinate_columns, time_column, *feature_columns]:
+            if not 0 <= column < nb_inputs:
+                raise ValueError(
+                    f"column {column} is out of range for nb_inputs="
+                    f"{nb_inputs}"
+                )
+        if charge_column is not None and not 0 <= charge_column < nb_inputs:
+            raise ValueError(
+                f"charge_column {charge_column} is out of range for "
+                f"nb_inputs={nb_inputs}"
+            )
+        if token_dim % num_heads != 0:
+            raise ValueError(
+                f"token_dim ({token_dim}) must be divisible by num_heads "
+                f"({num_heads})"
+            )
+        head_dim = token_dim // num_heads
+        if head_dim % 2 != 0 or head_dim < 8:
+            raise ValueError(
+                f"token_dim / num_heads = {head_dim}, but the 4D rotary "
+                "embedding requires an even head dimension of at least 8"
+            )
+
+        if output_dim is None:
+            output_dim = token_dim
+        super().__init__(nb_inputs, output_dim)
+
+        self._coordinate_columns = coordinate_columns
+        self._time_column = time_column
+        self._charge_column = charge_column
+        self._feature_columns = feature_columns
+        self._xyz_scale = xyz_scale
+        self._time_scale = time_scale
+        self._center_time = center_time
+        self._charge_scaling = charge_scaling
+        self._charge_scale = charge_scale
+
+        tokenizer_cfg: Dict[str, Any] = dict(tokenizer_kwargs or {})
+        mlp_layers = tokenizer_cfg.pop("mlp_layers", [256, 512, 768])
+        tokenizer_dropout = tokenizer_cfg.pop("dropout", dropout)
+        # Charge is always placed first by `forward`, so the tokenizer's own
+        # default of column 0 is correct and must not be overridden.
+        tokenizer_cfg.pop("charge_col", None)
+
+        self.tokenizer = FPSTokenizer(
+            feature_dim=1 + len(feature_columns),
+            max_tokens=num_patches,
+            token_dim=token_dim,
+            mlp_layers=mlp_layers,
+            dropout=tokenizer_dropout,
+            **tokenizer_cfg,
+        )
+
+        self.encoder = PointTransformerEncoder(
+            token_dim=token_dim,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            hidden_dim=hidden_dim,
+            dropout=dropout,
+            drop_path_rate=drop_path_rate,
+            pool_type=pool_type,
+            layerscale_init=layerscale_init,
+            attn_impl=attn_impl,
+            fourier_num_bands=fourier_num_bands,
+            fourier_freq_min=fourier_freq_min,
+            fourier_freq_max=fourier_freq_max,
+            fourier_axis_scales=fourier_axis_scales,
+            rope_scales=rope_scales,
+            rope_base=rope_base,
+        )
+
+        # The two extra inputs are event-level scalars: log token
+        # multiplicity and log total charge. Pooling normalizes event size
+        # and total light yield away, yet both carry direct signal -- energy
+        # above all.
+        self.head = nn.Sequential(
+            nn.Linear(token_dim + 2, token_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(token_dim, output_dim),
+        )
+
+        self.encoder_compiled = False
+        if compile_encoder:
+            self.encoder_compiled = self.compile_layers()
+
+    def compile_layers(
+        self, mode: str = "default", dynamic: bool = True
+    ) -> bool:
+        """Compile the transformer stack for faster training and inference.
+
+        Only `self.encoder.layers` is compiled: packing uses data-dependent
+        shapes and the tokenizer has data-dependent control flow, both of
+        which would force graph breaks. `dynamic=True` lets one graph serve
+        both the varying packed length `[1, N, D]` and the padded batch
+        `[B, S, D]`. Compilation is applied in place via `nn.Module.compile`,
+        so `state_dict` keys are unchanged and existing checkpoints stay
+        loadable, and it is lazy, so it targets the model's final device.
+
+        Args:
+            mode: `torch.compile` mode.
+            dynamic: Whether to compile with dynamic shapes.
+
+        Returns:
+            True if compilation was set up, False if it is unavailable, in
+            which case the model runs uncompiled.
+        """
+        if not hasattr(torch, "compile") or not hasattr(
+            self.encoder.layers, "compile"
+        ):
+            warnings.warn(
+                "torch.compile is unavailable in this PyTorch build; "
+                "running the Neptune encoder uncompiled."
+            )
+            self.encoder_compiled = False
+            return False
+        try:
+            self.encoder.layers.compile(mode=mode, dynamic=dynamic)
+        except Exception as exc:  # setup failure; tracing is lazy, so rare
+            warnings.warn(
+                "Neptune encoder torch.compile setup failed "
+                f"({type(exc).__name__}: {exc}); falling back to the "
+                "uncompiled encoder."
+            )
+            self._revert_compilation()
+            return False
+        self.encoder_compiled = True
+        self.encoder.packed_flex_ready = True
+        return True
+
+    def _revert_compilation(self) -> None:
+        """Drop back to the eager encoder and the padded attention path."""
+        self.encoder_compiled = False
+        # Route "auto" back to padded SDPA: eager flex would materialize the
+        # whole packed N x N, so the retry must not stay on the packed path.
+        self.encoder.packed_flex_ready = False
+        try:
+            self.encoder.layers._compiled_call_impl = None
+        except Exception:
+            pass
+
+    def _run_encoder(
+        self, tokens: Tensor, centroids: Tensor, masks: Optional[Tensor]
+    ) -> Tensor:
+        """Run the encoder, falling back to eager on a compile failure.
+
+        The guard stays armed beyond the first forward because lazy
+        dynamic compilation traces each distinct path on first use; the
+        packed path, for instance, only compiles when a sparse batch
+        first reaches it.
+        """
+        if not self.encoder_compiled:
+            return self.encoder(tokens, centroids, masks)
+        try:
+            return self.encoder(tokens, centroids, masks)
+        except Exception as exc:  # compile or backend failure at runtime
+            warnings.warn(
+                "Neptune encoder torch.compile failed at runtime "
+                f"({type(exc).__name__}: {exc}); falling back to the "
+                "uncompiled encoder and padded attention for the rest of "
+                "this process. `Neptune.encoder_compiled` records the "
+                "downgrade."
+            )
+            self._revert_compilation()
+            return self.encoder(tokens, centroids, masks)
+
+    def _physical_charge(self, column: Tensor) -> Tensor:
+        """Undo the detector's charge scaling to recover physical charge."""
+        scaled = column * self._charge_scale
+        if self._charge_scaling == "log1p":
+            charge = torch.expm1(scaled)
+        elif self._charge_scaling == "log10":
+            charge = torch.pow(
+                torch.tensor(10.0, dtype=scaled.dtype, device=scaled.device),
+                scaled,
+            )
+        else:
+            charge = scaled
+        return charge.clamp(min=0)
+
+    @staticmethod
+    def _event_mean(
+        values: Tensor, weights: Tensor, batch: Tensor, batch_size: int
+    ) -> Tensor:
+        """Return the per-event weighted mean of `values`.
+
+        Events whose weights sum to zero -- every pulse carrying no
+        charge -- fall back to an unweighted mean rather than collapsing
+        to zero.
+        """
+        zeros = torch.zeros(
+            batch_size, dtype=values.dtype, device=values.device
+        )
+        weight_sum = zeros.clone().index_add_(0, batch, weights)
+        count = zeros.clone().index_add_(0, batch, torch.ones_like(weights))
+        degenerate = weight_sum <= 0
+        weights = torch.where(
+            degenerate.index_select(0, batch),
+            torch.ones_like(weights),
+            weights,
+        )
+        weight_sum = torch.where(degenerate, count, weight_sum)
+        numerator = zeros.clone().index_add_(0, batch, values * weights)
+        return numerator / weight_sum.clamp(min=1e-12)
+
+    def _prepare_inputs(
+        self, data: Data
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, int]:
+        """Map a GraphNeT `Data` object onto Neptune's input contract.
+
+        Args:
+            data: Batch of events, with `data.x` standardized by a
+                `Detector`.
+
+        Returns:
+            `(coords [N, 4] in km and centred microseconds, features [N, F]
+            with `log1p` charge first, batch [N], physical charge [N],
+            batch_size)`.
+        """
+        x = data.x
+        batch = getattr(data, "batch", None)
+        if batch is None:
+            batch = torch.zeros(x.shape[0], dtype=torch.long, device=x.device)
+            batch_size = 1
+        else:
+            batch = batch.long()
+            # `num_graphs` is authoritative: inferring the batch size from
+            # `batch.max()` would silently drop trailing events with no
+            # pulses and misalign predictions against labels.
+            batch_size = int(getattr(data, "num_graphs", 0)) or (
+                int(batch.max()) + 1 if batch.numel() else 0
+            )
+
+        xyz = x[:, self._coordinate_columns] * self._xyz_scale
+        time = x[:, self._time_column] * self._time_scale
+
+        if self._charge_column is None:
+            q_phys = torch.ones_like(time)
+        else:
+            q_phys = self._physical_charge(x[:, self._charge_column])
+
+        if self._center_time and time.numel():
+            # Accumulate in float32: under a low-precision "-true" run this
+            # reduction spans every pulse of an event, and half-precision
+            # sums lose meaningful accuracy there. A no-op in float32.
+            offset = self._event_mean(
+                time.float(), q_phys.float(), batch, batch_size
+            ).index_select(0, batch)
+            time = time - offset.to(time.dtype)
+
+        coords = torch.cat([xyz, time.unsqueeze(-1)], dim=1)
+        features = torch.cat(
+            [torch.log1p(q_phys).unsqueeze(-1), x[:, self._feature_columns]],
+            dim=1,
+        )
+        return coords, features, batch, q_phys, batch_size
+
+    def forward(self, data: Data) -> Tensor:
+        """Apply learnable forward pass.
+
+        Args:
+            data: Batch of events.
+
+        Returns:
+            `[batch_size, nb_outputs]` event representations.
+        """
+        coords, features, batch, q_phys, batch_size = self._prepare_inputs(
+            data
+        )
+
+        tokens, centroids, masks = self.tokenizer(
+            coords[:, :3],
+            features,
+            batch,
+            coords[:, 3:],
+            batch_size=batch_size,
+        )
+        global_feat = self._run_encoder(tokens, centroids, masks)
+
+        # Event-level scalars that pooling normalizes away: the number of
+        # valid tokens and the total physical charge of the event.
+        n_tokens = masks.sum(dim=1).float()
+        total_q = torch.zeros(batch_size, device=tokens.device).index_add_(
+            0, batch, q_phys.float()
+        )
+        extras = torch.stack(
+            [torch.log1p(n_tokens), torch.log1p(total_q)], dim=-1
+        ).to(global_feat.dtype)
+
+        return self.head(torch.cat([global_feat, extras], dim=-1))

--- a/src/graphnet/models/utils.py
+++ b/src/graphnet/models/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for `graphnet.models`."""
 
-from typing import List, Tuple, Any, Union, Optional
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor, LongTensor
@@ -12,6 +12,18 @@ from torch_geometric.utils.num_nodes import maybe_num_nodes
 
 from torch_scatter import scatter, scatter_add
 from torch_sparse import SparseTensor
+
+try:
+    from torch.nn.attention.flex_attention import (
+        create_block_mask,
+        flex_attention,
+    )
+
+    FLEX_AVAILABLE = True
+except ImportError:  # pragma: no cover - torch built without flex
+    create_block_mask = None
+    flex_attention = None
+    FLEX_AVAILABLE = False
 
 
 def calculate_xyzt_homophily(
@@ -305,3 +317,130 @@ def get_rw_landing_probs(
     # (Num nodes) x (K steps)
     rw_landing = torch.cat(rws, dim=0).transpose(0, 1)
     return rw_landing
+
+
+# ------------------------------------------------------------------------
+# Variable-length packing for `flex_attention`
+# ------------------------------------------------------------------------
+#
+# A padded `[B, S, D]` batch pushes masked-out slots through every `Linear`,
+# wasting up to ~4x of the dominant compute when events are short. The helpers
+# below pack the valid tokens of a batch into a single `[1, N_total, D]`
+# sequence and drive a block-diagonal `flex_attention`, so each event still
+# attends only within itself. `pack`/`unpack` use data-dependent shapes
+# (`nonzero`) and must therefore stay outside any compiled region.
+
+# Compiling `create_block_mask` makes per-step block-mask construction roughly
+# 50x faster than eager, which otherwise dominates the packing overhead. Built
+# on first use rather than at import so that merely importing
+# `graphnet.models` has no `torch.compile` side effect.
+_COMPILED_CREATE_BLOCK_MASK: Optional[Callable] = None
+
+# Pack only when the batch is at most this full: packing trades padded-token
+# `Linear` work for a less efficient attention kernel (block-diagonal flex vs
+# batched flash), which wins below ~80% occupancy and loses above it.
+_PACK_OCCUPANCY_MAX = 0.8
+
+
+def pack(
+    tokens: Tensor,
+    centroids: Tensor,
+    masks: Tensor,
+) -> Optional[Tuple[Tensor, Tensor, Tensor, Tensor]]:
+    """Pack the valid tokens of a batch into one flat sequence.
+
+    Args:
+        tokens: Padded token features `[B, S, D]`.
+        centroids: Padded token positions `[B, S, C]`.
+        masks: Bool `[B, S]`; True marks a valid token.
+
+    Returns:
+        `(packed_tokens [1, N, D], packed_centroids [1, N, C], doc_id [N],
+        pack_idx [N])`, or None when packing would not pay off -- an empty
+        batch, or occupancy at or above the internal threshold. On None the
+        caller should run the padded path; no token is ever dropped.
+    """
+    batch_size, seq_length, n_features = tokens.shape
+
+    # One host sync.
+    pack_idx = masks.reshape(batch_size * seq_length).nonzero(as_tuple=True)[0]
+    n_valid = int(pack_idx.numel())
+    if (
+        n_valid == 0
+        or n_valid >= _PACK_OCCUPANCY_MAX * batch_size * seq_length
+    ):
+        return None
+
+    packed_tokens = (
+        tokens.reshape(batch_size * seq_length, n_features)
+        .index_select(0, pack_idx)
+        .unsqueeze(0)
+    )
+    packed_centroids = (
+        centroids.reshape(batch_size * seq_length, centroids.shape[-1])
+        .index_select(0, pack_idx)
+        .unsqueeze(0)
+    )
+    # Valid tokens are row-major, so integer division recovers the event.
+    doc_id = pack_idx // seq_length
+
+    # Mark the packed length dynamic so `torch.compile` builds one graph
+    # instead of recompiling for every distinct N.
+    torch._dynamo.mark_dynamic(packed_tokens, 1)
+    torch._dynamo.mark_dynamic(packed_centroids, 1)
+    return packed_tokens, packed_centroids, doc_id, pack_idx
+
+
+def build_block_mask(doc_id: Tensor, n_tokens: int) -> Any:
+    """Build a block-diagonal `BlockMask` over a packed sequence.
+
+    Args:
+        doc_id: `[N]` event index of every packed token.
+        n_tokens: Packed sequence length `N`.
+
+    Returns:
+        A `flex_attention` `BlockMask` allowing attention only within an
+        event.
+    """
+    global _COMPILED_CREATE_BLOCK_MASK
+    if not FLEX_AVAILABLE:
+        raise RuntimeError(
+            "flex_attention is unavailable in this PyTorch build; the packed "
+            "attention path cannot be used."
+        )
+    if _COMPILED_CREATE_BLOCK_MASK is None:
+        _COMPILED_CREATE_BLOCK_MASK = torch.compile(create_block_mask)
+
+    def mask_mod(
+        b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor
+    ) -> Tensor:
+        return doc_id[q_idx] == doc_id[kv_idx]
+
+    return _COMPILED_CREATE_BLOCK_MASK(
+        mask_mod,
+        B=None,
+        H=None,
+        Q_LEN=n_tokens,
+        KV_LEN=n_tokens,
+        device=doc_id.device,
+    )
+
+
+def unpack(
+    packed: Tensor, pack_idx: Tensor, batch_size: int, seq_length: int
+) -> Tensor:
+    """Scatter a packed `[1, N, D]` sequence back to padded `[B, S, D]`.
+
+    Args:
+        packed: Packed encoder output `[1, N, D]`.
+        pack_idx: The `pack_idx` returned by :func:`pack`.
+        batch_size: Original batch size `B`.
+        seq_length: Original padded sequence length `S`.
+
+    Returns:
+        Padded tensor `[B, S, D]`, zero at every padded slot.
+    """
+    n_features = packed.shape[-1]
+    result = packed.new_zeros(batch_size * seq_length, n_features)
+    result.index_copy_(0, pack_idx, packed[0])
+    return result.reshape(batch_size, seq_length, n_features)

--- a/src/graphnet/utilities/imports.py
+++ b/src/graphnet/utilities/imports.py
@@ -47,6 +47,20 @@ def has_jammy_flows_package() -> bool:
         return False
 
 
+def has_triton_package() -> bool:
+    """Check whether the `triton` package is available."""
+    try:
+        import triton  # pyright: reportMissingImports=false
+
+        return True
+    except ImportError:
+        Logger(log_folder=None).warning_once(
+            "`triton` not available. Falling back to the pure-PyTorch "
+            "implementation of farthest point sampling."
+        )
+        return False
+
+
 def has_km3net_package() -> bool:
     """Check whether the `km3net` packages are available."""
     try:

--- a/tests/models/test_neptune.py
+++ b/tests/models/test_neptune.py
@@ -1,0 +1,493 @@
+"""Unit tests for the Neptune backbone and its FPS components."""
+
+import os
+from typing import Any, Dict, List
+
+import pytest
+import torch
+from torch import Tensor
+from torch_geometric.data import Batch, Data
+
+from graphnet.models import Model, StandardModel
+from graphnet.models.components.fps import (
+    farthest_point_sampling,
+    farthest_point_sampling_with_assign,
+    farthest_point_sampling_with_knn,
+    nearest_assign,
+)
+from graphnet.models.components.tokenizers import FPSTokenizer
+from graphnet.models.data_representation import EdgelessGraph, NodesAsPulses
+from graphnet.models.detector.icecube import IceCube86, IceCubeKaggle
+from graphnet.models.detector.prometheus import Prometheus
+from graphnet.models.task.reconstruction import EnergyReconstruction
+from graphnet.models.transformer import Neptune
+from graphnet.training.loss_functions import LogCoshLoss
+from graphnet.utilities.config import ModelConfig
+
+# Feature layout used throughout: [x, y, z, t, charge, aux].
+N_FEATURES = 6
+NUM_PATCHES = 8
+
+# Small enough to keep every test in the sub-second range.
+TINY: Dict[str, Any] = dict(
+    num_patches=NUM_PATCHES,
+    token_dim=32,
+    num_layers=1,
+    num_heads=2,
+    hidden_dim=24,
+    tokenizer_kwargs={"mlp_layers": [16, 16]},
+)
+
+
+def _model(**kwargs: Any) -> Neptune:
+    """Build a tiny `Neptune` over the six-column feature layout."""
+    config: Dict[str, Any] = dict(TINY)
+    config.update(kwargs)
+    return Neptune(nb_inputs=N_FEATURES, charge_column=4, **config)
+
+
+def _batch(counts: List[int], seed: int = 0) -> Batch:
+    """Build a batch of events holding `counts[i]` pulses each."""
+    torch.manual_seed(seed)
+    return Batch.from_data_list(
+        [Data(x=torch.randn(n, N_FEATURES)) for n in counts]
+    )
+
+
+def test_forward_shape() -> None:
+    """Test that the backbone returns one row of `nb_outputs` per event."""
+    model = _model()
+    counts = [3, 5, 11]
+    output = model(_batch(counts))
+    assert output.shape == (len(counts), model.nb_outputs)
+    assert model.nb_outputs == TINY["token_dim"]
+    assert model.nb_inputs == N_FEATURES
+    assert torch.isfinite(output).all()
+
+
+def test_output_dim_overrides_nb_outputs() -> None:
+    """Test that `output_dim` sets the readout width."""
+    model = _model(output_dim=3)
+    assert model.nb_outputs == 3
+    assert model(_batch([4, 9])).shape == (2, 3)
+
+
+def test_both_tokenizer_paths() -> None:
+    """Test events below, at, and above the token budget in one batch."""
+    model = _model()
+    # Fewer than, exactly, and more than `num_patches` pulses.
+    counts = [NUM_PATCHES - 3, NUM_PATCHES, NUM_PATCHES * 5]
+    output = model(_batch(counts))
+    assert output.shape == (3, model.nb_outputs)
+    assert torch.isfinite(output).all()
+
+
+def test_zero_hit_event() -> None:
+    """Test that empty events keep their row and do not produce NaN.
+
+    Events with no pulses contribute no rows to `data.batch`, so a backbone
+    that infers the batch size from `batch.max()` would silently drop
+    trailing empty events and misalign predictions against labels.
+    """
+    model = _model()
+    counts = [4, 0, 7, 0]  # empty in the middle and at the end
+    output = model(_batch(counts))
+    assert output.shape == (len(counts), model.nb_outputs)
+    assert torch.isfinite(output).all()
+
+
+def test_all_events_empty() -> None:
+    """Test the degenerate batch in which no event has any pulse."""
+    model = _model()
+    output = model(_batch([0, 0]))
+    assert output.shape == (2, model.nb_outputs)
+    assert torch.isfinite(output).all()
+
+
+def test_single_event_without_batch_attribute() -> None:
+    """Test that an uncollated `Data` object is treated as one event."""
+    model = _model()
+    torch.manual_seed(0)
+    output = model(Data(x=torch.randn(12, N_FEATURES)))
+    assert output.shape == (1, model.nb_outputs)
+
+
+def test_gradients_reach_every_stage() -> None:
+    """Test that gradients flow to tokenizer, encoder, and readout.
+
+    The parameter names asserted here are also the `state_dict` keys of the
+    reference implementation, so this doubles as a check that the module
+    nesting -- and hence checkpoint compatibility -- is preserved.
+    """
+    model = _model()
+    model(_batch([6, NUM_PATCHES * 4])).sum().backward()
+    parameters = dict(model.named_parameters())
+    for name in [
+        "tokenizer.mlp1.0.weight",
+        "tokenizer.mlp2.0.weight",
+        "tokenizer.rel_encoder.0.weight",
+        "encoder.abs_pos_encoder.mlp.0.weight",
+        "encoder.layers.layers.0.qkv_proj.weight",
+        "encoder.layers.layers.0.ffn.w13.weight",
+        "encoder.layers.layers.0.gamma_1",
+        "encoder.norm.weight",
+        "head.0.weight",
+        "head.3.weight",
+    ]:
+        assert name in parameters, f"missing parameter {name}"
+        gradient = parameters[name].grad
+        assert gradient is not None, f"no gradient for {name}"
+        assert torch.isfinite(gradient).all(), f"NaN gradient in {name}"
+
+
+def test_attention_pooling() -> None:
+    """Test the attention pooling variant, including on empty events."""
+    model = _model(pool_type="attention")
+    output = model(_batch([0, 5, NUM_PATCHES * 3]))
+    assert output.shape == (3, model.nb_outputs)
+    assert torch.isfinite(output).all()
+
+
+@pytest.mark.parametrize(
+    "tokenizer_kwargs",
+    [
+        {"mlp_layers": [16, 16], "assign_mode": "knn", "k_neighbors": 3},
+        {"mlp_layers": [16, 16], "lloyd_iters": 2},
+        {"mlp_layers": [16, 16], "knn_pool": "max_mean"},
+    ],
+)
+def test_tokenizer_variants(tokenizer_kwargs: Dict[str, Any]) -> None:
+    """Test the alternative tokenizer assignment and pooling modes."""
+    model = _model(tokenizer_kwargs=tokenizer_kwargs)
+    output = model(_batch([4, NUM_PATCHES * 4]))
+    assert output.shape == (2, model.nb_outputs)
+    assert torch.isfinite(output).all()
+
+
+def test_charge_scaling_and_columns() -> None:
+    """Test the detector-unit adapter in front of the tokenizer."""
+    # `log10` charge is converted to the `log1p` the tokenizer expects, and
+    # placed in column 0 of the feature tensor.
+    model = _model(charge_scaling="log10")
+    x = torch.zeros(3, N_FEATURES)
+    x[:, 4] = torch.log10(torch.tensor([1.0, 10.0, 100.0]))
+    _, features, _, q_phys, _ = model._prepare_inputs(Data(x=x))
+    assert torch.allclose(q_phys, torch.tensor([1.0, 10.0, 100.0]), atol=1e-5)
+    assert torch.allclose(
+        features[:, 0], torch.log1p(torch.tensor([1.0, 10.0, 100.0]))
+    )
+    # The remaining feature columns follow charge, in order.
+    assert features.shape == (3, 1 + 1)  # charge + the single `aux` column
+    assert model.tokenizer.mlp1[0].in_features == 2
+
+    # Without a charge column every pulse counts once.
+    chargeless = Neptune(nb_inputs=4, charge_column=None, **TINY)
+    assert chargeless.tokenizer.mlp1[0].in_features == 1
+    _, features, _, q_phys, _ = chargeless._prepare_inputs(
+        Data(x=torch.randn(5, 4))
+    )
+    assert torch.equal(q_phys, torch.ones(5))
+    assert features.shape == (5, 1)
+
+
+def test_charge_scale_undoes_a_rescaled_logarithm() -> None:
+    """Test `charge_scale` for detectors that rescale the log charge.
+
+    `IceCubeKaggle` stores `log10(charge) / 3`, so undoing the scaling needs
+    the column multiplied by three first.
+    """
+    charge = torch.tensor([0.5, 1.0, 7.3, 120.0])
+    for detector, scale in ((IceCube86(), 1.0), (IceCubeKaggle(), 3.0)):
+        model = _model(charge_scaling="log10", charge_scale=scale)
+        x = torch.zeros(4, N_FEATURES)
+        x[:, 4] = detector._charge(charge)
+        _, _, _, q_phys, _ = model._prepare_inputs(Data(x=x))
+        assert torch.allclose(
+            q_phys, charge, rtol=1e-4
+        ), f"{type(detector).__name__} charge not recovered"
+
+
+def test_knn_padding_is_not_counted_as_neighbours() -> None:
+    """Test that repeated-centroid padding is excluded from kNN statistics.
+
+    When an event holds fewer points than `k_neighbors`, the sampling
+    backend pads the neighbour list by repeating the centroid index. Since
+    that index is itself valid, the padded slots must be masked out by rank,
+    or the centroid is counted several times in the per-token multiplicity,
+    total charge, mean, and spread. Asking for more neighbours than an event
+    has points must therefore give the same tokens as asking for exactly as
+    many as it has.
+    """
+    base: Dict[str, Any] = dict(
+        feature_dim=2,
+        max_tokens=4,
+        token_dim=8,
+        mlp_layers=[8],
+        assign_mode="knn",
+    )
+    # Event 0 holds 5 points, above `max_tokens` so it takes the sampling
+    # path, and below the 10 neighbours requested so its list gets padded.
+    counts = [5, 40]
+    torch.manual_seed(0)
+    n_points = sum(counts)
+    coords = torch.randn(n_points, 3)
+    times = torch.randn(n_points, 1)
+    features = torch.rand(n_points, 2) * 2
+    batch = torch.repeat_interleave(
+        torch.arange(len(counts)), torch.tensor(counts)
+    )
+
+    reference = FPSTokenizer(k_neighbors=8, **base).eval()
+
+    def tokens(k_neighbors: int) -> Tensor:
+        tokenizer = FPSTokenizer(k_neighbors=k_neighbors, **base).eval()
+        tokenizer.load_state_dict(reference.state_dict())
+        with torch.no_grad():
+            return tokenizer(
+                coords, features, batch, times, batch_size=len(counts)
+            )[0]
+
+    assert torch.allclose(tokens(10)[0], tokens(5)[0], atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.half])
+def test_low_precision_without_autocast(dtype: torch.dtype) -> None:
+    """Test a module converted to low precision and run without autocast.
+
+    This is what Lightning's `"16-true"` and `"bf16-true"` precision
+    modes do. The Fourier position encoding evaluates its trigonometry
+    in float32, so its output has to be cast back before reaching low-
+    precision weights.
+    """
+    model = _model().to(dtype)
+    batch = Batch.from_data_list(
+        [
+            Data(x=torch.randn(n, N_FEATURES).to(dtype))
+            for n in (4, NUM_PATCHES * 3, 0)
+        ]
+    )
+    output = model(batch)
+    assert output.shape == (3, model.nb_outputs)
+    assert output.dtype == dtype
+    assert torch.isfinite(output).all()
+
+
+def test_coordinate_and_time_scaling() -> None:
+    """Test that coordinates and time are rescaled and time is centred."""
+    model = _model(xyz_scale=0.5, time_scale=30.0, center_time=True)
+    x = torch.zeros(4, N_FEATURES)
+    x[:, :3] = 2.0
+    x[:, 3] = torch.tensor([0.0, 1.0, 2.0, 3.0])
+    coords, _, _, _, _ = model._prepare_inputs(Data(x=x))
+    assert torch.allclose(coords[:, :3], torch.full((4, 3), 1.0))
+    # Unit charge here, so centring subtracts the plain mean of 1.5 * 30.
+    expected = (torch.tensor([0.0, 1.0, 2.0, 3.0]) - 1.5) * 30.0
+    assert torch.allclose(coords[:, 3], expected)
+
+    uncentred = _model(time_scale=30.0, center_time=False)
+    coords, _, _, _, _ = uncentred._prepare_inputs(Data(x=x))
+    assert torch.allclose(
+        coords[:, 3], torch.tensor([0.0, 1.0, 2.0, 3.0]) * 30.0
+    )
+
+
+def test_invalid_configurations() -> None:
+    """Test that misconfigurations fail fast with a clear message."""
+    with pytest.raises(ValueError, match="divisible"):
+        _model(token_dim=33, num_heads=2)
+    with pytest.raises(ValueError, match="rotary embedding"):
+        # head_dim = 4, below the minimum of 8 required by RoPE4D.
+        Neptune(
+            nb_inputs=N_FEATURES,
+            token_dim=32,
+            num_heads=8,
+            **{
+                k: v
+                for k, v in TINY.items()
+                if k not in ("token_dim", "num_heads")
+            },
+        )
+    with pytest.raises(ValueError, match="exactly 3 columns"):
+        _model(coordinate_columns=[0, 1])
+    with pytest.raises(ValueError, match="charge_scaling"):
+        _model(charge_scaling="sqrt")
+    with pytest.raises(ValueError, match="out of range"):
+        _model(time_column=99)
+
+
+def test_model_config_round_trip(tmp_path: Any) -> None:
+    """Test that `Neptune` survives a `ModelConfig` round trip."""
+    path = os.path.join(str(tmp_path), "neptune.yml")
+    model = _model(output_dim=5, pool_type="attention")
+    model.save_config(path)
+
+    loaded_config = ModelConfig.load(path)
+    assert isinstance(loaded_config, ModelConfig)
+    assert loaded_config == model.config
+
+    reconstructed = Model.from_config(loaded_config)
+    assert reconstructed.config == model.config
+    assert repr(reconstructed) == repr(model)
+    assert set(reconstructed.state_dict()) == set(model.state_dict())
+
+
+def test_standard_model_end_to_end() -> None:
+    """Test `Neptune` as the backbone of a `StandardModel`."""
+    data_representation = EdgelessGraph(
+        detector=Prometheus(), node_definition=NodesAsPulses()
+    )
+    backbone = Neptune(
+        nb_inputs=data_representation.nb_outputs,
+        coordinate_columns=[0, 1, 2],
+        time_column=3,
+        charge_column=None,
+        xyz_scale=0.1,
+        time_scale=10.5,
+        **TINY,
+    )
+    task = EnergyReconstruction(
+        hidden_size=backbone.nb_outputs,
+        target_labels="total_energy",
+        loss_function=LogCoshLoss(),
+    )
+    model = StandardModel(
+        data_representation=data_representation,
+        backbone=backbone,
+        tasks=[task],
+    )
+    torch.manual_seed(0)
+    nb_inputs = data_representation.nb_outputs
+    batch = Batch.from_data_list(
+        [Data(x=torch.randn(n, nb_inputs)) for n in (4, 20, 0)]
+    )
+    predictions = model(batch)
+    assert len(predictions) == 1
+    assert predictions[0].shape == (3, 1)
+
+
+# ------------------------------------------------------------------------
+# Farthest point sampling
+# ------------------------------------------------------------------------
+
+
+def test_fps_matches_brute_force() -> None:
+    """Test FPS against an explicit greedy implementation."""
+    torch.manual_seed(0)
+    points = torch.randn(2, 40, 4)
+    mask = torch.ones(2, 40, dtype=torch.bool)
+    start = torch.zeros(2, dtype=torch.long)
+    idx = farthest_point_sampling(points, mask, 6, start_idx=start)
+
+    for b in range(2):
+        chosen = [0]
+        for _ in range(5):
+            dist = (
+                (points[b].unsqueeze(1) - points[b][chosen].unsqueeze(0))
+                .square()
+                .sum(-1)
+                .min(dim=1)
+                .values
+            )
+            dist[chosen] = -float("inf")
+            chosen.append(int(dist.argmax()))
+        assert idx[b].tolist() == chosen
+
+
+def test_fps_ties_pick_lowest_index() -> None:
+    """Test that exactly-tied candidates resolve to the lowest index."""
+    # Four points on a line: 0 and 3 are the extremes, 1 and 2 tie.
+    points = torch.tensor([[[0.0], [1.0], [2.0], [3.0]]])
+    mask = torch.ones(1, 4, dtype=torch.bool)
+    idx = farthest_point_sampling(
+        points, mask, 4, start_idx=torch.zeros(1, dtype=torch.long)
+    )
+    # After 0 and 3, points 1 and 2 are both at distance 1; 1 wins.
+    assert idx[0].tolist() == [0, 3, 1, 2]
+
+
+def test_fps_masked_and_exhausted_rows() -> None:
+    """Test that invalid points are skipped and short rows repeat."""
+    points = torch.arange(6, dtype=torch.float32).view(1, 6, 1)
+    mask = torch.tensor([[True, False, False, True, False, False]])
+    idx = farthest_point_sampling(
+        points,
+        mask,
+        4,
+        start_idx=torch.zeros(1, dtype=torch.long),
+        validate=False,
+    )
+    # Only indices 0 and 3 are selectable; once exhausted the last
+    # selection repeats.
+    assert idx[0].tolist() == [0, 3, 3, 3]
+
+
+def test_fps_with_assign_partitions_points() -> None:
+    """Test that Voronoi assignment sends each point to its closest
+    centroid."""
+    torch.manual_seed(0)
+    points = torch.randn(3, 30, 4)
+    mask = torch.ones(3, 30, dtype=torch.bool)
+    idx, assign = farthest_point_sampling_with_assign(
+        points, mask, 5, start_idx=torch.zeros(3, dtype=torch.long)
+    )
+    assert idx.shape == (3, 5)
+    assert assign.shape == (3, 30)
+    assert int(assign.min()) >= 0 and int(assign.max()) < 5
+    for b in range(3):
+        cents = points[b][idx[b]]
+        expected = (
+            (points[b].unsqueeze(1) - cents.unsqueeze(0))
+            .square()
+            .sum(-1)
+            .argmin(dim=1)
+        )
+        assert torch.equal(assign[b], expected)
+
+
+def test_fps_with_knn_is_sorted_and_padded() -> None:
+    """Test that kNN neighbours are closest-first and short rows padded."""
+    torch.manual_seed(0)
+    points = torch.randn(1, 12, 4)
+    mask = torch.ones(1, 12, dtype=torch.bool)
+    mask[0, 4:] = False  # only 4 valid points, fewer than k_neighbors
+    idx, neighbors = farthest_point_sampling_with_knn(
+        points,
+        mask,
+        3,
+        6,
+        start_idx=torch.zeros(1, dtype=torch.long),
+        validate=False,
+    )
+    assert neighbors.shape == (1, 3, 6)
+    # The nearest neighbour of a centroid is the centroid itself.
+    assert torch.equal(neighbors[0, :, 0], idx[0])
+    # Slots beyond the four valid points fall back to the centroid index.
+    assert torch.equal(neighbors[0, :, 4:], idx[0].unsqueeze(-1).expand(-1, 2))
+
+
+def test_nearest_assign_matches_brute_force() -> None:
+    """Test segmented nearest-centroid assignment against brute force."""
+    torch.manual_seed(0)
+    counts = torch.tensor([7, 11, 5])
+    starts = torch.cumsum(counts, 0) - counts
+    points = torch.randn(int(counts.sum()), 4)
+    cents = torch.randn(3 * 4, 4)
+    got = nearest_assign(points, cents, starts, counts, int(counts.max()), 4)
+
+    seg = torch.repeat_interleave(torch.arange(3), counts)
+    expected = (
+        (points[:, None, :] - cents.view(3, 4, 4)[seg]).square().sum(-1)
+    ).argmin(1)
+    assert torch.equal(got, expected)
+
+
+def test_fps_rejects_bad_input() -> None:
+    """Test the validation performed by the FPS front-end."""
+    points = torch.randn(2, 5, 4)
+    mask = torch.ones(2, 5, dtype=torch.bool)
+    with pytest.raises(ValueError, match="K <= number of valid points"):
+        farthest_point_sampling(points, mask, 9)
+    with pytest.raises(ValueError, match=r"\[B, N, D\]"):
+        farthest_point_sampling(points[0], mask, 2)
+    with pytest.raises(ValueError, match="k_neighbors must be positive"):
+        farthest_point_sampling_with_knn(points, mask, 2, 0)


### PR DESCRIPTION
## Summary

Adds **Neptune** ("a N Efficient Point Transformer for Ultrarelativistic Neutrino Events", [arXiv:2510.01733](https://arxiv.org/abs/2510.01733), [reference implementation](https://github.com/felixyu7/neptune)) as a backbone in `graphnet.models.transformer`.

Neptune treats an event as an irregular 4D `(x, y, z, t)` point cloud. It tokenizes the event by farthest point sampling (FPS) into a fixed number of centroids, pools the pulses of each token, runs a rotary-attention transformer over the tokens, and pools to one event vector. Because it has no edges and no pulse cap, it drops into a `StandardModel` with `EdgelessGraph` over `NodesAsPulses`, and its memory is insensitive to event size (a 166k-pulse event costs the same attention as a 100-pulse one).

## What is added

**New backbone**
- `graphnet/models/transformer/neptune.py`: `Neptune(GNN)` and `PointTransformerEncoder`. `Neptune` converts a `Detector`'s standardized columns into the physical units the model's geometric priors expect (`xyz_scale`, `time_scale`, `charge_scaling`), with documented settings for `IceCube86`, `IceCubeKaggle`, `Prometheus`, and `ORCA150SuperDense`. Optional `compile_encoder=True` compiles the transformer layers in place and falls back to eager on failure.

**New components**
- `components/tokenizers.py`: `FPSTokenizer`. Small events pass through one-token-per-pulse; large events are reduced to `max_tokens` centroids and pooled by Voronoi assignment (nothing is discarded) or kNN gather. One host sync per forward, no data-dependent-shape ops, and only the large-event subset is ever padded.
- `components/fps.py`: `farthest_point_sampling`, `farthest_point_sampling_with_assign`, `farthest_point_sampling_with_knn`, `nearest_assign`. Pure-PyTorch backend plus an optional Triton backend (`components/fps_triton.py`) that is used automatically on CUDA when `triton` is importable. Both backends produce identical indices; the Triton path streams distances so nothing of size `[B, N, K]` is materialised.
- `components/embedding.py`: `FourierPositionEncoder` (log-spaced Fourier features of token centroids).
- `components/layers.py`: `RMSNorm`, `SwiGLU`, `RoPE4D` (axis-aligned 4D rotary embedding), `AttentionPool`, `NeptuneTransformerEncoderLayer`, `NeptuneTransformerEncoder`.
- `models/utils.py`: `pack` / `unpack` / `build_block_mask` for variable-length packing with `flex_attention`. At low batch occupancy the valid tokens are packed into one flat sequence with a block-diagonal mask so padded slots skip every `Linear`; above ~80% occupancy the padded SDPA path is used instead. Guarded behind `FLEX_AVAILABLE`, so older torch builds still import.
- `utilities/imports.py`: `has_triton_package()`.

**Changes to existing code**
- `DropPath.forward` gains optional `doc_id` / `num_docs` arguments so stochastic depth stays per-event on the packed path. The default (padded) behaviour is unchanged.

**Example and tests**
- `examples/04_training/09_train_neptune_model.py`: direction reconstruction on the Prometheus example data, following the pattern of the other training examples.
- `tests/models/test_neptune.py`: 27 tests covering forward shapes, zero-hit and all-empty batches, gradients reaching every stage, both tokenizer paths, charge/coordinate/time scaling, low-precision weights without autocast, `ModelConfig` round trip, `StandardModel` end to end, and FPS/kNN/assign against brute force (ties, masking, exhaustion, padding).

## Dependencies

No new required dependencies. `triton` is optional (it ships with CUDA torch wheels); without it FPS falls back to the pure-PyTorch backend with a one-time warning. `flex_attention` is optional; without it the model runs the padded attention path.

## Validation

Trained on ~10.9M IceCube NuMu-CC events (direction reconstruction, `VonMisesFisher3DLoss`) on a single H200 alongside `DynEdge` under an identical schedule. Neptune reached a better best-validation loss than `DynEdge` on that setup, and predictions were consistent with the reference implementation. Tests and pre-commit hooks pass locally on CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
