### PR TITLE
Add CI coverage that pretrained model configs and QUESO weights still load

### DIFF
--- a/src/graphnet/models/gnn/dynedge.py
+++ b/src/graphnet/models/gnn/dynedge.py
@@ -1,6 +1,6 @@
 """Implementation of the DynEdge GNN model architecture."""
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Sequence, Union
 
 import torch
 from torch import Tensor, LongTensor
@@ -28,7 +28,7 @@ class DynEdge(GNN):
         *,
         nb_neighbours: int = 8,
         features_subset: Optional[Union[List[int], slice]] = None,
-        dynedge_layer_sizes: Optional[List[Tuple[int, ...]]] = None,
+        dynedge_layer_sizes: Optional[List[Sequence[int]]] = None,
         post_processing_layer_sizes: Optional[List[int]] = None,
         readout_layer_sizes: Optional[List[int]] = None,
         global_pooling_schemes: Optional[Union[str, List[str]]] = None,
@@ -102,7 +102,10 @@ class DynEdge(GNN):
 
         assert isinstance(dynedge_layer_sizes, list)
         assert len(dynedge_layer_sizes)
-        assert all(isinstance(sizes, tuple) for sizes in dynedge_layer_sizes)
+        # YAML has no tuple type, so a serialized config reloads these inner
+        # size pairs as lists; coerce them back so a saved DynEdge config
+        # round-trips.
+        dynedge_layer_sizes = [tuple(sizes) for sizes in dynedge_layer_sizes]
         assert all(len(sizes) > 0 for sizes in dynedge_layer_sizes)
         assert all(
             all(size > 0 for size in sizes) for sizes in dynedge_layer_sizes

--- a/tests/models/test_pretrained.py
+++ b/tests/models/test_pretrained.py
@@ -24,6 +24,16 @@ def _config_id(path: str) -> str:
     return os.path.relpath(path, PRETRAINED_MODEL_DIR)
 
 
+def _config_paths_with_state_dict() -> list:
+    """Return pretrained configs shipped alongside a state dict."""
+    return [
+        path
+        for path in _config_paths()
+        if path.endswith("_config.yml")
+        and os.path.exists(path.replace("_config.yml", "_state_dict.pth"))
+    ]
+
+
 @pytest.mark.parametrize("config_path", _config_paths(), ids=_config_id)
 def test_pretrained_config_builds(config_path: str) -> None:
     """Test that every shipped pretrained config constructs a model.
@@ -35,3 +45,21 @@ def test_pretrained_config_builds(config_path: str) -> None:
     assert isinstance(config, ModelConfig)
     model = Model.from_config(config, trust=True)
     assert isinstance(model, Model)
+
+
+@pytest.mark.parametrize(
+    "config_path", _config_paths_with_state_dict(), ids=_config_id
+)
+def test_pretrained_state_dict_loads(config_path: str) -> None:
+    """Test that shipped weights load into their model without key mismatch.
+
+    Only applies to models whose state dict is committed next to the
+    config; a strict load verifies the weights and the current
+    architecture still agree exactly.
+    """
+    config = ModelConfig.load(config_path)
+    assert isinstance(config, ModelConfig)
+    model = Model.from_config(config, trust=True)
+
+    state_dict_path = config_path.replace("_config.yml", "_state_dict.pth")
+    model.load_state_dict(state_dict_path)

--- a/tests/models/test_pretrained.py
+++ b/tests/models/test_pretrained.py
@@ -1,0 +1,37 @@
+"""Unit tests for the pretrained models shipped with GraphNeT."""
+
+import glob
+import os
+
+import pytest
+
+from graphnet.constants import PRETRAINED_MODEL_DIR
+from graphnet.models import Model
+from graphnet.utilities.config import ModelConfig
+
+
+def _config_paths() -> list:
+    """Return every pretrained model config shipped in the repository."""
+    return sorted(
+        glob.glob(
+            os.path.join(PRETRAINED_MODEL_DIR, "**", "*.yml"), recursive=True
+        )
+    )
+
+
+def _config_id(path: str) -> str:
+    """Return a readable test id relative to the pretrained model dir."""
+    return os.path.relpath(path, PRETRAINED_MODEL_DIR)
+
+
+@pytest.mark.parametrize("config_path", _config_paths(), ids=_config_id)
+def test_pretrained_config_builds(config_path: str) -> None:
+    """Test that every shipped pretrained config constructs a model.
+
+    Guards the committed configs against silent rot when a constructor
+    argument or class name changes elsewhere in the library.
+    """
+    config = ModelConfig.load(config_path)
+    assert isinstance(config, ModelConfig)
+    model = Model.from_config(config, trust=True)
+    assert isinstance(model, Model)


### PR DESCRIPTION
Addresses #921.

Adds CI coverage that the pretrained models shipped in the repo still load, so they can't silently rot as the library evolves. Two parametrized checks in `tests/models/test_pretrained.py`, both on the existing CPU unit-test job (no icetray, no new workflow, no credentials):

- **Config instantiation** — every `*.yml` under `PRETRAINED_MODEL_DIR` must build via `Model.from_config`. Covers all committed configs (5 Kaggle IceMix + 6 QUESO); catches a renamed constructor argument or class.
- **Strict weight load** — for models whose `*_state_dict.pth` is committed next to the config (the QUESO models), build from config and `load_state_dict(...)` strictly, verifying the weights and current architecture agree key-for-key.

Building this surfaced a real bug, fixed in the first commit: YAML has no tuple type, so `DynEdge.dynedge_layer_sizes` reloads as a list of lists and tripped an `isinstance(sizes, tuple)` assertion — i.e. *any* saved DynEdge config with explicit layer sizes was unloadable (two of the Kaggle configs among them). The inner sequences are now coerced to tuples.

### Scope

The Kaggle **weights** are intentionally not load-tested here. They are not committed (each model is ~115M parameters), and the published competition checkpoints no longer share key names with the current `DeepIce` port (`extractor.*` vs `fourier_ext.*`, plus learnable scale parameters the port omits), so loading them is a model-porting task rather than a test. Details in #921. This PR covers config instantiation for the Kaggle models and full (config + strict weights) coverage for QUESO.

### Tests

17 new cases, all passing: 11 config builds + 6 QUESO strict weight loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pqUKMMW7ZPkhc9EChzCux
